### PR TITLE
Fix dump of items

### DIFF
--- a/crypto/vm/stack.cpp
+++ b/crypto/vm/stack.cpp
@@ -90,15 +90,27 @@ void StackEntry::dump(std::ostream& os) const {
       os << dec_string(as_int());
       break;
     case t_cell:
-      os << "C{" << static_cast<Ref<Cell>>(ref)->get_hash().to_hex() << "}";
+      if (ref.not_null()) {
+        os << "C{" << static_cast<Ref<Cell>>(ref)->get_hash().to_hex() << "}";
+      } else {
+        os << "C{null}";
+      }
       break;
     case t_builder:
-      os << "BC{" << static_cast<Ref<CellBuilder>>(ref)->to_hex() << "}";
+      if (ref.not_null()) {
+        os << "BC{" << static_cast<Ref<CellBuilder>>(ref)->to_hex() << "}";
+      } else {
+        os << "BC{null}";
+      }
       break;
     case t_slice: {
-      os << "CS{";
-      static_cast<Ref<CellSlice>>(ref)->dump(os, 1, false);
-      os << '}';
+      if (ref.not_null()) {
+        os << "CS{";
+        static_cast<Ref<CellSlice>>(ref)->dump(os, 1, false);
+        os << '}';
+      } else {
+        os << "CS{null}";
+      }
       break;
     }
     case t_string:


### PR DESCRIPTION
This may be a controversial commit, but it seems right to me. 
Sometimes it happens that ref variable inside StackEntry is null. 
There's nothing wrong with that, but when you do `.s` inside fift - fift crashes completely. 
Imagine if python could crash on a `print` command :)

Test code:

```
"Asm.fif" include
 
<{ c4 PUSH CTOS 64 LDU }>s
32 // return actions
runvmx
.s
```

Original fift halt with error:

```
[ 0][t 0][2022-09-14 17:17:37.556055917][refcnt.hpp:288]  Check `ptr && "deferencing null Ref"` failed
```

Fixed fift just print:

```
0 9 C{null} 
```

In `toncli run_transaction` if you run TVM on transaction with stack dump it can halt in random moment :(