### PR TITLE
Fix complex funC setglob cases

### DIFF
--- a/crypto/func/func.h
+++ b/crypto/func/func.h
@@ -922,7 +922,7 @@ struct Expr {
   }
   int define_new_vars(CodeBlob& code);
   int predefine_vars();
-  std::vector<var_idx_t> pre_compile(CodeBlob& code, bool lval = false) const;
+  std::vector<var_idx_t> pre_compile(CodeBlob& code, std::vector<std::pair<SymDef*, var_idx_t>>* lval_globs = nullptr) const;
   static std::vector<var_idx_t> pre_compile_let(CodeBlob& code, Expr* lhs, Expr* rhs, const SrcLocation& here);
   var_idx_t new_tmp(CodeBlob& code) const;
   std::vector<var_idx_t> new_tmp_vect(CodeBlob& code) const {

--- a/crypto/func/gen-abscode.cpp
+++ b/crypto/func/gen-abscode.cpp
@@ -221,6 +221,13 @@ var_idx_t Expr::new_tmp(CodeBlob& code) const {
   return code.create_tmp_var(e_type, &here);
 }
 
+void add_set_globs(CodeBlob& code, std::vector<std::pair<SymDef*, var_idx_t>>& globs, const SrcLocation& here) {
+  for (const auto& p : globs) {
+    auto& op = code.emplace_back(here, Op::_SetGlob, std::vector<var_idx_t>{}, std::vector<var_idx_t>{ p.second }, p.first);
+    op.flags |= Op::_Impure;
+  }
+}
+
 std::vector<var_idx_t> Expr::pre_compile_let(CodeBlob& code, Expr* lhs, Expr* rhs, const SrcLocation& here) {
   while (lhs->is_type_apply()) {
     lhs = lhs->args.at(0);
@@ -245,19 +252,15 @@ std::vector<var_idx_t> Expr::pre_compile_let(CodeBlob& code, Expr* lhs, Expr* rh
     return tmp;
   }
   auto right = rhs->pre_compile(code);
-  if (lhs->cls == Expr::_GlobVar) {
-    assert(lhs->sym);
-    auto& op = code.emplace_back(here, Op::_SetGlob, std::vector<var_idx_t>{}, right, lhs->sym);
-    op.flags |= Op::_Impure;
-  } else {
-    auto left = lhs->pre_compile(code, true);
-    code.emplace_back(here, Op::_Let, std::move(left), right);
-  }
+  std::vector<std::pair<SymDef*, var_idx_t>> globs;
+  auto left = lhs->pre_compile(code, &globs);
+  code.emplace_back(here, Op::_Let, std::move(left), right);
+  add_set_globs(code, globs, here);
   return right;
 }
 
-std::vector<var_idx_t> Expr::pre_compile(CodeBlob& code, bool lval) const {
-  if (lval && !(cls == _Tensor || cls == _Var || cls == _Hole || cls == _TypeApply)) {
+std::vector<var_idx_t> Expr::pre_compile(CodeBlob& code, std::vector<std::pair<SymDef*, var_idx_t>>* lval_globs) const {
+  if (lval_globs && !(cls == _Tensor || cls == _Var || cls == _Hole || cls == _TypeApply || cls == _GlobVar)) {
     std::cerr << "lvalue expression constructor is " << cls << std::endl;
     throw src::Fatal{"cannot compile lvalue expression with unknown constructor"};
   }
@@ -265,7 +268,7 @@ std::vector<var_idx_t> Expr::pre_compile(CodeBlob& code, bool lval) const {
     case _Tensor: {
       std::vector<var_idx_t> res;
       for (const auto& x : args) {
-        auto add = x->pre_compile(code, lval);
+        auto add = x->pre_compile(code, lval_globs);
         res.insert(res.end(), add.cbegin(), add.cend());
       }
       return res;
@@ -297,7 +300,7 @@ std::vector<var_idx_t> Expr::pre_compile(CodeBlob& code, bool lval) const {
       return rvect;
     }
     case _TypeApply:
-      return args[0]->pre_compile(code, lval);
+      return args[0]->pre_compile(code, lval_globs);
     case _Var:
     case _Hole:
       return {val};
@@ -329,8 +332,13 @@ std::vector<var_idx_t> Expr::pre_compile(CodeBlob& code, bool lval) const {
     case _Glob:
     case _GlobVar: {
       auto rvect = new_tmp_vect(code);
-      code.emplace_back(here, Op::_GlobVar, rvect, std::vector<var_idx_t>{}, sym);
-      return rvect;
+      if (lval_globs) {
+        lval_globs->push_back({ sym, rvect[0] });
+        return rvect;
+      } else {
+        code.emplace_back(here, Op::_GlobVar, rvect, std::vector<var_idx_t>{}, sym);
+        return rvect;
+      }
     }
     case _Letop: {
       return pre_compile_let(code, args.at(0), args.at(1), here);
@@ -338,9 +346,14 @@ std::vector<var_idx_t> Expr::pre_compile(CodeBlob& code, bool lval) const {
     case _LetFirst: {
       auto rvect = new_tmp_vect(code);
       auto right = args[1]->pre_compile(code);
-      auto left = args[0]->pre_compile(code, true);
+      std::vector<std::pair<SymDef*, var_idx_t>> local_globs;
+      if (!lval_globs) {
+        lval_globs = &local_globs;
+      }
+      auto left = args[0]->pre_compile(code, lval_globs);
       left.push_back(rvect[0]);
       code.emplace_back(here, Op::_Let, std::move(left), std::move(right));
+      add_set_globs(code, local_globs, here);
       return rvect;
     }
     case _MkTuple: {


### PR DESCRIPTION
Currently, funC fails to compile any kind of assignment expression involving global variable assignment that isn't of the form `global_var = rvalue;`. It fails to compile modifying methods on global variables and/or assignments to tensors containing global variables, for example:

```
global cell ctx_dict;

(cell, (slice, int)) ~udict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDELGET" "NULLSWAPIFNOT";

() recv_internal() {
  (slice v, int ok) = ctx_dict~udict_delete_get?(1, 0);
  ~dump(v);
  ~dump(ok);
}
```

Compilation of this file fails with an obscure error:
```
lvalue expression constructor is 9
fatal: cannot compile lvalue expression with unknown constructor
```

This PR aims to fix this.