### PR TITLE
FunC #include: Use `td::realpath` and add re-inclusion tests

### DIFF
--- a/crypto/func/parse-func.cpp
+++ b/crypto/func/parse-func.cpp
@@ -23,7 +23,7 @@
 #include "block/block.h"
 #include "block-parse.h"
 #include <fstream>
-#include <climits>
+#include "td/utils/port/path.h"
 
 namespace sym {
 
@@ -1657,9 +1657,7 @@ bool parse_source_file(const char* filename, src::Lexem lex) {
       throw src::Fatal{msg};
     }
   }
-  char realpath_buf[PATH_MAX] = {0, };
-  realpath(filename, realpath_buf);
-  std::string real_filename = std::string{realpath_buf};
+  std::string real_filename = td::realpath(td::CSlice(filename)).move_as_ok();
   if (std::count(source_files.begin(), source_files.end(), real_filename)) {
     if (verbosity >= 2) {
       if (lex.tp) {

--- a/crypto/func/test/i1.fc
+++ b/crypto/func/test/i1.fc
@@ -12,3 +12,5 @@ global int i;
   sub2();
   i = 9;
 }
+
+#include "../test/i1sub2.fc";

--- a/crypto/func/test/i1sub1.fc
+++ b/crypto/func/test/i1sub1.fc
@@ -1,6 +1,8 @@
 ;; DO NOT COMPILE DIRECTLY!
 ;; Compile i1.fc
 
+#include "i1sub1.fc";
+
 () sub1() impure {
   i = 1;
 }

--- a/crypto/func/test/i1sub2.fc
+++ b/crypto/func/test/i1sub2.fc
@@ -1,6 +1,8 @@
 ;; DO NOT COMPILE DIRECTLY!
 ;; Compile i1.fc
 
+#include "./i1sub1.fc";
+
 () sub2() impure {
   sub1();
   sub0();


### PR DESCRIPTION
May fix build error on Windows and more tests checking re-inclusion were added.