### PR TITLE
Improve get_block_by_seqno / lt / unix time speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,12 @@ target_link_libraries(test-ton-collator overlay tdutils tdactor adnl tl_api dht
 add_executable(test-http test/test-http.cpp)
 target_link_libraries(test-http PRIVATE tonhttp)
 
+include_directories(SYSTEM ./test)
+add_executable(test-get-blocks test/test-get-blocks.cpp)
+target_link_libraries(test-get-blocks PUBLIC overlay tdutils tdactor adnl tl_api dht
+        catchain validatorsession validator-disk ton_validator validator-disk)
+
+
 get_directory_property(HAS_PARENT PARENT_DIRECTORY)
 if (HAS_PARENT)
   set(ALL_TEST_SOURCE

--- a/test/test-get-blocks.cpp
+++ b/test/test-get-blocks.cpp
@@ -6,26 +6,45 @@
 #include "validator/db/archive-manager.hpp"
 
 #include "td/utils/port/signals.h"
-#include "td/utils/Random.h"
-
 #include <memory>
 #include <numeric>
+#include "td/utils/logging.h"
+#include "td/actor/actor.h"
+#include "td/utils/Time.h"
+#include "td/utils/filesystem.h"
+#include "validator/validator.h"
+#include "validator/manager-disk.h"
+#include "ton/ton-types.h"
+#include "td/utils/Slice.h"
+#include "td/utils/common.h"
+#include <utility>
+#include "auto/tl/lite_api.h"
+#include "adnl/utils.hpp"
+#include "auto/tl/ton_api_json.h"
+#include "tuple"
 
 namespace ton {
 
 namespace validator {
-
 class TestEngine : public td::actor::Actor {
  public:
-  TestEngine(td::actor::ActorId<ArchiveManager> archive_manager_, bool is_masterchain_test_, td::uint32 seqno_first_,
-             td::uint32 seqno_last_) {
-    archive_manager = std::move(archive_manager_);
+  TestEngine(bool is_masterchain_test_, td::uint32 seqno_first_, td::uint32 seqno_last_, bool with_index_ = false,
+             bool async_ = false) {
     is_masterchain_test = is_masterchain_test_;
     seqno_first = seqno_first_;
     seqno_last = seqno_last_;
+    with_index = with_index_;
+    async = async_;
   };
 
-  void start_up() override {
+  void run(td::Promise<td::uint32> promise_, const td::actor::ActorId<ArchiveManager> &archive_manager_) {
+    ts = td::Time::now();
+    LOG(WARNING) << "Start test: " << get_name() << " Start from: " << seqno_first << " End at: " << seqno_last
+                 << " Is masterchain: " << is_masterchain_test;
+
+    archive_manager = archive_manager_;
+
+    promise = std::move(promise_);
     AccountIdPrefixFull pfx;
 
     if (is_masterchain_test) {
@@ -35,28 +54,44 @@ class TestEngine : public td::actor::Actor {
     }
 
     const unsigned int to_load = seqno_last - seqno_first;
-    timer = td::Timer();
+
     for (unsigned int i = 0; i < to_load; i++) {
       auto P = td::PromiseCreator::lambda([me = actor_id(this)](td::Result<ConstBlockHandle> R) {
-        CHECK(R.is_ok());
-        td::actor::send_closure(me, &TestEngine::done_part);
+        if (R.is_error()) {
+          LOG(ERROR) << R.move_as_error();
+          return;
+        }
+
+        auto ok = R.move_as_ok();
+        auto seqno = ok.get()->id().seqno();
+        td::actor::send_closure(me, &TestEngine::done_part, seqno);
       });
-      td::actor::send_closure(archive_manager, &ArchiveManager::get_block_by_seqno, pfx, seqno_first + i, std::move(P));
+
+      by_block_ts[seqno_first + i] = td::Time::now();
+
+      td::actor::send_closure(archive_manager, &ArchiveManager::get_block_by_seqno_custom, pfx, seqno_first + i,
+                              std::move(P), with_index, async);
     }
   }
 
-  void done_part() {
-    parts_done_at.push_back(timer.elapsed());
+  void done_part(BlockSeqno s) {
+    auto it = by_block_ts.find(s);
+    if (it == by_block_ts.end()) {
+      throw std::invalid_argument("?");
+    }
+    auto t = it->second;
+    parts_done_at.push_back(td::Time::now() - t);
 
     if (parts_done_at.size() == (seqno_last - seqno_first)) {
-      const auto end_at = timer.elapsed();
+      const auto end_at = td::Time::now() - ts;
       LOG(WARNING) << "Test " << get_name() << " done, results: ";
 
-      auto const count = static_cast<double>(parts_done_at.size());
-      const auto avg = std::accumulate(parts_done_at.begin(), parts_done_at.end(), 0.0) / count;
+      const auto avg =
+          std::accumulate(parts_done_at.begin(), parts_done_at.end(), 0.0) / static_cast<double>(parts_done_at.size());
 
       LOG(WARNING) << "AVG ON 1 request: " << avg;
       LOG(WARNING) << "Done at: " << end_at;
+      promise.set_value(0);
       stop();
     }
   }
@@ -66,33 +101,134 @@ class TestEngine : public td::actor::Actor {
   bool is_masterchain_test;
   td::uint32 seqno_first;
   td::uint32 seqno_last;
-  td::Timer timer;
+  double ts;
+  std::map<BlockSeqno, double> by_block_ts;
   td::vector<double> parts_done_at;
+  td::Promise<td::uint32> promise;
+  bool with_index = false;
+  bool async = false;
+};
+
+class TestEngineVisor : public td::actor::Actor {
+ public:
+  TestEngineVisor(td::unique_ptr<td::vector<td::actor::ActorId<TestEngine>>> tests_) {
+    tests = std::move(tests_);
+  };
+
+  void run(const std::string &db_root, const std::string &global_config) {
+    auto dummy = td::actor::ActorId<ton::validator::RootDb>();
+    archive_manager = td::actor::create_actor<ton::validator::ArchiveManager>("archive", dummy, db_root);
+
+    auto P = td::PromiseCreator::lambda([me = actor_id(this)](td::Result<td::uint32> R) {
+      if (R.is_error()) {
+        LOG(ERROR) << R.move_as_error();
+        return;
+      }
+
+      td::actor::send_closure(me, &TestEngineVisor::done_part, 0);
+    });
+
+    LOG(DEBUG) << "Start tests";
+    td::actor::send_closure(tests->at(current_test), &TestEngine::run, std::move(P), archive_manager.get());
+  }
+
+  void read_complete(td::uint32 a) {
+    auto P = td::PromiseCreator::lambda([me = actor_id(this)](td::Result<td::uint32> R) {
+      if (R.is_error()) {
+        LOG(ERROR) << R.move_as_error();
+        return;
+      }
+
+      td::actor::send_closure(me, &TestEngineVisor::done_part, 0);
+    });
+
+    LOG(DEBUG) << "Start tests";
+    td::actor::send_closure(tests->at(current_test), &TestEngine::run, std::move(P), archive_manager.get());
+  }
+
+  void done_part(td::uint32 a) {
+    if (current_test < tests->size()) {
+      current_test++;
+
+      if (current_test == tests->size()) {
+        std::exit(0);
+      }
+
+      auto P = td::PromiseCreator::lambda([me = actor_id(this)](td::Result<td::uint32> R) {
+        CHECK(R.is_ok());
+        td::actor::send_closure(me, &TestEngineVisor::done_part, 0);
+      });
+      td::actor::send_closure(tests->at(current_test), &TestEngine::run, std::move(P), archive_manager.get());
+    } else {
+      std::exit(0);
+    }
+  }
+
+ private:
+  td::unique_ptr<td::vector<td::actor::ActorId<TestEngine>>> tests;
+  td::uint32 current_test = 0;
+  td::actor::ActorOwn<ton::validator::ArchiveManager> archive_manager;
 };
 
 }  // namespace validator
 }  // namespace ton
-int main() {
+int main(int argc, char *argv[]) {
   SET_VERBOSITY_LEVEL(verbosity_DEBUG);
 
   std::string db_root_;
+  std::string global_config_;
   td::uint32 t;
 
   td::OptionParser p;
   p.set_description("test archive db methods");
-  p.add_option('d', "db", "set database parse", [&](td::Slice arg) { db_root_ = arg.str(); });
-  p.add_option('t', "threads", "set threads", [&](td::Slice arg) { t = td::to_integer<td::uint32>(arg); });
+  p.add_option('d', "db", "set database parse", [&db_root_](td::Slice arg) { db_root_ = arg.str(); });
+  p.add_option('c', "config", "set global config", [&global_config_](td::Slice arg) { global_config_ = arg.str(); });
+  p.add_option('t', "threads", "set threads", [&t](td::Slice arg) { t = td::to_integer<td::uint32>(arg); });
+  p.run(argc, argv).ensure();
 
   td::actor::Scheduler scheduler({t});
+  td::actor::ActorOwn<ton::validator::TestEngineVisor> test_visor;
+  td::vector<td::actor::ActorId<ton::validator::TestEngine>> tests_actors;
+  //  archive_db_ = td::actor::create_actor<ArchiveManager>("archive", actor_id(this), root_path_);
 
-  scheduler.run_in_context([&scheduler, db_root_] {
-    LOG(DEBUG) << "Start testing of get_blocks of archive_db;";
+  scheduler.run_in_context([&] {
+    LOG(DEBUG) << "Start testing of get_blocks of archive_db; DB_ROOT: " << db_root_ << " Threads: " << t;
     auto dummy = td::actor::ActorId<ton::validator::RootDb>();
-    auto archive_db = td::actor::create_actor<ton::validator::ArchiveManager>("archive", dummy, db_root_);
-    archive_db.release();
 
-    LOG(DEBUG) << "Start testing of get_blocks of archive_db;";
-    td::actor::create_actor<ton::validator::TestEngine>("TestEngine #1", archive_db.get(), true, 0, 1000000).release();
+    tests_actors.push_back(td::actor::create_actor<ton::validator::TestEngine>("Dummy test1", true, 2, 10).release());
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Dummy test2", false, 1000, 10000).release());
+
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Pure TestMC #1", true, 3600000, 3610000).release());  // mc
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Pure TestWC #2", false, 3600000, 3610000)
+            .release());  // wc
+
+    // With index
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Index TestMC #1", true, 3600000, 3610000, true)
+            .release());  // mc
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Index TestWC #2", false, 3600000, 3610000, true)
+            .release());  // wc
+
+    // With async
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Async TestMC #1", true, 3600000, 3610000, true, true)
+            .release());  // mc
+    tests_actors.push_back(
+        td::actor::create_actor<ton::validator::TestEngine>("Async TestWC #2", false, 3600000, 3610000, true, true)
+            .release());  // wc
+
+    auto tests_actors_ptr = td::make_unique<td::vector<td::actor::ActorId<ton::validator::TestEngine>>>(tests_actors);
+
+    test_visor = td::actor::create_actor<ton::validator::TestEngineVisor>("tests_visor", std::move(tests_actors_ptr));
+  });
+
+  scheduler.run_in_context([&] {
+    td::actor::send_closure(test_visor.get(), &ton::validator::TestEngineVisor::run, std::move(db_root_),
+                            std::move(global_config_));
   });
 
   scheduler.run();

--- a/test/test-get-blocks.cpp
+++ b/test/test-get-blocks.cpp
@@ -1,0 +1,99 @@
+//
+// Created by Andrey Tvorozhkov (andrey@head-labs.com) on 4/5/23.
+//
+
+#include "td/utils/OptionParser.h"
+#include "validator/db/archive-manager.hpp"
+
+#include "td/utils/port/signals.h"
+#include "td/utils/Random.h"
+
+#include <memory>
+#include <numeric>
+
+namespace ton {
+
+namespace validator {
+
+class TestEngine : public td::actor::Actor {
+ public:
+  TestEngine(td::actor::ActorId<ArchiveManager> archive_manager_, bool is_masterchain_test_, td::uint32 seqno_first_,
+             td::uint32 seqno_last_) {
+    archive_manager = std::move(archive_manager_);
+    is_masterchain_test = is_masterchain_test_;
+    seqno_first = seqno_first_;
+    seqno_last = seqno_last_;
+  };
+
+  void start_up() override {
+    AccountIdPrefixFull pfx;
+
+    if (is_masterchain_test) {
+      pfx = AccountIdPrefixFull{masterchainId, 0};
+    } else {
+      pfx = AccountIdPrefixFull{0, 0};
+    }
+
+    const unsigned int to_load = seqno_last - seqno_first;
+    timer = td::Timer();
+    for (unsigned int i = 0; i < to_load; i++) {
+      auto P = td::PromiseCreator::lambda([me = actor_id(this)](td::Result<ConstBlockHandle> R) {
+        CHECK(R.is_ok());
+        td::actor::send_closure(me, &TestEngine::done_part);
+      });
+      td::actor::send_closure(archive_manager, &ArchiveManager::get_block_by_seqno, pfx, seqno_first + i, std::move(P));
+    }
+  }
+
+  void done_part() {
+    parts_done_at.push_back(timer.elapsed());
+
+    if (parts_done_at.size() == (seqno_last - seqno_first)) {
+      const auto end_at = timer.elapsed();
+      LOG(WARNING) << "Test " << get_name() << " done, results: ";
+
+      auto const count = static_cast<double>(parts_done_at.size());
+      const auto avg = std::accumulate(parts_done_at.begin(), parts_done_at.end(), 0.0) / count;
+
+      LOG(WARNING) << "AVG ON 1 request: " << avg;
+      LOG(WARNING) << "Done at: " << end_at;
+      stop();
+    }
+  }
+
+ private:
+  td::actor::ActorId<ArchiveManager> archive_manager;
+  bool is_masterchain_test;
+  td::uint32 seqno_first;
+  td::uint32 seqno_last;
+  td::Timer timer;
+  td::vector<double> parts_done_at;
+};
+
+}  // namespace validator
+}  // namespace ton
+int main() {
+  SET_VERBOSITY_LEVEL(verbosity_DEBUG);
+
+  std::string db_root_;
+  td::uint32 t;
+
+  td::OptionParser p;
+  p.set_description("test archive db methods");
+  p.add_option('d', "db", "set database parse", [&](td::Slice arg) { db_root_ = arg.str(); });
+  p.add_option('t', "threads", "set threads", [&](td::Slice arg) { t = td::to_integer<td::uint32>(arg); });
+
+  td::actor::Scheduler scheduler({t});
+
+  scheduler.run_in_context([&scheduler, db_root_] {
+    LOG(DEBUG) << "Start testing of get_blocks of archive_db;";
+    auto dummy = td::actor::ActorId<ton::validator::RootDb>();
+    auto archive_db = td::actor::create_actor<ton::validator::ArchiveManager>("archive", dummy, db_root_);
+    archive_db.release();
+
+    LOG(DEBUG) << "Start testing of get_blocks of archive_db;";
+    td::actor::create_actor<ton::validator::TestEngine>("TestEngine #1", archive_db.get(), true, 0, 1000000).release();
+  });
+
+  scheduler.run();
+}

--- a/validator/db/archive-manager.hpp
+++ b/validator/db/archive-manager.hpp
@@ -46,8 +46,7 @@ class ArchiveManager : public td::actor::Actor {
   void add_persistent_state(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::BufferSlice data,
                             td::Promise<td::Unit> promise);
   void add_persistent_state_gen(BlockIdExt block_id, BlockIdExt masterchain_block_id,
-                                std::function<td::Status(td::FileFd&)> write_state,
-                                td::Promise<td::Unit> promise);
+                                std::function<td::Status(td::FileFd &)> write_state, td::Promise<td::Unit> promise);
   void get_zero_state(BlockIdExt block_id, td::Promise<td::BufferSlice> promise);
   void get_persistent_state(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::Promise<td::BufferSlice> promise);
   void get_persistent_state_slice(BlockIdExt block_id, BlockIdExt masterchain_block_id, td::int64 offset,
@@ -63,6 +62,8 @@ class ArchiveManager : public td::actor::Actor {
   /* from LTDB */
   void get_block_by_unix_time(AccountIdPrefixFull account_id, UnixTime ts, td::Promise<ConstBlockHandle> promise);
   void get_block_by_lt(AccountIdPrefixFull account_id, LogicalTime lt, td::Promise<ConstBlockHandle> promise);
+  void get_block_by_seqno_custom(AccountIdPrefixFull account_id, BlockSeqno seqno, td::Promise<ConstBlockHandle> promise,
+                          bool with_index, bool async);
   void get_block_by_seqno(AccountIdPrefixFull account_id, BlockSeqno seqno, td::Promise<ConstBlockHandle> promise);
 
   void get_archive_id(BlockSeqno masterchain_seqno, td::Promise<td::uint64> promise);
@@ -103,6 +104,7 @@ class ArchiveManager : public td::actor::Actor {
 
     std::map<ShardIdFull, Desc> first_blocks;
     td::actor::ActorOwn<ArchiveSlice> file;
+    BlockSeqno min_seqno;  // todo: add min_lt & min_unix
   };
 
   std::map<PackageId, FileDescription> files_;
@@ -134,6 +136,9 @@ class ArchiveManager : public td::actor::Actor {
   FileDescription *get_file_desc_by_lt(ShardIdFull shard, LogicalTime lt, bool key_block);
   FileDescription *get_file_desc_by_unix_time(ShardIdFull shard, UnixTime ts, bool key_block);
   FileDescription *get_file_desc_by_seqno(AccountIdPrefixFull shard, BlockSeqno seqno, bool key_block);
+  FileDescription *get_file_desc_by_seqno_with_index(AccountIdPrefixFull account, BlockSeqno seqno, bool key_block);
+  void get_file_desc_by_seqno_with_index_and_async(AccountIdPrefixFull account, BlockSeqno seqno, bool key_block,
+                                                    td::Promise<ConstBlockHandle> promise);
   FileDescription *get_file_desc_by_lt(AccountIdPrefixFull shard, LogicalTime lt, bool key_block);
   FileDescription *get_file_desc_by_unix_time(AccountIdPrefixFull shard, UnixTime ts, bool key_block);
   FileDescription *get_next_file_desc(FileDescription *f);


### PR DESCRIPTION
This is not for production, but for getting feedback. 

The main problem is that the methods (`get_file_desc_by_seqno` / `get_file_desc_by_unix_time` / `get_file_desc_lt`) combine multithreaded queries into 1 thread, so they also go through the map every time, without using indexes. These methods degrade performance. 

This is my improvement for this problem, currently there is only test file, indexes and async+indexes examples with `get_block_by_seqno`, but if all 'ok', it can be used in all 3 methods.

For test, I've requested blocks by seqno from MC and WC with seqno from 3 600 000 to 3 610 000.

Current realization:

```
[!Pure TestMC #1]	Start test: Pure TestMC #1 Start from: 3600000 End at: 3610000 Is masterchain: true
[!Pure TestMC #1]	Test Pure TestMC #1 done, results:
[!Pure TestMC #1]	AVG: 8.980766
[!Pure TestMC #1]	Done at: 8.997811

[!Pure TestWC #2]	Start test: Pure TestWC #2 Start from: 3600000 End at: 3610000 Is masterchain: false
[!Pure TestWC #2]	Test Pure TestWC #2 done, results:
[!Pure TestWC #2]	AVG: 27.886684
[!Pure TestWC #2]	Done at: 27.905077
```

It can be improved by precalculating min_seqno in each file to skip a lot of `td::map` in `ArchiveManager::load_package`, also there we can add calculation of minimal lt and unix time. If we add this min index and add skipping we got improvements: 

```
[!Index TestMC #1]	Start test: Index TestMC #1 Start from: 3600000 End at: 3610000 Is masterchain: true
[!Index TestMC #1]	Test Index TestMC #1 done, results:
[!Index TestMC #1]	AVG: 4.828474
[!Index TestMC #1]	Done at: 4.846530

[!Index TestWC #2]	Start test: Index TestWC #2 Start from: 3600000 End at: 3610000 Is masterchain: false
[!Index TestWC #2]	Test Index TestWC #2 done, results:
[!Index TestWC #2]	AVG: 8.406131
[!Index TestWC #2]	Done at: 8.427663
```

As you see masterchain requests of 10k blocks works *x2 faster*, while workchain request of 10k blocks speeds up from *27.9* sec to *8.4* sec. But, now we can add async worker to calculate `file_desc` in threads, it'll improve situation:


```
[!Async TestMC #1]	Start test: Async TestMC #1 Start from: 3600000 End at: 3610000 Is masterchain: true
[!Async TestMC #1]	Test Async TestMC #1 done, results:
[!Async TestMC #1]	AVG: 2.749450
[!Async TestMC #1]	Done at: 2.852702

[!Async TestWC #2]	Start test: Async TestWC #2 Start from: 3600000 End at: 3610000 Is masterchain: false
[!Async TestWC #2]	Test Async TestWC #2 done, results:
[!Async TestWC #2]	AVG: 3.310955
[!Async TestWC #2]	Done at: 4.184114
```

*8.9* sec -> *2.8* sec
*27.9* sec -> *4.1* sec

This impact on all get block requests including liteserver, validator, indexers, etc. 

---

I must admit that I'm not excellent at C++ and could have made a mistake, but our dton.io indexer now index old blocks much faster :)

