### PR TITLE
Add smartcont/auto folder to portable artifacts

### DIFF
--- a/assembly/nix/build-linux-arm64-nix.sh
+++ b/assembly/nix/build-linux-arm64-nix.sh
@@ -27,6 +27,7 @@ fi
 
 mkdir -p artifacts/lib
 cp ./result/bin/* artifacts/
+test $? -eq 0 || { echo "No artifacts have been built..."; exit 1; }
 chmod +x artifacts/*
 rm -rf result
 nix-build linux-arm64-tonlib.nix

--- a/assembly/nix/build-linux-x86-64-nix.sh
+++ b/assembly/nix/build-linux-x86-64-nix.sh
@@ -27,6 +27,7 @@ fi
 
 mkdir -p artifacts/lib
 cp ./result/bin/* artifacts/
+test $? -eq 0 || { echo "No artifacts have been built..."; exit 1; }
 chmod +x artifacts/*
 rm -rf result
 nix-build linux-x86-64-tonlib.nix

--- a/assembly/nix/build-macos-nix.sh
+++ b/assembly/nix/build-macos-nix.sh
@@ -25,6 +25,7 @@ fi
 
 mkdir -p artifacts/lib
 cp ./result-bin/bin/* artifacts/
+test $? -eq 0 || { echo "No artifacts have been built..."; exit 1; }
 chmod +x artifacts/*
 rm -rf result-bin
 nix-build macos-tonlib.nix


### PR DESCRIPTION
smartcont was used from sources, not from the actual build directory where it includes autogenerated content