### PR TITLE
New github action. Emscripten WebAssembly. fift.js and func.js

### DIFF
--- a/.github/scripts/em.patch
+++ b/.github/scripts/em.patch
@@ -1,0 +1,110 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9f17a4..c60bac9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,7 +80,7 @@ else()
+ endif()
+ 
+ #BEGIN internal
+-option(TON_ONLY_TONLIB "Use \"ON\" to build only tonlib." OFF)
++option(TON_ONLY_TONLIB "Use \"ON\" to build only tonlib." ON)
+ if (TON_ONLY_TONLIB)
+   set(NOT_TON_ONLY_TONLIB false)
+ else()
+@@ -257,10 +257,10 @@ elseif (CLANG OR GCC)
+     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fvisibility=hidden -Wl,-dead_strip,-x,-S")
+   else()
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections")
+-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL")
++    #set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL")
+     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+     if (NOT TON_USE_ASAN AND NOT TON_USE_TSAN AND NOT MEMPROF)
+-      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
++      #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
+     endif()
+   endif()
+ elseif (INTEL)
+diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
+index 76c8ae9..a6d1a05 100644
+--- a/crypto/CMakeLists.txt
++++ b/crypto/CMakeLists.txt
+@@ -335,12 +335,12 @@ if (TON_USE_ASAN AND NOT WIN32)
+ endif()
+ 
+ file(MAKE_DIRECTORY smartcont/auto)
+-if (NOT CMAKE_CROSSCOMPILING)
++#if (NOT CMAKE_CROSSCOMPILING)
+   set(GENERATE_TLB_CMD tlbc)
+   add_custom_command(
+     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/block
+     COMMAND ${TURN_OFF_LSAN}
+-    COMMAND ${GENERATE_TLB_CMD} -o block-auto -n block::gen -z block.tlb
++#    COMMAND ${GENERATE_TLB_CMD} -o block-auto -n block::gen -z block.tlb
+     COMMENT "Generate block tlb source files"
+     OUTPUT ${TLB_BLOCK_AUTO}
+     DEPENDS tlbc block/block.tlb
+@@ -397,7 +397,7 @@ if (NOT CMAKE_CROSSCOMPILING)
+   GenFif(DEST smartcont/auto/payment-channel-code SOURCE smartcont/payment-channel-code.fc NAME payment-channel)
+ 
+   GenFif(DEST smartcont/auto/simple-wallet-ext-code SOURCE smartcont/simple-wallet-ext-code.fc NAME simple-wallet-ext)
+-endif()
++#endif()
+ 
+ add_library(smc-envelope ${SMC_ENVELOPE_SOURCE})
+ target_include_directories(smc-envelope PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+diff --git a/tdutils/td/utils/port/config.h b/tdutils/td/utils/port/config.h
+index 2bd671b..956a28a 100644
+--- a/tdutils/td/utils/port/config.h
++++ b/tdutils/td/utils/port/config.h
+@@ -39,7 +39,7 @@
+   #define TD_EVENTFD_BSD 1
+ #elif TD_EMSCRIPTEN
+   #define TD_POLL_POLL 1
+-  #define TD_EVENTFD_UNSUPPORTED 1
++//  #define TD_EVENTFD_UNSUPPORTED 1
+ #elif TD_DARWIN
+   #define TD_POLL_KQUEUE 1
+   #define TD_EVENTFD_BSD 1
+@@ -51,7 +51,11 @@
+ #endif
+ 
+ #if TD_EMSCRIPTEN
+-  #define TD_THREAD_UNSUPPORTED 1
++//  #define TD_THREAD_UNSUPPORTED 1
++  #define TD_POLL_EPOLL 1
++  #define TD_EVENTFD_UNSUPPORTED 0
++  #define TD_THREAD_PTHREAD 1
++  #define TD_EVENTFD_LINUX 1
+ #elif TD_TIZEN || TD_LINUX || TD_DARWIN
+   #define TD_THREAD_PTHREAD 1
+ #else
+diff --git a/tonlib/CMakeLists.txt b/tonlib/CMakeLists.txt
+index 5b6530a..568cc69 100644
+--- a/tonlib/CMakeLists.txt
++++ b/tonlib/CMakeLists.txt
+@@ -88,7 +88,7 @@ set(TONLIB_JSON_SOURCE tonlib/tonlib_client_json.cpp)
+ 
+ include(GenerateExportHeader)
+ 
+-add_library(tonlibjson SHARED ${TONLIB_JSON_SOURCE} ${TONLIB_JSON_HEADERS})
++add_library(tonlibjson STATIC ${TONLIB_JSON_SOURCE} ${TONLIB_JSON_HEADERS})
+ target_link_libraries(tonlibjson PRIVATE tonlibjson_private)
+ generate_export_header(tonlibjson EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/tonlib/tonlibjson_export.h)
+ target_include_directories(tonlibjson PUBLIC
+@@ -149,11 +149,11 @@ endif()
+ 
+ install(FILES ${TONLIB_JSON_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/tonlib/tonlibjson_export.h DESTINATION include/tonlib/)
+ 
+-install(EXPORT Tonlib
+-  FILE TonlibTargets.cmake
+-  NAMESPACE Tonlib::
+-  DESTINATION lib/cmake/Tonlib
+-)
++#install(EXPORT Tonlib
++#  FILE TonlibTargets.cmake
++#  NAMESPACE Tonlib::
++#  DESTINATION lib/cmake/Tonlib
++#)
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file("TonlibConfigVersion.cmake"
+   VERSION ${TON_VERSION}

--- a/.github/scripts/fift-func-wasm-build-ubuntu.sh
+++ b/.github/scripts/fift-func-wasm-build-ubuntu.sh
@@ -1,0 +1,95 @@
+#sudo apt-get install -y build-essential git make cmake clang libgflags-dev zlib1g-dev libssl-dev libreadline-dev libmicrohttpd-dev pkg-config libgsl-dev python3 python3-dev python3-pip nodejs
+
+export CC=$(which clang)
+export CXX=$(which clang++)
+export CCACHE_DISABLE=1
+
+git clone https://github.com/openssl/openssl.git
+cd openssl
+git checkout OpenSSL_1_1_1j
+
+./config
+make -j2
+
+OPENSSL_DIR=`pwd`
+
+cd ..
+
+git clone https://github.com/madler/zlib.git
+cd zlib
+ZLIB_DIR=`pwd`
+
+cd ..
+
+# only to generate auto-block.cpp
+git clone --recursive https://github.com/ton-blockchain/ton.git
+cd ton
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so -DZLIB_INCLUDE_DIR=$ZLIB_DIR -DOPENSSL_ROOT_DIR=$OPENSSL_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_DIR/libcrypto.so -DOPENSSL_SSL_LIBRARY=$OPENSSL_DIR/libssl.so ..
+make -j2 fift
+
+rm -rf *
+
+cd ../..
+
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install latest
+./emsdk activate latest
+EMSDK_DIR=`pwd`
+
+source $EMSDK_DIR/emsdk_env.sh
+export CC=$(which emcc)
+export CXX=$(which em++)
+export CCACHE_DISABLE=1
+
+cd ../zlib
+
+emconfigure ./configure --static
+emmake make -j2
+ZLIB_DIR=`pwd`
+
+cd ../openssl
+
+make clean
+emconfigure ./Configure linux-generic32 no-shared no-dso no-engine no-unit-test no-ui
+sed -i 's/CROSS_COMPILE=.*/CROSS_COMPILE=/g' Makefile
+sed -i 's/-ldl//g' Makefile
+sed -i 's/-O3/-Os/g' Makefile
+emmake make depend
+emmake make -j2
+
+cd ../ton
+git apply ../em.patch
+cd build
+
+emcmake cmake -DCMAKE_BUILD_TYPE=Release -DZLIB_LIBRARY=$ZLIB_DIR/libz.a -DZLIB_INCLUDE_DIR=$ZLIB_DIR -DOPENSSL_ROOT_DIR=$OPENSSL_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_DIR/libcrypto.a -DOPENSSL_SSL_LIBRARY=$OPENSSL_DIR/libssl.a -DCMAKE_TOOLCHAIN_FILE=$EMSDK_DIR/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_CXX_FLAGS="-pthread -sUSE_ZLIB=1" ..
+
+truncate -s -1 crypto/CMakeFiles/fift.dir/link.txt
+echo " --preload-file smartcont --preload-file lib -sASSERTIONS -g -sNO_DISABLE_EXCEPTION_CATCHING" >> crypto/CMakeFiles/fift.dir/link.txt
+
+truncate -s -1 crypto/CMakeFiles/func.dir/link.txt
+echo " --preload-file smartcont --preload-file lib -sASSERTIONS -g -sNO_DISABLE_EXCEPTION_CATCHING" >> crypto/CMakeFiles/func.dir/link.txt
+
+cp -R ../crypto/smartcont ../crypto/fift/lib crypto
+
+emmake make -j2 fift func
+
+cat <<examples
+
+// create standard new-wallet located in wasm's virtual file system
+node --experimental-wasm-threads fift.js -Ilib -s smartcont/new-wallet.fif 0 new-wallet
+
+// execute custom Fift script located outside wasm's virtual file system
+node --experimental-wasm-threads fift.js -Ilib -i < ~/new-wallet-test.fif 0 new-wallet
+
+Notice: Fift in interactive mode does not support arguments, please adjust your script accordingly.
+
+// convert FunC code into Fift assemler taking file from wasm's virtual file system
+node --experimental-wasm-threads func.js -SPA smartcont/stdlib.fc smartcont/simple-wallet-code.fc
+
+// convert FunC code into Fift assemler taking file from external location
+node --experimental-wasm-threads func.js -I -SPA smartcont/stdlib.fc < ~/simple-wallet-code.fc
+
+examples

--- a/.github/workflows/wasm-compile.yaml
+++ b/.github/workflows/wasm-compile.yaml
@@ -1,0 +1,30 @@
+name: Wasm Compile
+
+on: [push,workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Execute fift-func-wasm-build-ubuntu.sh
+        run: |
+          mkdir wasm-build
+          cp .github/scripts/* wasm-build
+          cd wasm-build
+          chmod +x fift-func-wasm-build-ubuntu.sh 
+          ./fift-func-wasm-build-ubuntu.sh
+
+      - name: Find & copy binaries
+        run: |
+          cd /home/runner/work/ton/ton/wasm-build
+          mkdir artifacts
+          cp ton/build/crypto/fift.* ton/build/crypto/func.* artifacts
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: fift-func-wasm-binaries
+          path: wasm-build/artifacts


### PR DESCRIPTION
WASM versions of fift and func utilities. Compiled with Emscripten.

Due to security reasons wasm restricts access to a file system, however Emscripten has a feature, where one can pack any files into wasm assembly.
These both assemblies include crypto/lib and crypto/smartcont folders, that allows to run standard scripts out of the box.
Thanks to interactive mode that is supported by fift and func, one can also supply any external script or contract via argument.

Usage examples:
// create standard new-wallet located in wasm's virtual file system
node --experimental-wasm-threads fift.js -Ilib -s smartcont/new-wallet.fif 0 new-wallet

// execute custom Fift script located outside wasm's virtual file system
node --experimental-wasm-threads fift.js -Ilib -i < ~/new-wallet-test.fif 0 new-wallet

Notice: Fift in interactive mode does not support arguments, please adjust your script accordingly.

// convert FunC code into Fift assemler taking file from wasm's virtual file system
node --experimental-wasm-threads func.js -SPA smartcont/stdlib.fc smartcont/simple-wallet-code.fc

// convert FunC code into Fift assemler taking file from external location
node --experimental-wasm-threads func.js -I -SPA smartcont/stdlib.fc < ~/simple-wallet-code.fc