### PR TITLE
[emulator] Fix emulating on account_none and set account block_lt

### DIFF
--- a/emulator/emulator-extern.cpp
+++ b/emulator/emulator-extern.cpp
@@ -103,6 +103,7 @@ const char *transaction_emulator_emulate_transaction(void *transaction_emulator,
 
   td::Ref<vm::CellSlice> addr_slice;
   auto account_slice = vm::load_cell_slice(shard_account.account);
+  bool account_exists = block::gen::t_Account.get_tag(account_slice) == block::gen::Account::account;
   if (block::gen::t_Account.get_tag(account_slice) == block::gen::Account::account_none) {
     if (msg_tag == block::gen::CommonMsgInfo::ext_in_msg_info) {
       block::gen::CommonMsgInfo::Record_ext_in_msg_info info;
@@ -120,12 +121,14 @@ const char *transaction_emulator_emulate_transaction(void *transaction_emulator,
     } else {
       ERROR_RESPONSE(PSTRING() << "Only ext in and int message are supported");
     }
-  } else {
+  } else if (block::gen::t_Account.get_tag(account_slice) == block::gen::Account::account) {
     block::gen::Account::Record_account account_record;
     if (!tlb::unpack(account_slice, account_record)) {
       ERROR_RESPONSE(PSTRING() << "Can't unpack account cell");
     }
     addr_slice = std::move(account_record.addr);
+  } else {
+    ERROR_RESPONSE(PSTRING() << "Can't parse account cell");
   }
   ton::WorkchainId wc;
   ton::StdSmcAddress addr;
@@ -139,8 +142,16 @@ const char *transaction_emulator_emulate_transaction(void *transaction_emulator,
     now = (unsigned)std::time(nullptr);
   }
   bool is_special = wc == ton::masterchainId && emulator->get_config().is_special_smartcontract(addr);
-  if (!account.unpack(vm::load_cell_slice_ref(shard_account_cell.move_as_ok()), now, is_special)) {
-    ERROR_RESPONSE(PSTRING() << "Can't unpack shard account");
+  if (account_exists) {
+    if (!account.unpack(vm::load_cell_slice_ref(shard_account_cell.move_as_ok()), now, is_special)) {
+      ERROR_RESPONSE(PSTRING() << "Can't unpack shard account");
+    }
+  } else {
+    if (!account.init_new(now)) {
+      ERROR_RESPONSE(PSTRING() << "Can't init new account");
+    }
+    account.last_trans_lt_ = shard_account.last_trans_lt;
+    account.last_trans_hash_ = shard_account.last_trans_hash;
   }
 
   auto result = emulator->emulate_transaction(std::move(account), message_cell, now, 0, block::transaction::Transaction::tr_ord);

--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -42,6 +42,7 @@ td::Result<std::unique_ptr<TransactionEmulator::EmulationResult>> TransactionEmu
     if (!lt) {
       lt = (account.last_trans_lt_ / block::ConfigInfo::get_lt_align() + 1) * block::ConfigInfo::get_lt_align(); // next block after account_.last_trans_lt_
     }
+    account.block_lt = lt - lt % block::ConfigInfo::get_lt_align();
 
     compute_phase_cfg.libraries = std::make_unique<vm::Dictionary>(libraries_);
     compute_phase_cfg.ignore_chksig = ignore_chksig_;


### PR DESCRIPTION
Emulator improvements:
- Fix emulating tx on non-existing account with `prev_trans_lt` and `prev_trans_hash`
- Set `account.block_lt`