### PR TITLE
Add disasm libs

### DIFF
--- a/crypto/fift/lib/Disasm.fif
+++ b/crypto/fift/lib/Disasm.fif
@@ -6,12 +6,12 @@ variable 'disasm
 { 'disasm @ execute } : disasm  // disassemble a slice
 // usage: x{74B0} disasm
 
+variable @vmlibs dictnew @vmlibs !
 variable @dismode  @dismode 0!
 { rot over @ and rot xor swap ! } : andxor!
 { -2 0 @dismode andxor! } : stack-disasm  // output 's1 s4 XCHG'
 { -2 1 @dismode andxor! } : std-disasm    // output 'XCHG s1, s4'
 { -3 2 @dismode andxor! } : show-vm-code
-{ -3 0 @dismode andxor! } : hide-vm-code
 { @dismode @ 1 and 0= } : stack-disasm?
 
 variable @indent  @indent 0!
@@ -56,7 +56,28 @@ variable @contX  variable @contY  variable @cdict
 { atom>$ type } : .atom
 { dup first .atom dup count 1 > { space 0 over count 2- { 1+ 2dup [] type .", " } swap times 1+ [] type } { drop } cond } : std-show-op
 { 0 over count 1- { 1+ 2dup [] type space } swap times drop first .atom } : stk-show-op
-{ @dismode @ 2 and { .indent ."// " @curop @ csr. } if } : .curop?
+
+{
+  @curop @ dup 8 u@
+  dup 0x88 = { // PUSHREF
+    drop ref@ <spec {
+        8 u@+ swap 2 = {
+        256 u@ dup @vmlibs @ 256 udict@ // load lib
+        {
+            ."// LIB: " swap X. cr
+            ref@ <s +indent +indent disasm -indent -indent
+        } { drop } cond
+     } { drop } cond
+    } { drop } cond
+  }
+  { // TODO: other variants of PUSHREF
+    2drop
+  } cond
+} : lib-disasm
+{
+  @dismode @ 2 and { .indent ."// " @curop @ csr. } if
+  lib-disasm
+} : .curop?
 { .curop? .indent @dismode @ 1 and ' std-show-op ' stk-show-op cond cr
 } : show-simple-op
 { dup 4 u@ 9 = { 8 u@+ swap 15 and 3 << s@ } {

--- a/crypto/fift/words.cpp
+++ b/crypto/fift/words.cpp
@@ -1028,13 +1028,19 @@ void interpret_store_end(vm::Stack& stack, bool special) {
   stack.push_cell(std::move(cell));
 }
 
-void interpret_from_cell(vm::Stack& stack) {
+void interpret_from_cell(vm::Stack& stack, bool load_special) {
   auto cell = stack.pop_cell();
-  Ref<vm::CellSlice> cs{true, vm::NoVmOrd(), std::move(cell)};
-  if (!cs->is_valid()) {
-    throw IntError{"deserializing a special cell as ordinary"};
+  bool is_special;
+  td::Ref<vm::CellSlice> cs = td::make_ref<vm::CellSlice>(vm::load_cell_slice_special(cell, is_special));
+  if (!load_special) {
+    if (is_special) {
+      throw IntError{"deserializing a special cell as ordinary"};
+    }
+    stack.push(cs);
+  } else {
+    stack.push(cs);
+    stack.push_bool(is_special);
   }
-  stack.push(cs);
 }
 
 // cs n -- cs' x
@@ -3301,7 +3307,8 @@ void init_words_common(Dictionary& d) {
   d.def_stack_word("hashu ", std::bind(interpret_cell_hash, _1, true));
   d.def_stack_word("hashB ", std::bind(interpret_cell_hash, _1, false));
   // cellslice manipulation (read from cells)
-  d.def_stack_word("<s ", interpret_from_cell);
+  d.def_stack_word("<s ", std::bind(interpret_from_cell, _1, false));
+  d.def_stack_word("<spec ", std::bind(interpret_from_cell, _1, true));
   d.def_stack_word("i@ ", std::bind(interpret_fetch, _1, 1));
   d.def_stack_word("u@ ", std::bind(interpret_fetch, _1, 0));
   d.def_stack_word("i@+ ", std::bind(interpret_fetch, _1, 3));

--- a/crypto/test/fift/disasm-libs.fif
+++ b/crypto/test/fift/disasm-libs.fif
@@ -1,0 +1,21 @@
+"Disasm.fif" include
+"Asm.fif" include
+
+PROGRAM{
+    DECLPROC foo1
+    DECLPROC foo4
+    DECLPROC main
+    foo1 PROC:<{ DUP 137 PUSHINT MUL PAIR }>
+    foo4 PROC:<{ UNPAIR SWAP DIV }>
+    main PROC:<{ 70 PUSHINT DIV }>
+}END>c constant code-1
+
+// add lib cell to vmlibs
+<b code-1 ref, b> <s code-1 hashu @vmlibs @ 256 udict! drop @vmlibs !
+
+<{
+   // add lib in pushref
+   <b 2 8 u, code-1 hashu 256 u, b>spec PUSHREF
+   BLESS
+   EXECUTE
+}>c <s disasm cr


### PR DESCRIPTION
This is not the best way, but it's really helpful. Please notice me, if it's needed in main repo.

The main problem is that a lot of users use `PUSHREF` in mainnet to load libs, and current disassembler not disassemble them. The one way it can be done is follow: check if cell is special, and if it is, and we know such lib - add lib disassemble to code.

Also, I've added `<spec` to load special cells as slices, it might be needed :)

Before: 

```
(592A3699870F04DA0FFDF26D0FF47AD0684F5B48B4FBB144854397FBFD2EA46C) PUSHREF
BLESS
EXECUTE

```

After:

```
// LIB: DA2BB4D0547F78C3B2199F9815274E14BB1F31F737F71B0572039980F5B6F9C4 
    0 SETCP
    19 (xC_) DICTPUSHCONST
    DICTIGETJMPZ {
      0 => <{
        70 PUSHINT
        DIV
      }>
    }
    11 THROWARG
(592A3699870F04DA0FFDF26D0FF47AD0684F5B48B4FBB144854397FBFD2EA46C) PUSHREF
BLESS
EXECUTE
```