### PR TITLE
FunC: Detection of unused variables (assigns) and (proc) calls

### DIFF
--- a/crypto/func/abscode.cpp
+++ b/crypto/func/abscode.cpp
@@ -285,6 +285,7 @@ void Op::show(std::ostream& os, const std::vector<TmpVar>& vars, std::string pfx
     os << " ]\n";
   }
   std::string dis = disabled() ? "<disabled> " : "";
+  if (replaced()) dis = "<replaced> "; // not just disabled
   if (noreturn()) {
     dis += "<noret> ";
   }
@@ -425,6 +426,9 @@ void Op::show_var_list(std::ostream& os, const std::vector<VarDescr>& list, cons
       }
       if (list[i].is_unused()) {
         os << '?';
+      }
+      if (list[i].is_replaced()) {
+        os << "#";
       }
       os << vars.at(list[i].idx) << ':';
       list[i].show_value(os);

--- a/crypto/func/analyzer.cpp
+++ b/crypto/func/analyzer.cpp
@@ -185,6 +185,17 @@ std::size_t VarDescrList::count_used(const std::vector<var_idx_t> idx_list) cons
   return res;
 }
 
+std::size_t VarDescrList::count_unreplaced(const std::vector<var_idx_t> idx_list) const {
+  std::size_t res = 0;
+  for (var_idx_t idx : idx_list) {
+    auto v = operator[](idx);
+    if (!v || !v->is_replaced()) {
+      ++res;
+    }
+  }
+  return res;
+}
+
 VarDescrList& VarDescrList::operator-=(var_idx_t idx) {
   auto it = std::lower_bound(list.begin(), list.end(), idx);
   if (it != list.end() && it->idx == idx) {
@@ -200,19 +211,22 @@ VarDescrList& VarDescrList::operator-=(const std::vector<var_idx_t>& idx_list) {
   return *this;
 }
 
-VarDescrList& VarDescrList::add_var(var_idx_t idx, bool unused) {
+VarDescrList& VarDescrList::add_var(var_idx_t idx, bool unused, bool replaced) {
   auto it = std::lower_bound(list.begin(), list.end(), idx);
   if (it == list.end() || it->idx != idx) {
-    list.emplace(it, idx, VarDescr::_Last | (unused ? VarDescr::_Unused : 0));
+    list.emplace(it, idx, VarDescr::_Last | (unused ? VarDescr::_Unused : 0) 
+	  | (replaced ? (VarDescr::_Unused | VarDescr::_Replaced) : 0));
   } else if (it->is_unused() && !unused) {
     it->clear_unused();
+  } else if (it->is_replaced() && !replaced) {
+    it->clear_replaced();
   }
   return *this;
 }
 
-VarDescrList& VarDescrList::add_vars(const std::vector<var_idx_t>& idx_list, bool unused) {
+VarDescrList& VarDescrList::add_vars(const std::vector<var_idx_t>& idx_list, bool unused, bool replaced) {
   for (var_idx_t idx : idx_list) {
-    add_var(idx, unused);
+    add_var(idx, unused, replaced);
   }
   return *this;
 }
@@ -328,7 +342,7 @@ VarDescrList& VarDescrList::import_values(const VarDescrList& values) {
   return *this;
 }
 
-bool Op::std_compute_used_vars(bool disabled) {
+bool Op::std_compute_used_vars(bool disabled, bool replaced) {
   // left = OP right
   // var_info := (var_info - left) + right
   VarDescrList new_var_info{next->var_info};
@@ -336,10 +350,10 @@ bool Op::std_compute_used_vars(bool disabled) {
   new_var_info.clear_last();
   if (args.size() == right.size() && !disabled) {
     for (const VarDescr& arg : args) {
-      new_var_info.add_var(arg.idx, arg.is_unused());
+      new_var_info.add_var(arg.idx, arg.is_unused(), arg.is_replaced());
     }
   } else {
-    new_var_info.add_vars(right, disabled);
+    new_var_info.add_vars(right, disabled, replaced);
   }
   return set_var_info(std::move(new_var_info));
 }
@@ -358,10 +372,13 @@ bool Op::compute_used_vars(const CodeBlob& code, bool edit) {
       // left = EXEC right;
       if (!next_var_info.count_used(left) && is_pure()) {
         // all variables in `left` are not needed
+		bool repl = left.size() && !next_var_info.count_unreplaced(left);
         if (edit) {
           disable();
+          if (repl)
+            replace(); // mark as replaced
         }
-        return std_compute_used_vars(true);
+        return std_compute_used_vars(true, repl);
       }
       return std_compute_used_vars();
     }
@@ -375,6 +392,7 @@ bool Op::compute_used_vars(const CodeBlob& code, bool edit) {
     case _Let: {
       // left = right
       std::size_t cnt = next_var_info.count_used(left);
+	  std::size_t unr = next_var_info.count_unreplaced(left);
       assert(left.size() == right.size());
       auto l_it = left.cbegin(), r_it = right.cbegin();
       VarDescrList new_var_info{next_var_info};
@@ -384,7 +402,7 @@ bool Op::compute_used_vars(const CodeBlob& code, bool edit) {
       for (; l_it < left.cend(); ++l_it, ++r_it) {
         if (std::find(l_it + 1, left.cend(), *l_it) == left.cend()) {
           auto p = next_var_info[*l_it];
-          new_var_info.add_var(*r_it, !p || p->is_unused());
+          new_var_info.add_var(*r_it, !p || p->is_unused(), p && p->is_replaced());
           new_left.push_back(*l_it);
           new_right.push_back(*r_it);
         }
@@ -396,6 +414,8 @@ bool Op::compute_used_vars(const CodeBlob& code, bool edit) {
       if (!cnt && edit) {
         // all variables in `left` are not needed
         disable();
+        if (left.size() && !unr)
+          replaced();
       }
       return set_var_info(std::move(new_var_info));
     }

--- a/crypto/func/func.cpp
+++ b/crypto/func/func.cpp
@@ -34,7 +34,7 @@
 
 namespace funC {
 
-int verbosity, indent, opt_level = 2;
+int verbosity, indent, opt_level = 2, warn_unused;
 bool stack_layout_comments, op_rewrite_comments, program_envelope, asm_preamble;
 std::ostream* outs = &std::cout;
 std::string generated_from, boc_output_filename;
@@ -171,7 +171,8 @@ void usage(const char* progname) {
          "-S\tInclude stack layout comments in the output code\n"
          "-R\tInclude operation rewrite comments in the output code\n"
          "-W<output-boc-file>\tInclude Fift code to serialize and save generated code into specified BoC file. Enables "
-         "-A and -P.\n";
+         "-A and -P.\n"
+		 "-u\tEnable warnings about unused calls and variables (once for assigns, twice also for calls)\n";
   std::exit(2);
 }
 
@@ -180,7 +181,7 @@ std::string output_filename;
 int main(int argc, char* const argv[]) {
   int i;
   bool interactive = false;
-  while ((i = getopt(argc, argv, "Ahi:Io:O:PRSvW:")) != -1) {
+  while ((i = getopt(argc, argv, "Ahi:Io:O:PRSuvW:")) != -1) {
     switch (i) {
       case 'A':
         funC::asm_preamble = true;
@@ -205,6 +206,9 @@ int main(int argc, char* const argv[]) {
         break;
       case 'S':
         funC::stack_layout_comments = true;
+        break;
+      case 'u':
+        ++funC::warn_unused;
         break;
       case 'v':
         ++funC::verbosity;

--- a/crypto/func/func.h
+++ b/crypto/func/func.h
@@ -33,7 +33,7 @@
 
 namespace funC {
 
-extern int verbosity;
+extern int verbosity, warn_unused;
 extern bool op_rewrite_comments;
 
 constexpr int optimize_depth = 12;
@@ -290,7 +290,7 @@ struct TmpVar {
 
 struct VarDescr {
   var_idx_t idx;
-  enum { _Last = 1, _Unused = 2 };
+  enum { _Last = 1, _Unused = 2, _Replaced = 4 };
   int flags;
   enum {
     _Const = 16,
@@ -324,6 +324,9 @@ struct VarDescr {
   }
   bool is_unused() const {
     return flags & _Unused;
+  }
+  bool is_replaced() const {
+    return flags & _Replaced;
   }
   bool is_last() const {
     return flags & _Last;
@@ -382,8 +385,16 @@ struct VarDescr {
   void unused() {
     flags |= _Unused;
   }
+  void replaced() {
+    unused(); // replaced var is always unused
+    flags |= _Replaced;
+  }
   void clear_unused() {
     flags &= ~_Unused;
+    clear_replaced();
+  }
+  void clear_replaced() {
+    flags &= ~_Replaced;
   }
   void set_const(long long value);
   void set_const(td::RefInt256 value);
@@ -433,12 +444,13 @@ struct VarDescrList {
   VarDescrList& operator+=(const std::vector<var_idx_t>& idx_list) {
     return add_vars(idx_list);
   }
-  VarDescrList& add_var(var_idx_t idx, bool unused = false);
-  VarDescrList& add_vars(const std::vector<var_idx_t>& idx_list, bool unused = false);
+  VarDescrList& add_var(var_idx_t idx, bool unused = false, bool replaced = false);
+  VarDescrList& add_vars(const std::vector<var_idx_t>& idx_list, bool unused = false, bool replaced = false);
   VarDescrList& operator-=(const std::vector<var_idx_t>& idx_list);
   VarDescrList& operator-=(var_idx_t idx);
   std::size_t count(const std::vector<var_idx_t> idx_list) const;
   std::size_t count_used(const std::vector<var_idx_t> idx_list) const;
+  std::size_t count_unreplaced(const std::vector<var_idx_t> idx_list) const;
   VarDescr& add(var_idx_t idx);
   VarDescr& add_newval(var_idx_t idx);
   VarDescrList& operator&=(const VarDescrList& values);
@@ -512,7 +524,7 @@ struct Op {
     _Again
   };
   int cl;
-  enum { _Disabled = 1, _Reachable = 2, _NoReturn = 4, _ImpureR = 8, _ImpureW = 16, _Impure = 24 };
+  enum { _Disabled = 1, _Reachable = 2, _NoReturn = 4, _ImpureR = 8, _ImpureW = 16, _Impure = 24, _Replaced = 32 };
   int flags;
   std::unique_ptr<Op> next;
   SymDef* fun_ref;
@@ -544,11 +556,18 @@ struct Op {
   bool disabled() const {
     return flags & _Disabled;
   }
+  bool replaced() const {
+    return flags & _Replaced;
+  }
   bool enabled() const {
     return !disabled();
   }
   void disable() {
     flags |= _Disabled;
+  }
+  void replace() {
+    disable();
+    flags |= _Replaced;
   }
   bool unreachable() {
     return !(flags & _Reachable);
@@ -562,7 +581,7 @@ struct Op {
   void split_vars(const std::vector<TmpVar>& vars);
   static void split_var_list(std::vector<var_idx_t>& var_list, const std::vector<TmpVar>& vars);
   bool compute_used_vars(const CodeBlob& code, bool edit);
-  bool std_compute_used_vars(bool disabled = false);
+  bool std_compute_used_vars(bool disabled = false, bool replaced = false);
   bool set_var_info(const VarDescrList& new_var_info);
   bool set_var_info(VarDescrList&& new_var_info);
   bool set_var_info_except(const VarDescrList& new_var_info, const std::vector<var_idx_t>& var_list);


### PR DESCRIPTION
_This PR is splitted from #220 into seperate branch for maintainability._

This massive (in terms of lines, to say the least) upgrade adds a counting `-u` flag that allows to warn about something really missing out: unused variables (assignments) if used at least once, adding unused procedure (and operator) calls if used at least twice.

If used, the compiler would display warnings about all unused things for this level (depending of number of `-u` flags used), that would allow to find many different mistakes in code, such as incorrect usage of impure or pure functions, mistypes, accidental redefenitions, copy-paste mistakes, etc.

Technically, replacements are marked with special _Replaced flag, while unused calls and variables only have the _Unused flag. This way, it is possbile to separate builtin-precalculated from really unused vars and calls.

As a room for improvement: I have not yet found a way to beautifully extract the name of unused variable (that should be relatively easy), ignore assignments to _ (holes) and correctly handle and display warnings about `(..., ..., ...) = (...~..., ...~..., ...~...)` functions (because of nature of tlide op).