### PR TITLE
Fix category signedness check in manual-dns-manage.fif

### DIFF
--- a/crypto/smartcont/manual-dns-manage.fif
+++ b/crypto/smartcont/manual-dns-manage.fif
@@ -42,7 +42,7 @@ variable Actions
 { @end? abort"subdomain name expected" @next dup $len 127 > abort"subdomain name too long"
 } : parse-domain
 { @end? abort"category number expected" @next (number) 1 <> abort"category must be integer"
-  dup 256 fits not abort"category does not fit into 256 bit integer"
+  dup 256 ufits not abort"category does not fit into 256 bit unsigned integer"
   dup 0= abort"category must be non-zero"
 } : parse-cat-num
 { @end? abort"`cat` expected" @next "cat" $= not abort"`cat` expected" parse-cat-num


### PR DESCRIPTION
Fix a check in manual DNS management Fift script, that verifies the category number as an signed `int256` instead of unsigned `uint256,` that this number is actually treated as later in the code (`256 u,`).

Importance of this fix is that the common `"wallet"H` category hash is `0xe8d44050873dba865aa7c170ab4cce64d90839a34dcfd6cf71d14e0205443b1b`, and therefore has a high bit set - therefore without this fix it is impossible to create subdomains in the `"wallet"H` category.