### PR TITLE
Make path separator cross-platform in few places

### DIFF
--- a/validator/db/archive-manager.cpp
+++ b/validator/db/archive-manager.cpp
@@ -27,6 +27,12 @@ namespace ton {
 
 namespace validator {
 
+#if defined(WIN32) || defined(_WIN32) || defined __CYGWIN__
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
 std::string PackageId::path() const {
   if (temp) {
     return "/files/packages/";
@@ -906,7 +912,7 @@ void ArchiveManager::start_up() {
   td::WalkPath::run(db_root_ + "/archive/states/", [&](td::CSlice fname, td::WalkPath::Type t) -> void {
     if (t == td::WalkPath::Type::NotDir) {
       LOG(ERROR) << "checking file " << fname;
-      auto pos = fname.rfind('/');
+      auto pos = fname.rfind(PATH_SEPARATOR);
       if (pos != td::Slice::npos) {
         fname.remove_prefix(pos + 1);
       }

--- a/validator/db/archive-manager.cpp
+++ b/validator/db/archive-manager.cpp
@@ -27,12 +27,6 @@ namespace ton {
 
 namespace validator {
 
-#if defined(WIN32) || defined(_WIN32) || defined __CYGWIN__
-#define PATH_SEPARATOR '\\'
-#else
-#define PATH_SEPARATOR '/'
-#endif
-
 std::string PackageId::path() const {
   if (temp) {
     return "/files/packages/";
@@ -912,7 +906,7 @@ void ArchiveManager::start_up() {
   td::WalkPath::run(db_root_ + "/archive/states/", [&](td::CSlice fname, td::WalkPath::Type t) -> void {
     if (t == td::WalkPath::Type::NotDir) {
       LOG(ERROR) << "checking file " << fname;
-      auto pos = fname.rfind(PATH_SEPARATOR);
+      auto pos = fname.rfind(TD_DIR_SLASH);
       if (pos != td::Slice::npos) {
         fname.remove_prefix(pos + 1);
       }

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -51,12 +51,6 @@ namespace ton {
 
 namespace validator {
 
-#if defined(WIN32) || defined(_WIN32) || defined __CYGWIN__
-#define PATH_SEPARATOR '\\'
-#else
-#define PATH_SEPARATOR '/'
-#endif
-
 void ValidatorManagerImpl::validate_block_is_next_proof(BlockIdExt prev_block_id, BlockIdExt next_block_id,
                                                         td::BufferSlice proof, td::Promise<td::Unit> promise) {
   if (!prev_block_id.is_masterchain() || !next_block_id.is_masterchain()) {
@@ -1470,7 +1464,7 @@ void ValidatorManagerImpl::start_up() {
   auto S = td::WalkPath::run(to_import_dir, [&](td::CSlice cfname, td::WalkPath::Type t) -> void {
     auto fname = td::Slice(cfname);
     if (t == td::WalkPath::Type::NotDir) {
-      auto d = fname.rfind(PATH_SEPARATOR);
+      auto d = fname.rfind(TD_DIR_SLASH);
       if (d != td::Slice::npos) {
         fname = fname.substr(d + 1);
       }

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -51,6 +51,12 @@ namespace ton {
 
 namespace validator {
 
+#if defined(WIN32) || defined(_WIN32) || defined __CYGWIN__
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
 void ValidatorManagerImpl::validate_block_is_next_proof(BlockIdExt prev_block_id, BlockIdExt next_block_id,
                                                         td::BufferSlice proof, td::Promise<td::Unit> promise) {
   if (!prev_block_id.is_masterchain() || !next_block_id.is_masterchain()) {
@@ -1464,7 +1470,7 @@ void ValidatorManagerImpl::start_up() {
   auto S = td::WalkPath::run(to_import_dir, [&](td::CSlice cfname, td::WalkPath::Type t) -> void {
     auto fname = td::Slice(cfname);
     if (t == td::WalkPath::Type::NotDir) {
-      auto d = fname.rfind('/');
+      auto d = fname.rfind(PATH_SEPARATOR);
       if (d != td::Slice::npos) {
         fname = fname.substr(d + 1);
       }


### PR DESCRIPTION
This fixes some tonlibjson requests that fail with LITE_SERVER_NOTREADY error if validator-engine runs on Windows.