### PR TITLE
Write persistent state directly to file instead of a buffer

### DIFF
--- a/crypto/vm/boc.h
+++ b/crypto/vm/boc.h
@@ -23,6 +23,7 @@
 #include "td/utils/buffer.h"
 #include "td/utils/HashMap.h"
 #include "td/utils/HashSet.h"
+#include "td/utils/port/FileFd.h"
 
 namespace vm {
 using td::Ref;
@@ -216,8 +217,6 @@ class BagOfCells {
   int max_depth{1024};
   Info info;
   unsigned long long data_bytes{0};
-  unsigned char* store_ptr{nullptr};
-  unsigned char* store_end{nullptr};
   td::HashMap<Hash, int> cells;
   struct CellInfo {
     Ref<DataCell> dc_ref;
@@ -267,6 +266,9 @@ class BagOfCells {
   std::string serialize_to_string(int mode = 0);
   td::Result<td::BufferSlice> serialize_to_slice(int mode = 0);
   std::size_t serialize_to(unsigned char* buffer, std::size_t buff_size, int mode = 0);
+  td::Status serialize_to_file(td::FileFd& fd, int mode = 0);
+  template<typename WriterT>
+  std::size_t serialize_to_impl(WriterT& writer, int mode = 0);
   std::string extract_string() const;
 
   td::Result<long long> deserialize(const td::Slice& data, int max_roots = default_max_roots);
@@ -295,23 +297,6 @@ class BagOfCells {
     cell_list_.clear();
   }
   td::uint64 compute_sizes(int mode, int& r_size, int& o_size);
-  void init_store(unsigned char* from, unsigned char* to) {
-    store_ptr = from;
-    store_end = to;
-  }
-  void store_chk() const {
-    DCHECK(store_ptr <= store_end);
-  }
-  bool store_empty() const {
-    return store_ptr == store_end;
-  }
-  void store_uint(unsigned long long value, unsigned bytes);
-  void store_ref(unsigned long long value) {
-    store_uint(value, info.ref_byte_size);
-  }
-  void store_offset(unsigned long long value) {
-    store_uint(value, info.offset_byte_size);
-  }
   void reorder_cells();
   int revisit(int cell_idx, int force = 0);
   unsigned long long get_idx_entry_raw(int index);

--- a/validator/db/archive-manager.hpp
+++ b/validator/db/archive-manager.hpp
@@ -45,6 +45,9 @@ class ArchiveManager : public td::actor::Actor {
   void add_zero_state(BlockIdExt block_id, td::BufferSlice data, td::Promise<td::Unit> promise);
   void add_persistent_state(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice data,
                             td::Promise<td::Unit> promise);
+  void add_persistent_state_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                std::function<td::Status(td::FileFd&)> write_state,
+                                td::Promise<td::Unit> promise);
   void get_zero_state(BlockIdExt block_id, td::Promise<td::BufferSlice> promise);
   void get_persistent_state(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::Promise<td::BufferSlice> promise);
   void get_persistent_state_slice(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::int64 offset,
@@ -137,6 +140,8 @@ class ArchiveManager : public td::actor::Actor {
   PackageId get_max_temp_file_desc_idx();
   PackageId get_prev_temp_file_desc_idx(PackageId id);
 
+  void add_persistent_state_impl(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::Promise<td::Unit> promise,
+                                 std::function<void(std::string, td::Promise<std::string>)> create_writer);
   void written_perm_state(FileReferenceShort id);
 
   void persistent_state_gc(FileHash last);

--- a/validator/db/files-async.hpp
+++ b/validator/db/files-async.hpp
@@ -52,30 +52,50 @@ class WriteFile : public td::actor::Actor {
     auto res = R.move_as_ok();
     auto file = std::move(res.first);
     auto old_name = res.second;
-    td::uint64 offset = 0;
-    while (data_.size() > 0) {
-      auto R = file.pwrite(data_.as_slice(), offset);
-      auto s = R.move_as_ok();
-      offset += s;
-      data_.confirm_read(s);
+    auto status = write_data_(file);
+    if (!status.is_error()) {
+      status = file.sync();
     }
-    file.sync().ensure();
+    if (status.is_error()) {
+      td::unlink(old_name);
+      promise_.set_error(std::move(status));
+      stop();
+      return;
+    }
     if (new_name_.length() > 0) {
-      td::rename(old_name, new_name_).ensure();
-      promise_.set_value(std::move(new_name_));
+      status = td::rename(old_name, new_name_);
+      if (status.is_error()) {
+        promise_.set_error(std::move(status));
+      } else {
+        promise_.set_value(std::move(new_name_));
+      }
     } else {
       promise_.set_value(std::move(old_name));
     }
     stop();
   }
+  WriteFile(std::string tmp_dir, std::string new_name, std::function<td::Status(td::FileFd&)> write_data,
+            td::Promise<std::string> promise)
+      : tmp_dir_(tmp_dir), new_name_(new_name), write_data_(std::move(write_data)), promise_(std::move(promise)) {
+  }
   WriteFile(std::string tmp_dir, std::string new_name, td::BufferSlice data, td::Promise<std::string> promise)
-      : tmp_dir_(tmp_dir), new_name_(new_name), data_(std::move(data)), promise_(std::move(promise)) {
+      : tmp_dir_(tmp_dir), new_name_(new_name), promise_(std::move(promise)) {
+    write_data_ = [data_ptr = std::make_shared<td::BufferSlice>(std::move(data))] (td::FileFd& fd) {
+      auto data = std::move(*data_ptr);
+      td::uint64 offset = 0;
+      while (data.size() > 0) {
+        TRY_RESULT(s, fd.pwrite(data.as_slice(), offset));
+        offset += s;
+        data.confirm_read(s);
+      }
+      return td::Status::OK();
+    };
   }
 
  private:
   const std::string tmp_dir_;
   std::string new_name_;
-  td::BufferSlice data_;
+  std::function<td::Status(td::FileFd&)> write_data_;
   td::Promise<std::string> promise_;
 };
 

--- a/validator/db/rootdb.cpp
+++ b/validator/db/rootdb.cpp
@@ -276,6 +276,13 @@ void RootDb::store_persistent_state_file(BlockIdExt block_id, BlockIdExt masterc
                           std::move(state), std::move(promise));
 }
 
+void RootDb::store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                             std::function<td::Status(td::FileFd&)> write_data,
+                                             td::Promise<td::Unit> promise) {
+  td::actor::send_closure(archive_db_, &ArchiveManager::add_persistent_state_gen, block_id, masterchain_block_id,
+                          std::move(write_data), std::move(promise));
+}
+
 void RootDb::get_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id,
                                        td::Promise<td::BufferSlice> promise) {
   td::actor::send_closure(archive_db_, &ArchiveManager::get_persistent_state, block_id, masterchain_block_id,

--- a/validator/db/rootdb.hpp
+++ b/validator/db/rootdb.hpp
@@ -69,6 +69,9 @@ class RootDb : public Db {
 
   void store_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice state,
                                    td::Promise<td::Unit> promise) override;
+  void store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                       std::function<td::Status(td::FileFd&)> write_data,
+                                       td::Promise<td::Unit> promise) override;
   void get_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id,
                                  td::Promise<td::BufferSlice> promise) override;
   void get_persistent_state_file_slice(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::int64 offset,

--- a/validator/impl/shard.hpp
+++ b/validator/impl/shard.hpp
@@ -87,6 +87,7 @@ class ShardStateQ : virtual public ShardState {
   td::Result<Ref<ShardState>> merge_with(const ShardState& with) const override;
   td::Result<std::pair<Ref<ShardState>, Ref<ShardState>>> split() const override;
   td::Result<td::BufferSlice> serialize() const override;
+  td::Status serialize_to_file(td::FileFd& fd) const override;
 };
 
 #if TD_MSVC

--- a/validator/interfaces/db.h
+++ b/validator/interfaces/db.h
@@ -53,6 +53,9 @@ class Db : public td::actor::Actor {
 
   virtual void store_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice state,
                                            td::Promise<td::Unit> promise) = 0;
+  virtual void store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                               std::function<td::Status(td::FileFd&)> write_data,
+                                               td::Promise<td::Unit> promise) = 0;
   virtual void get_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id,
                                          td::Promise<td::BufferSlice> promise) = 0;
   virtual void get_persistent_state_file_slice(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::int64 offset,

--- a/validator/interfaces/shard.h
+++ b/validator/interfaces/shard.h
@@ -55,6 +55,7 @@ class ShardState : public td::CntObject {
   virtual td::Result<std::pair<td::Ref<ShardState>, td::Ref<ShardState>>> split() const = 0;
 
   virtual td::Result<td::BufferSlice> serialize() const = 0;
+  virtual td::Status serialize_to_file(td::FileFd& fd) const = 0;
 };
 
 class MasterchainState : virtual public ShardState {

--- a/validator/interfaces/validator-manager.h
+++ b/validator/interfaces/validator-manager.h
@@ -57,6 +57,9 @@ class ValidatorManager : public ValidatorManagerInterface {
                                td::Promise<td::Ref<ShardState>> promise) = 0;
   virtual void store_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice state,
                                            td::Promise<td::Unit> promise) = 0;
+  virtual void store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                               std::function<td::Status(td::FileFd&)> write_data,
+                                               td::Promise<td::Unit> promise) = 0;
   virtual void store_zero_state_file(BlockIdExt block_id, td::BufferSlice state, td::Promise<td::Unit> promise) = 0;
   virtual void wait_block_state(BlockHandle handle, td::uint32 priority, td::Timestamp timeout,
                                 td::Promise<td::Ref<ShardState>> promise) = 0;

--- a/validator/manager-disk.cpp
+++ b/validator/manager-disk.cpp
@@ -680,6 +680,13 @@ void ValidatorManagerImpl::store_persistent_state_file(BlockIdExt block_id, Bloc
                           std::move(promise));
 }
 
+void ValidatorManagerImpl::store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                                           std::function<td::Status(td::FileFd&)> write_data,
+                                                           td::Promise<td::Unit> promise) {
+  td::actor::send_closure(db_, &Db::store_persistent_state_file_gen, block_id, masterchain_block_id,
+                          std::move(write_data), std::move(promise));
+}
+
 void ValidatorManagerImpl::store_zero_state_file(BlockIdExt block_id, td::BufferSlice state,
                                                  td::Promise<td::Unit> promise) {
   td::actor::send_closure(db_, &Db::store_zero_state_file, block_id, std::move(state), std::move(promise));

--- a/validator/manager-disk.hpp
+++ b/validator/manager-disk.hpp
@@ -143,6 +143,9 @@ class ValidatorManagerImpl : public ValidatorManager {
                        td::Promise<td::Ref<ShardState>> promise) override;
   void store_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice state,
                                    td::Promise<td::Unit> promise) override;
+  void store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                       std::function<td::Status(td::FileFd&)> write_data,
+                                       td::Promise<td::Unit> promise) override;
   void store_zero_state_file(BlockIdExt block_id, td::BufferSlice state, td::Promise<td::Unit> promise) override;
   void wait_block_state(BlockHandle handle, td::uint32 priority, td::Timestamp timeout,
                         td::Promise<td::Ref<ShardState>> promise) override;

