### PR TITLE
Add unsigned dictionary manipulation funC primitives

### DIFF
--- a/crypto/smartcont/stdlib.fc
+++ b/crypto/smartcont/stdlib.fc
@@ -63,9 +63,13 @@ tuple parse_addr(slice s) asm "PARSEMSGADDR";
 
 cell idict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETREF";
 (cell, ()) ~idict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETREF";
+cell udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
+(cell, ()) ~udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
 cell idict_get_ref(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETOPTREF";
+cell udict_get_ref(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGETOPTREF";
 (cell, cell) idict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETGETOPTREF";
 (cell, int) idict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDEL";
+(cell, int) udict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDEL";
 (slice, int) idict_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGET" "NULLSWAPIFNOT";
 (slice, int) udict_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGET" "NULLSWAPIFNOT";
 (cell, slice, int) idict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDELGET" "NULLSWAPIFNOT";


### PR DESCRIPTION
Unsigned keys in dictionaries are common when working, for example, with keys that are hashes (for example `HASH` returns an unsigned 256-bit integer; I guess signed keys would work just fine, but it's nicer this way).

Another set of primitives that I'm really feeling the lack of (both in TVM and in funC) are dictionary count primitives: a .count() method would be extremely nice, instead of being forced to use a loop to count elements; tuples already have such a primitive, but dictionaries are extremely handy when working with large keys and values, since TVM automatically handles serialization of large keys and values with references to separate cells (and now that I think of it, there's no native way to serialize a simple tuple to a HashMapE).