### PR TITLE
Fix cell declaration

### DIFF
--- a/crypto/block/block.tlb
+++ b/crypto/block/block.tlb
@@ -366,7 +366,7 @@ trans_merge_install$0111 split_info:SplitMergeInfo
 smc_info#076ef1ea actions:uint16 msgs_sent:uint16
   unixtime:uint32 block_lt:uint64 trans_lt:uint64 
   rand_seed:bits256 balance_remaining:CurrencyCollection
-  myself:MsgAddressInt global_config:(Maybe Cell) = SmartContractInfo;
+  myself:MsgAddressInt global_config:(Maybe ^Cell) = SmartContractInfo;
 //
 //
 out_list_empty$_ = OutList 0;


### PR DESCRIPTION
All serializable cells MUST be declared with prefix `^` like this: `foo:^Cell`