--- a/validator/manager-hardfork.hpp
+++ b/validator/manager-hardfork.hpp
@@ -169,6 +169,11 @@ class ValidatorManagerImpl : public ValidatorManager {
                                    td::Promise<td::Unit> promise) override {
     UNREACHABLE();
   }
+  void store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                       std::function<td::Status(td::FileFd&)> write_data,
+                                       td::Promise<td::Unit> promise) override {
+    UNREACHABLE();
+  }
   void store_zero_state_file(BlockIdExt block_id, td::BufferSlice state, td::Promise<td::Unit> promise) override {
     UNREACHABLE();
   }

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -1051,6 +1051,13 @@ void ValidatorManagerImpl::store_persistent_state_file(BlockIdExt block_id, Bloc
                           std::move(promise));
 }
 
+void ValidatorManagerImpl::store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                                           std::function<td::Status(td::FileFd&)> write_data,
+                                                           td::Promise<td::Unit> promise) {
+  td::actor::send_closure(db_, &Db::store_persistent_state_file_gen, block_id, masterchain_block_id,
+                          std::move(write_data), std::move(promise));
+}
+
 void ValidatorManagerImpl::store_zero_state_file(BlockIdExt block_id, td::BufferSlice state,
                                                  td::Promise<td::Unit> promise) {
   td::actor::send_closure(db_, &Db::store_zero_state_file, block_id, std::move(state), std::move(promise));

--- a/validator/manager.hpp
+++ b/validator/manager.hpp
@@ -347,6 +347,9 @@ class ValidatorManagerImpl : public ValidatorManager {
                        td::Promise<td::Ref<ShardState>> promise) override;
   void store_persistent_state_file(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice state,
                                    td::Promise<td::Unit> promise) override;
+  void store_persistent_state_file_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
+                                       std::function<td::Status(td::FileFd&)> write_data,
+                                       td::Promise<td::Unit> promise) override;
   void store_zero_state_file(BlockIdExt block_id, td::BufferSlice state, td::Promise<td::Unit> promise) override;
   void wait_block_state(BlockHandle handle, td::uint32 priority, td::Timestamp timeout,
                         td::Promise<td::Ref<ShardState>> promise) override;

