### PR TITLE
add m1 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,8 @@ set(TON_ARCH "native" CACHE STRING "Architecture, will be passed to -march=")
 #BEGIN M1 support
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 
-if (ARCHITECTURE MATCHES "arm64")
+if ((ARCHITECTURE MATCHES "arm64") AND (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
     set(TON_ARCH "apple-m1")
-    set(CMAKE_CXX_STANDARD 14)
 endif()
 #END M1 support
 
@@ -213,7 +212,11 @@ find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 
 if (TON_ARCH AND NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")
+  if (TON_ARCH STREQUAL "apple-m1")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")	
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${TON_ARCH}")
+  endif()
 endif()
 if (THREADS_HAVE_PTHREAD_ARG)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
@@ -576,4 +579,3 @@ add_test(test-tddb test-tddb ${TEST_OPTIONS})
 add_test(test-db test-db ${TEST_OPTIONS})
 endif()
 #END internal
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,15 @@ option(TON_USE_TSAN "Use \"ON\" to enable ThreadSanitizer." OFF)
 option(TON_USE_UBSAN "Use \"ON\" to enable UndefinedBehaviorSanitizer." OFF)
 set(TON_ARCH "native" CACHE STRING "Architecture, will be passed to -march=")
 
+#BEGIN M1 support
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+
+if (ARCHITECTURE MATCHES "arm64")
+    set(TON_ARCH "apple-m1")
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+#END M1 support
+
 if (TON_USE_ABSEIL)
   message("Add abseil-cpp")
   add_subdirectory(third-party/abseil-cpp EXCLUDE_FROM_ALL)
@@ -204,7 +213,7 @@ find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 
 if (TON_ARCH AND NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${TON_ARCH}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")
 endif()
 if (THREADS_HAVE_PTHREAD_ARG)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")


### PR DESCRIPTION
Tested on Apple M1 Max
```
$ make -j 10          
                                                                                                                                                                    
[  0%] Built target crc32c_sse42
[  0%] Built target crc32c_arm64
[  0%] Checking the git repository for changes...
[  0%] Built target absl_dynamic_annotations
[  0%] Built target absl_log_severity
[  1%] Built target absl_exponential_biased
[  1%] Built target absl_spinlock_wait
[  2%] Built target absl_int128
[  4%] Built target absl_civil_time
[  4%] Built target absl_time_zone
[  4%] Built target absl_city
[  4%] Built target absl_raw_logging_internal
[  5%] Built target tdtl
[  5%] Built target crc32c
[  5%] Built target absl_debugging_internal
[  5%] Built target absl_strings_internal
[  5%] Built target absl_bad_optional_access
[  5%] Built target absl_throw_delegate
[  5%] Built target tonlib_generate_java_api
[  5%] Built target absl_bad_variant_access
[  5%] Built target absl_base
[  5%] Built target absl_stacktrace
[  5%] Built target absl_demangle_internal
[  5%] Built target absl_malloc_internal
[  6%] Built target absl_strings
[  6%] Built target absl_graphcycles_internal
[  8%] Built target absl_symbolize
[  8%] Built target absl_hash
[  9%] Built target absl_time
[  9%] Built target check_git
[  9%] Built target absl_synchronization
[  9%] Built target git
[  9%] Built target absl_hashtablez_sampler
[  9%] Built target absl_raw_hash_set
[ 15%] Built target tdutils
[ 15%] Built target memprof
[ 16%] Built target tdactor
[ 16%] Built target generate_common
[ 17%] Built target tdfec
[ 17%] Built target tl_generate_common
[ 17%] Built target benchmark
[ 17%] Built target tdnet
[ 17%] Built target terminal
[ 19%] Built target test-tdactor
[ 20%] Built target tddb_utils
[ 20%] Built target benchmark-fec
[ 20%] Built target test-fec
[ 20%] Built target tl_api
[ 23%] Built target test-tdutils
[ 24%] Built target tl_tonlib_api
[ 24%] Built target tl_lite_api
[ 24%] Built target tcp_ping_pong
[ 24%] Built target udp_ping_pong
[ 24%] Built target test-net
[ 24%] Built target fec
[ 24%] Built target tl_tonlib_api_json
[ 28%] Built target ton_crypto
[ 28%] Built target test-cells
[ 28%] Built target common
[ 30%] Built target test-bigint
[ 30%] Built target test-hello-world
[ 30%] Built target test-ed25519
[ 30%] Built target src_parser
[ 30%] Built target tl-utils
[ 30%] Built target tl-lite-utils
[ 31%] Built target tonhttp
[ 32%] Built target test-ed25519-crypto
[ 32%] Built target tlbc
[ 32%] Built target keyring
[ 32%] Built target keys
[ 32%] Built target test-http
[ 32%] Built target adnl-proxy
[ 32%] Built target http-proxy
[ 32%] Built target tlb_generate_block
[ 63%] Built target rocksdb
[ 63%] Built target json2tlo
[ 63%] Built target adnllite
[ 63%] Built target tddb
[ 64%] Built target ton_block
[ 64%] Built target io-bench
[ 64%] Built target test-rocksdb
[ 64%] Built target ton_db
[ 64%] Built target test-tddb
[ 64%] Built target lite-client-common
[ 64%] Built target pow-miner-lib
[ 65%] Built target storage
[ 65%] Built target blockchain-explorer
[ 68%] Built target adnl
[ 69%] Built target validator-engine-console
[ 71%] Built target func
[ 71%] Built target test-db
[ 72%] Built target lite-client
[ 72%] Built target fift-lib
[ 72%] Built target pow-miner
[ 73%] Built target adnltest
[ 73%] Built target rldp
[ 75%] Built target generate-random-id
[ 75%] Built target dht
[ 75%] Built target fift
[ 76%] Built target rldp2
[ 76%] Built target adjust-block
[ 76%] Built target test-vm
[ 76%] Built target test-fift
[ 78%] Built target dump-block
[ 79%] Built target test-weight-distr
[ 79%] Built target test-dht
[ 80%] Built target test-rldp
[ 80%] Built target test-adnl
[ 80%] Built target gen_fif_smartcont_auto_config_code
[ 80%] Built target gen_fif_smartcont_auto_wallet_code
[ 80%] Built target gen_fif_smartcont_auto_simple_wallet_ext_code
[ 80%] Built target adnl-pong
[ 80%] Built target dht-server
[ 80%] Built target overlay
[ 80%] Built target gen_fif_smartcont_auto_wallet3_code
[ 80%] Built target gen_fif_smartcont_auto_highload_wallet_code
[ 80%] Built target gen_fif_smartcont_auto_highload_wallet_v2_code
[ 80%] Built target gen_fif_smartcont_auto_simple_wallet_code
[ 80%] Built target gen_fif_smartcont_auto_elector_code
[ 80%] Built target gen_fif_smartcont_auto_restricted_wallet_code
[ 80%] Built target gen_fif_smartcont_auto_restricted_wallet3_code
[ 80%] Built target gen_fif_smartcont_auto_multisig_code
[ 82%] Built target gen_fif_smartcont_auto_restricted_wallet2_code
[ 82%] Built target gen_fif_smartcont_auto_pow_testgiver_code
[ 82%] Built target gen_fif_smartcont_auto_dns_auto_code
[ 83%] Built target gen_fif_smartcont_auto_dns_manual_code
[ 83%] Built target gen_fif_smartcont_auto_payment_channel_code
[ 83%] Built target test-storage
[ 83%] Built target test-rldp2
[ 84%] Built target catchain
[ 84%] Built target gen_fif
[ 84%] Built target test-catchain
[ 86%] Built target validatorsession
[ 87%] Built target smc-envelope
[ 87%] Built target test-validator-session-state
[ 87%] Built target test-smartcont
[ 87%] Built target full-node
[ 89%] Built target ton_validator
[ 91%] Built target validator-hardfork
[ 91%] Built target validator-disk
[ 93%] Built target tonlib
[ 95%] Built target validator
[ 95%] Built target create-hardfork
[ 95%] Built target tonlibjson_private
[ 97%] Built target create-state
[ 97%] Built target tonlib-cli
[ 97%] Built target test-ton-collator
[ 97%] Built target validator-engine
[ 97%] Built target test-tonlib-offline
[ 97%] Built target rldp-http-proxy
[ 97%] Built target storage-cli
[ 97%] Built target test-tonlib
[ 97%] Built target tonlibjson_static
[100%] Built target pack-viewer
[100%] Built target tonlibjson
```