### PR TITLE
Add make_any_function_request method for tonlib client

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -2191,6 +2191,11 @@ void TonlibClient::on_update(object_ptr<tonlib_api::Object> response) {
   on_result(0, std::move(response));
 }
 
+void TonlibClient::make_any_function_request(tonlib_api::object_ptr<tonlib_api::Function>&& function,
+                                             td::Promise<tonlib_api::object_ptr<tonlib_api::Object>>&& promise) {
+  make_any_request(*function, {}, std::move(promise));
+}
+
 void TonlibClient::make_any_request(tonlib_api::Function& function, QueryContext query_context,
                                     td::Promise<tonlib_api::object_ptr<tonlib_api::Object>>&& promise) {
   auto old_context = std::move(query_context_);

--- a/tonlib/tonlib/TonlibClient.h
+++ b/tonlib/tonlib/TonlibClient.h
@@ -90,6 +90,10 @@ class TonlibClient : public td::actor::Actor {
     }
   }
 
+  void make_any_function_request(tonlib_api::object_ptr<tonlib_api::Function>&& function,
+                                td::Promise<tonlib_api::object_ptr<tonlib_api::Object>>&& promise);
+
+
  private:
   enum class State { Uninited, Running, Closed } state_ = State::Uninited;
   td::unique_ptr<TonlibCallback> callback_;


### PR DESCRIPTION
By opening that method, we can easily use the tonlib client directly, without the need for TonlibClientWrapper.