--- a/validator/state-serializer.cpp
+++ b/validator/state-serializer.cpp
@@ -196,15 +196,16 @@ void AsyncStateSerializer::got_masterchain_state(td::Ref<MasterchainState> state
     shards_.push_back(v->top_block_id());
   }
 
-  auto B = masterchain_state_->serialize();
-  B.ensure();
+  auto write_data = [state = masterchain_state_] (td::FileFd& fd) {
+    return state->serialize_to_file(fd);
+  };
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Unit> R) {
     R.ensure();
     td::actor::send_closure(SelfId, &AsyncStateSerializer::stored_masterchain_state);
   });
 
-  td::actor::send_closure(manager_, &ValidatorManager::store_persistent_state_file, masterchain_handle_->id(),
-                          masterchain_handle_->id(), B.move_as_ok(), std::move(P));
+  td::actor::send_closure(manager_, &ValidatorManager::store_persistent_state_file_gen, masterchain_handle_->id(),
+                          masterchain_handle_->id(), write_data, std::move(P));
 }
 
 void AsyncStateSerializer::stored_masterchain_state() {
@@ -225,13 +226,15 @@ void AsyncStateSerializer::got_shard_handle(BlockHandle handle) {
 }
 
 void AsyncStateSerializer::got_shard_state(BlockHandle handle, td::Ref<ShardState> state) {
-  auto B = state->serialize().move_as_ok();
+  auto write_data = [state] (td::FileFd& fd) {
+    return state->serialize_to_file(fd);
+  };
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Unit> R) {
     R.ensure();
     td::actor::send_closure(SelfId, &AsyncStateSerializer::success_handler);
   });
-  td::actor::send_closure(manager_, &ValidatorManager::store_persistent_state_file, handle->id(),
-                          masterchain_handle_->id(), std::move(B), std::move(P));
+  td::actor::send_closure(manager_, &ValidatorManager::store_persistent_state_file_gen, handle->id(),
+                          masterchain_handle_->id(), write_data, std::move(P));
   LOG(INFO) << "storing persistent state for " << masterchain_handle_->id().seqno() << ":" << handle->id().id.shard;
   next_idx_++;
 }


### PR DESCRIPTION
This reduces peak memory consumption during serialization of persistent state (by ~2GB).
Tested by serializing some shard state using the old and the new serializer and comparing files.