### PR TITLE
FunC: Include keyword implementation

### DIFF
--- a/crypto/func/func.h
+++ b/crypto/func/func.h
@@ -35,6 +35,7 @@ namespace funC {
 
 extern int verbosity;
 extern bool op_rewrite_comments;
+extern std::string generated_from;
 
 constexpr int optimize_depth = 12;
 
@@ -105,7 +106,8 @@ enum Keyword {
   _Operator,
   _Infix,
   _Infixl,
-  _Infixr
+  _Infixr,
+  _Include
 };
 
 void define_keywords();

--- a/crypto/func/keywords.cpp
+++ b/crypto/func/keywords.cpp
@@ -123,6 +123,9 @@ void define_keywords() {
       .add_keyword("infix", Kw::_Infix)
       .add_keyword("infixl", Kw::_Infixl)
       .add_keyword("infixr", Kw::_Infixr);
+	  
+
+  sym::symbols.add_keyword("include", Kw::_Include);
 }
 
 }  // namespace funC


### PR DESCRIPTION
_This PR is splitted from #220 into seperate branch for maintainability._

Added `include` keyword that allows to include another .fc files from the source.

Circular references are automatically protected from because while parsing source code func locks the source file from subsequent access, therefore if circular reference happens compilation would fail.
Relative paths to scripts are handled correctly as well (both in value and source relativity).

Keyword usage: `include "filename.fc";`
