### PR TITLE
Fix for not enough space for the wallet.fif message body slice

### DIFF
--- a/crypto/smartcont/wallet.fif
+++ b/crypto/smartcont/wallet.fif
@@ -52,10 +52,12 @@ constant body-cell
 dest_addr 2dup bounce 7 + .Addr ." = " .addr 
 ."seqno=0x" seqno x. ."bounce=" bounce . cr
 ."Body of transfer message is " body-cell <s csr. cr
+
+{ sbitrefs swap 1 + swap rot brembitrefs rot >= -rot <= and } : s-fits-plus-one?
   
 // create a message
 <b b{01} s, bounce 1 i, b{000100} s, dest_addr addr, amount Gram, 0 9 64 32 + + 1+ u, 
-  body-cell <s 2dup s-fits? not rot over 1 i, -rot { drop body-cell ref, } { s, } cond
+  body-cell <s 2dup s-fits-plus-one? not rot over 1 i, -rot { drop body-cell ref, } { s, } cond
 b>
 <b seqno 32 u, send-mode 8 u, swap ref, b>
 dup ."signing message: " <s csr. cr


### PR DESCRIPTION
body-cell slice bits are calculated before 1 i flag so there is a case when builder has exactly the body-cell length bits left and body-cell won't fit.