### PR TITLE
Generate deb and brew packages

### DIFF
--- a/.github/workflows/create-deb-packages.yml
+++ b/.github/workflows/create-deb-packages.yml
@@ -1,0 +1,49 @@
+name: Create deb packages
+
+on: [workflow_dispatch]
+
+permissions: write-all
+
+jobs:
+  create-release:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create deb packages
+        run: |
+          REPO_DIR=$PWD
+          git fetch --all --tags
+          TAG=$(gh release list |  awk '{print $(NF-1)}')
+          echo "latest TAG = $TAG"
+
+          mkdir ../work; cd ../work
+          curl -L https://github.com/ton-blockchain/ton/releases/latest/download/ton-linux-arm64.zip -o ton-linux-arm64.zip
+          curl -L https://github.com/ton-blockchain/ton/releases/latest/download/ton-linux-x86_64.zip -o ton-linux-amd64.zip
+          unzip ton-linux-arm64.zip -d ton-linux-arm64
+          unzip ton-linux-amd64.zip -d ton-linux-amd64
+          rm -rf ton-linux-arm64/lib ton-linux-arm64/smartcont
+          rm -rf ton-linux-amd64/lib ton-linux-amd64/smartcont
+
+          mkdir -p ton-linux-deb-arm64/bin ton-linux-deb-arm64/lib
+          cp ton-linux-arm64/* ton-linux-deb-arm64/bin/
+          mv ton-linux-deb-arm64/bin/libtonlibjson.so.0.5 ton-linux-deb-arm64/lib/
+
+          mkdir -p ton-linux-deb-amd64/bin ton-linux-deb-amd64/lib
+          cp ton-linux-amd64/* ton-linux-deb-amd64/bin/
+          mv ton-linux-deb-amd64/bin/libtonlibjson.so.0.5 ton-linux-deb-amd64/lib/
+
+          mkdir packages-out
+          chmod +x $REPO_DIR/packages/deb.sh
+          $REPO_DIR/packages/deb.sh packages-out $REPO_DIR/packages/deb/ton $PWD/ton-linux-deb-amd64 amd64 ${TAG:1}
+          $REPO_DIR/packages/deb.sh packages-out $REPO_DIR/packages/deb/ton $PWD/ton-linux-deb-arm64 arm64 ${TAG:1}
+          cd packages-out/deb-install
+          dpkg-scanpackages -a amd64 . > Packages
+          dpkg-scanpackages -a arm64 . >> Packages
+          apt-ftparchive release . > Release
+
+          cd $REPO_DIR
+          gh release upload --clobber $TAG ../work/packages-out/deb-install/Packages ../work/packages-out/deb-install/Release ../work/packages-out/deb-install/ton_amd64.deb ../work/packages-out/deb-install/ton_arm64.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-deb-packages.yml
+++ b/.github/workflows/create-deb-packages.yml
@@ -29,11 +29,13 @@ jobs:
           mkdir -p ton-linux-deb-arm64/bin ton-linux-deb-arm64/lib
           cp ton-linux-arm64/* ton-linux-deb-arm64/bin/
           mv ton-linux-deb-arm64/bin/libtonlibjson.so.0.5 ton-linux-deb-arm64/lib/
-
+          chmod 555 ton-linux-deb-arm64/bin/* ton-linux-deb-arm64/lib/*
+          
           mkdir -p ton-linux-deb-amd64/bin ton-linux-deb-amd64/lib
           cp ton-linux-amd64/* ton-linux-deb-amd64/bin/
           mv ton-linux-deb-amd64/bin/libtonlibjson.so.0.5 ton-linux-deb-amd64/lib/
-
+          chmod 555 ton-linux-deb-amd64/bin/* ton-linux-deb-amd64/lib/*
+  
           mkdir packages-out
           chmod +x $REPO_DIR/packages/deb.sh
           $REPO_DIR/packages/deb.sh packages-out $REPO_DIR/packages/deb/ton $PWD/ton-linux-deb-amd64 amd64 ${TAG:1}

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ Usually, the response to your pull request will indicate which section it falls 
 * Thou shall not merge your own PRs, at least one person should review the PR and merge it (4-eyes rule)
 * Thou shall make sure that workflows are cleanly completed for your PR before considering merge
 
-## Workflows responsibility
-If a CI workflow fails not because of your changes but workflow issues, try to fix it yourself or contact one of the persons listed below via Telegram messenger:
+## Installation of TON artifacts
+### deb (apt)
 
-* **C/C++ CI (ccpp-linux.yml)**: TBD
-* **C/C++ CI Win64 Compile (ccpp-win64.yml)**: TBD
+```sh
+sudo bash -c 'echo "deb [trusted=yes] https://github.com/ton-blockchain/ton/releases/latest/download ./" > /etc/apt/sources.list.d/10-ton.list'
+sudo apt update
+sudo apt install ton
+```

--- a/README.md
+++ b/README.md
@@ -60,12 +60,3 @@ Usually, the response to your pull request will indicate which section it falls 
 
 * Thou shall not merge your own PRs, at least one person should review the PR and merge it (4-eyes rule)
 * Thou shall make sure that workflows are cleanly completed for your PR before considering merge
-
-## Installation of TON artifacts
-### deb (apt)
-
-```sh
-sudo bash -c 'echo "deb [trusted=yes] https://github.com/ton-blockchain/ton/releases/latest/download ./" > /etc/apt/sources.list.d/10-ton.list'
-sudo apt update
-sudo apt install ton
-```

--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@ Usually, the response to your pull request will indicate which section it falls 
 
 * Thou shall not merge your own PRs, at least one person should review the PR and merge it (4-eyes rule)
 * Thou shall make sure that workflows are cleanly completed for your PR before considering merge
+
+## Installation of TON artifacts
+### deb (apt)
+
+```sh
+sudo bash -c 'echo "deb [trusted=yes] https://github.com/ton-blockchain/ton/releases/latest/download ./" > /etc/apt/sources.list.d/10-ton.list'
+sudo apt update
+sudo apt install ton
+```

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Main TON monorepo, which includes the code of the node/validator, lite-client, t
 ## The Open Network
 
 __The Open Network (TON)__ is a fast, secure, scalable blockchain focused on handling _millions of transactions per second_ (TPS) with the goal of reaching hundreds of millions of blockchain users.
-- To learn more about different aspects of TON blockchain and its underlying ecosystem check [documentation](ton.org/docs)
-- To run node, validator or lite-server check [Participate section](https://ton.org/docs/participate/nodes/run-node)
-- To develop decentralised apps check [Tutorials](https://ton.org/docs/develop/smart-contracts/), [FunC docs](https://ton.org/docs/develop/func/overview) and [DApp tutorials](https://ton.org/docs/develop/dapps/)
+- To learn more about different aspects of TON blockchain and its underlying ecosystem check [documentation](https://docs.ton.org/)
+- To run node, validator or lite-server check [Participate section](https://docs.ton.org/participate/nodes/node-types)
+- To develop decentralised apps check [Tutorials](https://docs.ton.org/develop/smart-contracts/), [FunC docs](https://docs.ton.org/develop/func/overview) and [DApp tutorials](https://docs.ton.org/develop/getting-started#web-and-dapps-development)
 - To work on TON check [wallets](https://ton.app/wallets), [explorers](https://ton.app/explorers), [DEXes](https://ton.app/dex) and [utilities](https://ton.app/utilities)
-- To interact with TON check [APIs](https://ton.org/docs/develop/dapps/apis/)
+- To interact with TON check [APIs](https://docs.ton.org/develop/dapps/apis)
 
 ## Updates flow:
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ sudo bash -c 'echo "deb [trusted=yes] https://github.com/ton-blockchain/ton/rele
 sudo apt update
 sudo apt install ton
 ```
+
+### brew
+
+```sh
+brew tap ton-blockchain/ton
+brew install ton
+```

--- a/packages/deb.sh
+++ b/packages/deb.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+BUILD_PATH="$1"
+DEB_TEMPLATE_PATH="$2"
+NIX_RESULT_PATH="$3"
+PACKAGE_ARCH="$4"
+PACKAGE_VERSION="$5"
+DEB_BUILD_PATH="$BUILD_PATH"/deb-build/$(basename "$DEB_TEMPLATE_PATH")_"$PACKAGE_ARCH"
+DEB_INSTALL_PATH="$BUILD_PATH"/deb-install
+
+mkdir -p "$DEB_BUILD_PATH" "$DEB_INSTALL_PATH"
+cp -r "$DEB_TEMPLATE_PATH"/* "$DEB_BUILD_PATH"
+sed -i s/ARCH/"$PACKAGE_ARCH"/ "$DEB_BUILD_PATH"/DEBIAN/control
+sed -i s/VERSION/"$PACKAGE_VERSION"/ "$DEB_BUILD_PATH"/DEBIAN/control
+mkdir "$DEB_BUILD_PATH"/usr
+cp -r -L "$NIX_RESULT_PATH"/* "$DEB_BUILD_PATH"/usr
+dpkg-deb --build "$DEB_BUILD_PATH"
+cp "$BUILD_PATH"/deb-build/*.deb "$DEB_INSTALL_PATH"

--- a/packages/deb/ton/DEBIAN/control
+++ b/packages/deb/ton/DEBIAN/control
@@ -1,0 +1,6 @@
+Package: ton
+Version: VERSION
+Architecture: ARCH
+Maintainer: TON Foundation
+Priority: optional
+Description: TON (The Open Network) binary artifacts


### PR DESCRIPTION
Adding two github actions to create deb and brew installation packages. The second action is located in ton-blockchain/homebrew-ton repository. Both actions should be executed after Mac and Linux aarch64/arm64 artifacts are uploaded to the latest release. 
+update documentation links in README.md