### PR TITLE
Add modifying version for `skip_dict`

### DIFF
--- a/crypto/smartcont/stdlib.fc
+++ b/crypto/smartcont/stdlib.fc
@@ -337,6 +337,7 @@ cell preload_dict(slice s) asm "PLDDICT";
 
 ;;; Loads a dictionary as [load_dict], but returns only the remainder of the slice.
 slice skip_dict(slice s) asm "SKIPDICT";
+(slice, ()) ~skip_dict(slice s) asm "SKIPDICT";
 
 ;;; Loads (Maybe ^Cell) from `slice` [s].
 ;;; In other words loads 1 bit and if it is true


### PR DESCRIPTION
I tried to skip extra currencies dictionary in the message header like this:

```
cs~skip_dict();
```

but found out that the modifying version is not in the stdlib.

With current stdlib I have to change the above code to this:

```
cs = cs.skip_dict();
```

which doesn't look good alongside other lines working on the slice.