### PR TITLE
FunC: Integer constants basic support

### DIFF
--- a/crypto/func/builtins.cpp
+++ b/crypto/func/builtins.cpp
@@ -27,7 +27,7 @@ using namespace std::literals::string_literals;
  * 
  */
 
-int glob_func_cnt, undef_func_cnt, glob_var_cnt;
+int glob_func_cnt, undef_func_cnt, glob_var_cnt, const_cnt;
 std::vector<SymDef*> glob_func, glob_vars;
 
 SymDef* predefine_builtin_func(std::string name, TypeExpr* func_type) {

--- a/crypto/func/func.h
+++ b/crypto/func/func.h
@@ -98,6 +98,7 @@ enum Keyword {
   _Asm,
   _Impure,
   _Global,
+  _Const,
   _Extern,
   _Inline,
   _InlineRef,
@@ -763,7 +764,18 @@ struct SymValGlobVar : sym::SymValBase {
   }
 };
 
-extern int glob_func_cnt, undef_func_cnt, glob_var_cnt;
+struct SymValConst : sym::SymValBase {
+  td::RefInt256 intval;
+  SymValConst(int idx, td::RefInt256 value)
+      : sym::SymValBase(_Const, idx), intval(value) {
+  }
+  ~SymValConst() override = default;
+  td::RefInt256 get_value() const {
+    return intval;
+  }
+};
+
+extern int glob_func_cnt, undef_func_cnt, glob_var_cnt, const_cnt;
 extern std::vector<SymDef*> glob_func, glob_vars;
 
 /*

--- a/crypto/func/keywords.cpp
+++ b/crypto/func/keywords.cpp
@@ -113,6 +113,7 @@ void define_keywords() {
       .add_keyword("forall", Kw::_Forall);
 
   sym::symbols.add_keyword("extern", Kw::_Extern)
+      .add_keyword("const", Kw::_Const)
       .add_keyword("global", Kw::_Global)
       .add_keyword("asm", Kw::_Asm)
       .add_keyword("impure", Kw::_Impure)

--- a/crypto/parser/symtable.h
+++ b/crypto/parser/symtable.h
@@ -32,7 +32,7 @@ namespace sym {
 typedef int var_idx_t;
 
 struct SymValBase {
-  enum { _Param, _Var, _Func, _Typename, _GlobVar };
+  enum { _Param, _Var, _Func, _Typename, _GlobVar, _Const };
   int type;
   int idx;
   SymValBase(int _type, int _idx) : type(_type), idx(_idx) {


### PR DESCRIPTION
_This PR is splitted from #220 into seperate branch for maintainability._

This PR implements `const` keyword that allows defining integer constants.

They can be used in code as like `const name = value;`
`value` must be a number or name of another constant.

The use of constant completely emulates use of it's value as close as possible.
This allows to maintain usability of code while not sacrificing optimizations (constant is treated as it's value in-place) and improving code readability (against pure numbers and even against asm or function-based constants, no need for braces).

In order to prevent confusion redefinition of constants is forbidden.

Caveat: expressions in value not yet supported (`const a = b + c;`). Such support requires precise and not so simple expression parsing, ensuring that only constants are used, immediately resolving them and applying operations while compiling. Not a task for the 4 AM brain.

Support of constants of other types is not useful, because constants are compile-time (their value must be injected while lexer is parsing), and no other simple types are supported.

P.S. I got really **determined** and finally understood FunC lexer and compiler logic after the last commit acf1671 and finally decided to actually implement something useful in FunC core.
_Too sad I did not get this enlightement 2-3 months ago._

Test case:
```
;; test constant stacking
const a = 111, b = 222;
const c = 123, d = c;
const e = 257; ;; large constant

;; const c = 124; ;; NOT permitted

int const_test(slice s, int v) {
	;; const f = 1; ;; NOT allowed, constants are global
	;; directly load constant into variable
	int z = a;
	;; use constant as native function argument
	int y = s~load_uint(b); ;; 222 LDU
	;; use variable as native function argument
	int x = s~load_uint(v); ;; ... LDUX
	;; test behaviour of direct and indirect const
	return x + y + z + c + e;
	;; will have at least 123 ADDCONST and 257 PUSHINT ADD
}

int const_test_bitwise(int v) {
	return v | a & b;
}

int const_test_condition(int v) {
	if (v == a) { return b; }
	elseif (v > c) { return e; }
	else { return c; }
}
```
generates code:
```
DECLPROC const_test
DECLPROC const_test_bitwise
DECLPROC const_test_condition
const_test PROC:<{
  SWAP
  222 LDU
  ROT
  LDUX
  DROP
  SWAP
  ADD
  111 ADDCONST
  123 ADDCONST
  257 PUSHINT
  ADD
}>
const_test_bitwise PROC:<{
  111 PUSHINT
  222 PUSHINT
  AND
  OR
}>
const_test_condition PROC:<{
  DUP
  111 EQINT
  IFJMP:<{
    DROP
    222 PUSHINT
  }>
  123 GTINT
  IFJMP:<{
    257 PUSHINT
  }>
  123 PUSHINT
}>
```