### PR TITLE
FunC: implicit functions (parameterless)

### DIFF
--- a/crypto/func/keywords.cpp
+++ b/crypto/func/keywords.cpp
@@ -122,7 +122,8 @@ void define_keywords() {
       .add_keyword("operator", Kw::_Operator)
       .add_keyword("infix", Kw::_Infix)
       .add_keyword("infixl", Kw::_Infixl)
-      .add_keyword("infixr", Kw::_Infixr);
+      .add_keyword("infixr", Kw::_Infixr)
+      .add_keyword("implicit", Kw::_Implicit);
 }
 
 }  // namespace funC


### PR DESCRIPTION
This PR implements an `implicit` keyword that allows to define functions that should not be followed by arguments tuple.
This way it is possible to more beautifully implement something more closely resembling structures without awful `()` everywhere.

This much like **native** constants (autoapply functions) with the exception that it is possible to chain function call with variable (with calling . or modifying ~) and it would not expect any arguments tuple afterwards.

A tiny example:
```
int implasm() implicit asm "32 PUSHINT";

int explflag(int a) asm "1 PUSHINT AND";
int implflag(int a) implicit asm "2 PUSHINT OR";

int implfun(int this) implicit {
	return 32 * this;
}

(int, ()) ~implmod(int this) implicit {
	return (this + 33, ());
}

...

() main() {
	int test = 1;
	test~implmod;
	var data = begin_cell().store_uint(0xc0de, test.implfun).end_cell();
	if (fn1(data) | fn2(data)){
		data = begin_cell().store_uint(0xc0ffee, implasm)
			.store_uint(test.explflag(), test.implflag).end_cell();	
		fn3(data);
	}
	return ();
}
```