### PR TITLE
Add ~strdump and STRDUMP TVM OP

### DIFF
--- a/crypto/func/builtins.cpp
+++ b/crypto/func/builtins.cpp
@@ -1063,6 +1063,8 @@ void define_builtins() {
                       AsmOp::Nop());
   define_builtin_func("~dump", TypeExpr::new_forall({X}, TypeExpr::new_map(X, TypeExpr::new_tensor({X, Unit}))),
                       AsmOp::Custom("s0 DUMP", 1, 1), true);
+  define_builtin_func("~strdump", TypeExpr::new_forall({X}, TypeExpr::new_map(X, TypeExpr::new_tensor({X, Unit}))),
+                      AsmOp::Custom("STRDUMP", 1, 1), true);
   define_builtin_func("run_method0", TypeExpr::new_map(Int, Unit),
                       [](auto a, auto b, auto c) { return compile_run_method(a, b, c, 0, false); }, true);
   define_builtin_func("run_method1", TypeExpr::new_forall({X}, TypeExpr::new_map(TypeExpr::new_tensor({Int, X}), Unit)),

--- a/crypto/vm/debugops.cpp
+++ b/crypto/vm/debugops.cpp
@@ -105,6 +105,37 @@ int exec_dump_value(VmState* st, unsigned arg) {
   return 0;
 }
 
+int exec_dump_string(VmState* st) {
+  VM_LOG(st) << "execute STRDUMP";
+  if (!vm_debug_enabled) {
+    return 0;
+  }
+
+  Stack& stack = st->get_stack();
+  auto item = stack[0];
+
+  if (item.is(4)) {  // wanted t_slice
+    auto cs = item.as_slice();
+    auto size = cs->size();
+
+    if (size % 8 == 0) {
+      auto cnt = size / 8;
+
+      unsigned char tmp[128];
+      cs.write().fetch_bytes(tmp, cnt);
+      std::string s{tmp, tmp + cnt};
+
+      std::cerr << "#DEBUG#: " << s;
+      std::cerr << std::endl;
+    } else {
+      std::cerr << "#DEBUG#: slice contains not valid bits count";
+    }
+  } else {
+    std::cerr << "#DEBUG#: is not a slice" << std::endl;
+  }
+  return 0;
+}
+
 void register_debug_ops(OpcodeTable& cp0) {
   using namespace std::placeholders;
   if (!vm_debug_enabled) {
@@ -113,7 +144,9 @@ void register_debug_ops(OpcodeTable& cp0) {
   } else {
     // NB: all non-redefined opcodes in fe00..feff should be redirected to dummy debug definitions
     cp0.insert(OpcodeInstr::mksimple(0xfe00, 16, "DUMPSTK", exec_dump_stack))
-        .insert(OpcodeInstr::mkfixedrange(0xfe01, 0xfe20, 16, 8, instr::dump_1c_and(0xff, "DEBUG "), exec_dummy_debug))
+        .insert(OpcodeInstr::mkfixedrange(0xfe01, 0xfe13, 16, 8, instr::dump_1c_and(0xff, "DEBUG "), exec_dummy_debug))
+        .insert(OpcodeInstr::mksimple(0xfe14, 16,"STRDUMP", exec_dump_string))
+        .insert(OpcodeInstr::mkfixedrange(0xfe15, 0xfe20, 16, 8, instr::dump_1c_and(0xff, "DEBUG "), exec_dummy_debug))
         .insert(OpcodeInstr::mkfixed(0xfe2, 12, 4, instr::dump_1sr("DUMP"), exec_dump_value))
         .insert(OpcodeInstr::mkfixedrange(0xfe30, 0xfef0, 16, 8, instr::dump_1c_and(0xff, "DEBUG "), exec_dummy_debug))
         .insert(OpcodeInstr::mkext(0xfef, 12, 4, dump_dummy_debug_str, exec_dummy_debug_str, compute_len_debug_str));


### PR DESCRIPTION
Now you can do: 

![latest-screenshot](https://user-images.githubusercontent.com/19264196/188720442-f4b84f86-b3b6-466b-9924-20881f1be8c1.png)

I've added realization of `FE14 — STRDUMP, dumps the Slice at s0 as an UTF-8 string.`