### PR TITLE
Improve gen-zerostate

### DIFF
--- a/crypto/smartcont/gen-zerostate.fif
+++ b/crypto/smartcont/gen-zerostate.fif
@@ -195,7 +195,7 @@ smc1_addr config.minter_smc!
 
 1000000000000 -17 of-cc 666666666666 239 of-cc cc+ config.to_mint!
 
-"validator-keys" +suffix +".pub" file>B
+"validator-keys" +suffix +".pk" load-generate-keypair drop
 { dup Blen } { 32 B| swap dup ."Validator public key = " Bx. cr
   17 add-validator } while drop
 // newkeypair nip dup ."Validator #1 public key = " Bx. cr 


### PR DESCRIPTION
The validator-keys pubkey has to be a pure 256-bit ecdh key with no headers, this allows gen-zerostate to automatically create such key.
Edit: HMMM now that I think about it this prevents us from loading multiple validator keys from a single file, anyway my issue was that the generate-random-id utility didn't generate pure ecdh keys, prepending instead a header