### PR TITLE
Add slice_data_equal? to stdlib.fc

### DIFF
--- a/crypto/smartcont/stdlib.fc
+++ b/crypto/smartcont/stdlib.fc
@@ -634,6 +634,7 @@ int get_seed() impure asm "RANDSEED";
 
 ;;; Checks whether the data parts of two slices coinside
 int equal_slice_bits (slice a, slice b) asm "SDEQ";
+int slice_data_equal?(slice a, slice b) asm "SDEQ";
 
 ;;; Concatenates two builders
 builder store_builder(builder to, builder from) asm "STBR";


### PR DESCRIPTION
The stdlib already has the functions `slice_empty?`, `slice_data_empty?` and `slice_refs_empty?` corresponding to "SEMPTY", "SDEMPTY" and "SREMPTY" assembly instructions. 

It's clear that the function name corresponding to assembly instruction 'SDEQ' should be `slice_data_equal?`, not `equal_slice_bits`, in order to maintain consistent naming conventions. Unfortunately, the mistake of calling the function `equal_slice_bits` has already been made, but at least it is possible to add the correct name as well.