### PR TITLE
Fift: Add a flag to support backtracing error call stack

### DIFF
--- a/crypto/fift/Dictionary.h
+++ b/crypto/fift/Dictionary.h
@@ -49,6 +49,9 @@ class WordDef : public td::CntObject {
   virtual const std::vector<Ref<WordDef>>* get_list() const {
     return nullptr;
   }
+  virtual long long inner_addr() const {
+    return 0;
+  }
 };
 
 class StackWord : public WordDef {
@@ -59,6 +62,9 @@ class StackWord : public WordDef {
   }
   ~StackWord() override = default;
   Ref<WordDef> run_tail(IntCtx& ctx) const override;
+  long long inner_addr() const override {
+    return (long long) &f;
+  }
 };
 
 class CtxWord : public WordDef {
@@ -69,6 +75,9 @@ class CtxWord : public WordDef {
   }
   ~CtxWord() override = default;
   Ref<WordDef> run_tail(IntCtx& ctx) const override;
+  long long inner_addr() const override {
+    return (long long) &f;
+  }
 };
 
 typedef std::function<Ref<WordDef>(IntCtx&)> CtxTailWordFunc;
@@ -81,6 +90,9 @@ class CtxTailWord : public WordDef {
   }
   ~CtxTailWord() override = default;
   Ref<WordDef> run_tail(IntCtx& ctx) const override;
+  long long inner_addr() const override {
+    return (long long) &f;
+  }
 };
 
 class WordList : public WordDef {
@@ -150,6 +162,7 @@ WordRef::WordRef(std::vector<Ref<WordDef>>&& word_list) : def(Ref<WordList>{true
 class Dictionary {
  public:
   WordRef* lookup(td::Slice name);
+  std::string reverse_lookup(const WordDef* ref);
   void def_ctx_word(std::string name, CtxWordFunc func);
   void def_ctx_tail_word(std::string name, CtxTailWordFunc func);
   void def_active_word(std::string name, CtxWordFunc func);

--- a/crypto/fift/Fift.cpp
+++ b/crypto/fift/Fift.cpp
@@ -61,6 +61,7 @@ td::Result<int> Fift::do_interpret(IntCtx& ctx) {
   ctx.dictionary = &config_.dictionary;
   ctx.output_stream = config_.output_stream;
   ctx.error_stream = config_.error_stream;
+  if (config_.trace_errors) ctx.enable_error_trace();
   if (!ctx.output_stream) {
     return td::Status::Error("Cannot run interpreter without output_stream");
   }

--- a/crypto/fift/Fift.h
+++ b/crypto/fift/Fift.h
@@ -36,6 +36,7 @@ struct Fift {
     fift::Dictionary dictionary;
     std::ostream* output_stream{&std::cout};
     std::ostream* error_stream{&std::cerr};
+    bool trace_errors{false};
   };
   // Fift must own ton_db and dictionary, no concurrent access is allowed
   explicit Fift(Config config);

--- a/crypto/fift/IntCtx.h
+++ b/crypto/fift/IntCtx.h
@@ -69,6 +69,7 @@ struct IntCtx {
   int include_depth{0};
   int line_no{0};
   bool need_line{true};
+  bool trace_errors{false};
   std::string filename;
   std::string currentd_dir;
   std::istream* input_stream{nullptr};
@@ -122,6 +123,14 @@ struct IntCtx {
   }
 
   bool is_sb() const;
+
+  void enable_error_trace() { 
+    trace_errors = true; 
+  }
+
+  bool tracing_errors() const {
+    return trace_errors;
+  }
 
   void clear() {
     state = 0;

--- a/crypto/fift/fift-main.cpp
+++ b/crypto/fift/fift-main.cpp
@@ -65,7 +65,8 @@ void usage(const char* progname) {
                "\t-L<library-fif-file>\tPre-loads a library source file\n"
                "\t-d<ton-db-path>\tUse a ton database\n"
                "\t-s\tScript mode: use first argument as a fift source file and import remaining arguments as $n)\n"
-               "\t-v<verbosity-level>\tSet verbosity level\n";
+               "\t-v<verbosity-level>\tSet verbosity level\n"
+               "\t-t\tEnables detailed error stack trace on exception\n";
   std::exit(2);
 }
 
@@ -84,6 +85,7 @@ int main(int argc, char* const argv[]) {
   bool interactive = false;
   bool fift_preload = true, no_env = false;
   bool script_mode = false;
+  bool trace_errors = false;
   std::vector<std::string> library_source_files, source_list;
   std::vector<std::string> source_include_path;
   std::string ton_db_path;
@@ -92,7 +94,7 @@ int main(int argc, char* const argv[]) {
 
   int i;
   int new_verbosity_level = VERBOSITY_NAME(INFO);
-  while (!script_mode && (i = getopt(argc, argv, "hinI:L:d:sv:")) != -1) {
+  while (!script_mode && (i = getopt(argc, argv, "hinI:L:d:sv:t")) != -1) {
     switch (i) {
       case 'i':
         interactive = true;
@@ -115,6 +117,9 @@ int main(int argc, char* const argv[]) {
         break;
       case 'v':
         new_verbosity_level = VERBOSITY_NAME(FATAL) + td::to_integer<int>(td::Slice(optarg));
+        break;
+      case 't':
+        trace_errors = true;
         break;
       case 'h':
       default:
@@ -163,6 +168,8 @@ int main(int argc, char* const argv[]) {
     fift::import_cmdline_args(config.dictionary, source_list.empty() ? "" : source_list[0], argc - optind,
                               argv + optind);
   }
+
+  config.trace_errors = trace_errors;
 
   fift::Fift fift(std::move(config));
 


### PR DESCRIPTION
This PR implements a `-t` flag that activates error tracing mode.

That would cause detailed backtrace be printed as WARN and INFO in cause of error during compilation or interpretation (execution) of a fift script.
This can help debugging errors tremendously, because otherwise only top-level called word is displayed in error, and it may be **very very** difficult to find out where error has occured.
Now debugging such errors becomes several orders of magnitude easier.

If the flag is activated and error occurs, much information would be printed to 2 (WARN) and 3 (INFO) levels during unwinding including call stack of words, position of called words, currently executed branches of cond and while, operation mode of `funny loop`.

---

Technically additional operation on dictionary, reverse lookup, was implemented, to allow to (approximately) find the called word name when unwinding (reverse iterator is used to find out first defined instance of word - it should be most semantically correct).

Execution tokens are displayed as some hex number (picked to be most adequate, not very large but reasonably unique in execution), but currently I can't find the link between token address and the actual word list to be executed, it would be very expressive when this is fixed.

`cond` had to be rewritten into _ordinary word_ instead of _tail execution word_ because otherwise it is not possible to catch which branch was actually executed and display corresponding message during unwinding.

An example of "informative" error message without the -t flag:
![image](https://user-images.githubusercontent.com/5331782/72035276-16638b00-32a0-11ea-9329-61b4eaad2a9a.png)

And a much more **informative** backtrace with the -t flag:
![image](https://user-images.githubusercontent.com/5331782/72035311-31ce9600-32a0-11ea-977f-ab7228dc349e.png)
Now the origin of error is perfectly traceable.

It may also be reasonable to snapshot stack before word execution and in case of error dump, but that is not implemented yet and may incur some more overhead, and add much mess to output.