### PR TITLE
Fix truncating JsonString

### DIFF
--- a/tl/tl/tl_json.h
+++ b/tl/tl/tl_json.h
@@ -53,7 +53,8 @@ struct JsonBytes {
 };
 
 inline void to_json(JsonValueScope &jv, const JsonBytes json_bytes) {
-  jv << JsonString(PSLICE() << base64_encode(json_bytes.bytes));
+  auto base64 = base64_encode(json_bytes.bytes);
+  jv << JsonString(base64);
 }
 template <class T>
 struct JsonVectorBytesImpl {


### PR DESCRIPTION
Removing usage of `PSLICE()` because `td::Logger` has `BUFFER_SIZE = 128 * 1024`. It leads to truncating base64 string.