### PR TITLE
Fix `advance_ext`

### DIFF
--- a/crypto/vm/cells/CellSlice.cpp
+++ b/crypto/vm/cells/CellSlice.cpp
@@ -264,7 +264,7 @@ bool CellSlice::advance_ext(unsigned bits, unsigned refs) {
 }
 
 bool CellSlice::advance_ext(unsigned bits_refs) {
-  return advance_ext(bits_refs >> 16, bits_refs & 0xffff);
+  return advance_ext(bits_refs & 0xffff, bits_refs >> 16);
 }
 
 // (PRIVATE)


### PR DESCRIPTION
Such TLB:

```
_ a:(## 64) b:^# = A;
_ a:A = T;
```

Will generate:

<hr/>

```
bool skip(vm::CellSlice& cs) const override {
  return cs.advance_ext(0x10040);
}
```

Which has arguments: `bits: bits_refs >> 16` and `refs: bits_refs & 0xffff`

```
bool CellSlice::advance_ext(unsigned bits_refs) {
  return advance_ext(bits_refs >> 16, bits_refs & 0xffff);
}
```

But it'll also generate:

```
bool T::unpack(vm::CellSlice& cs, T::Record& data) const {
  return cs.fetch_subslice_ext_to(0x10040, data.a);
}
```

Which has arguments: `bits: size & 0xffff` and `refs: size >> 16`

```
td::Ref<CellSlice> CellSlice::fetch_subslice_ext(unsigned size) {
  return fetch_subslice(size & 0xffff, size >> 16);
}
```

I've checked all current `block.tlb` scheme and as I understand bagged `skip` methods are not calling in `cpp` code. But `block-auto.cpp` contains invalid `skip` methods for 59 types. This can lead to random skip size of bits & refs for types. 