### PR TITLE
Fixes for Fift semantics

### DIFF
--- a/crypto/fift/words.cpp
+++ b/crypto/fift/words.cpp
@@ -937,8 +937,9 @@ void interpret_fetch(vm::Stack& stack, int mode) {
     if (mode & 2) {
       stack.push(std::move(cs));
     }
-    stack.push_bool(false);
-    if (!(mode & 4)) {
+    if (mode & 4) {
+      stack.push_bool(false);
+    } else {
       throw IntError{"end of data while reading integer from cell"};
     }
   } else {
@@ -964,8 +965,9 @@ void interpret_fetch_bytes(vm::Stack& stack, int mode) {
     if (mode & 2) {
       stack.push(std::move(cs));
     }
-    stack.push_bool(false);
-    if (!(mode & 4)) {
+    if (mode & 4) {
+      stack.push_bool(false);
+    } else {
       throw IntError{"end of data while reading byte string from cell"};
     }
   } else {
@@ -1018,8 +1020,9 @@ void interpret_fetch_ref(vm::Stack& stack, int mode) {
     if (mode & 2) {
       stack.push(std::move(cs));
     }
-    stack.push_bool(false);
-    if (!(mode & 4)) {
+    if (mode & 4) {
+      stack.push_bool(false);
+    } else {
       throw IntError{"end of data while reading reference from cell"};
     }
   } else {

--- a/crypto/fift/words.cpp
+++ b/crypto/fift/words.cpp
@@ -978,7 +978,9 @@ void interpret_fetch_bytes(vm::Stack& stack, int mode) {
     } else {
       stack.push_string(std::move(s));
     }
-    stack.push(std::move(cs));
+    if (mode & 2) {
+      stack.push(std::move(cs));
+    }
     if (mode & 4) {
       stack.push_bool(true);
     }

--- a/crypto/fift/words.cpp
+++ b/crypto/fift/words.cpp
@@ -934,7 +934,9 @@ void interpret_fetch(vm::Stack& stack, int mode) {
   auto n = stack.pop_smallint_range(256 + (mode & 1));
   auto cs = stack.pop_cellslice();
   if (!cs->have(n)) {
-    stack.push(std::move(cs));
+    if (mode & 2) {
+      stack.push(std::move(cs));
+    }
     stack.push_bool(false);
     if (!(mode & 4)) {
       throw IntError{"end of data while reading integer from cell"};
@@ -959,7 +961,9 @@ void interpret_fetch_bytes(vm::Stack& stack, int mode) {
   unsigned n = stack.pop_smallint_range(127);
   auto cs = stack.pop_cellslice();
   if (!cs->have(n * 8)) {
-    stack.push(std::move(cs));
+    if (mode & 2) {
+      stack.push(std::move(cs));
+    }
     stack.push_bool(false);
     if (!(mode & 4)) {
       throw IntError{"end of data while reading byte string from cell"};
@@ -1011,7 +1015,9 @@ void interpret_cell_remaining(vm::Stack& stack) {
 void interpret_fetch_ref(vm::Stack& stack, int mode) {
   auto cs = stack.pop_cellslice();
   if (!cs->have_refs(1)) {
-    stack.push(std::move(cs));
+    if (mode & 2) {
+      stack.push(std::move(cs));
+    }
     stack.push_bool(false);
     if (!(mode & 4)) {
       throw IntError{"end of data while reading reference from cell"};

--- a/crypto/fift/words.cpp
+++ b/crypto/fift/words.cpp
@@ -1018,14 +1018,14 @@ void interpret_fetch_ref(vm::Stack& stack, int mode) {
     }
   } else {
     auto cell = (mode & 2) ? cs.write().fetch_ref() : cs.write().prefetch_ref();
-    if (mode & 2) {
-      stack.push(std::move(cs));
-    }
     if (mode & 1) {
       Ref<vm::CellSlice> new_cs{true, vm::NoVm(), std::move(cell)};
       stack.push(std::move(new_cs));
     } else {
       stack.push_cell(std::move(cell));
+    }
+    if (mode & 2) {
+      stack.push(std::move(cs));
     }
     if (mode & 4) {
       stack.push_bool(true);

--- a/doc/fiftbase.tex
+++ b/doc/fiftbase.tex
@@ -1178,9 +1178,9 @@ The following words can be used to manipulate values of the type {\em Slice\/}, 
 \item {\tt B@?+} ($s$ $x$ -- $B$ $s'$ $-1$ or $s$ $0$), similar to {\tt B@+}, but uses a flag to indicate failure instead of throwing an exception.
 \item {\tt \$@}, {\tt \$@+}, {\tt \$@?}, {\tt \$@?+}, counterparts of {\tt B@}, {\tt B@+}, {\tt B@?}, {\tt B@?+}, returning the result as a (UTF-8) {\em String} instead of a {\em Bytes} value. These primitives do not check whether the byte sequence read is a valid UTF-8 string.
 \item {\tt ref@} ($s$ -- $c$), fetches the first reference from {\em Slice\/}~$s$ and returns the {\em Cell}~$c$ referred to. If there are no references left, throws an exception.
-\item {\tt ref@+} ($s$ -- $s'$ $c$), similar to {\tt ref@}, but returns the remainder of $s$ as well.
+\item {\tt ref@+} ($s$ -- $c$ $s'$), similar to {\tt ref@}, but returns the remainder of $s$ as well.
 \item {\tt ref@?} ($s$ -- $c$ $-1$ or $0$), similar to {\tt ref@}, but uses a flag to indicate failure instead of throwing an exception.
-\item {\tt ref@?+} ($s$ -- $s'$ $c$ $-1$ or $s$ $0$), similar to {\tt ref@+}, but uses a flag to indicate failure instead of throwing an exception.
+\item {\tt ref@?+} ($s$ -- $c$ $s'$ $-1$ or $s$ $0$), similar to {\tt ref@+}, but uses a flag to indicate failure instead of throwing an exception.
 \item {\tt empty?} ($s$ -- $?$), checks whether a {\em Slice\/} is empty (i.e., has no data bits and no references left), and returns $-1$ or $0$ accordingly.
 \item {\tt remaining} ($s$ -- $x$ $y$), returns both the number of data bits $x$ and the number of cell references $y$ remaining in {\em Slice\/}~$s$.
 \item {\tt sbits} ($s$ -- $x$), returns the number of data bits $x$ remaining in {\em Slice\/}~$s$.


### PR DESCRIPTION
There are a couple of places where the semantics of Fift diverge from the specification. It seems that in all cases we found so far the specification was right, meaning that the behaviour described in it made more sense than what the implementation did, thus we fixed the implementation.

Too sad there is no easily usable testing framework, otherwise I would write defect test-cases.

_(On behalf of Team Serokell)_