### PR TITLE
Fix pretty print json (remove unnecessary line breaks)

### DIFF
--- a/tdutils/td/utils/JsonBuilder.h
+++ b/tdutils/td/utils/JsonBuilder.h
@@ -363,7 +363,6 @@ class JsonArrayScope : public JsonScope {
   void leave() {
     jb_->dec_offset();
     if (jb_->is_pretty()) {
-      *sb_ << "\n";
       jb_->print_offset();
     }
     *sb_ << "]";
@@ -385,7 +384,6 @@ class JsonArrayScope : public JsonScope {
       is_first_ = true;
     }
     if (jb_->is_pretty()) {
-      *sb_ << "\n";
       jb_->print_offset();
     }
     return jb_->enter_value();
@@ -410,7 +408,6 @@ class JsonObjectScope : public JsonScope {
   void leave() {
     jb_->dec_offset();
     if (jb_->is_pretty()) {
-      *sb_ << "\n";
       jb_->print_offset();
     }
     *sb_ << "}";
@@ -424,7 +421,6 @@ class JsonObjectScope : public JsonScope {
       is_first_ = true;
     }
     if (jb_->is_pretty()) {
-      *sb_ << "\n";
       jb_->print_offset();
     }
     jb_->enter_value() << key;


### PR DESCRIPTION
Before:

<img width="765" alt="image" src="https://user-images.githubusercontent.com/97797573/199123106-4b26b2df-4202-496e-8e7b-d63375c88905.png">

After:

<img width="732" alt="image" src="https://user-images.githubusercontent.com/97797573/199123412-2ae4ab03-5c94-4a7d-96b4-9c4683536087.png">
