### PR TITLE
Fix emulator bounce conditions

### DIFF
--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -227,7 +227,9 @@ td::Result<std::unique_ptr<block::transaction::Transaction>> TransactionEmulator
     return td::Status::Error(-669,"cannot create action phase of a new transaction for smart contract "s + acc->addr.to_hex());
   }
 
-  if (trans->bounce_enabled && !trans->compute_phase->success && !trans->prepare_bounce_phase(*action_phase_cfg)) {
+  if (trans->bounce_enabled
+  && (!trans->compute_phase->success || trans->action_phase->state_exceeds_limits || trans->action_phase->bounce)
+  && !trans->prepare_bounce_phase(*action_phase_cfg)) {
     return td::Status::Error(-669,"cannot create bounce phase of a new transaction for smart contract "s + acc->addr.to_hex());
   }
 


### PR DESCRIPTION
When send mode 16 was added, new code was added into transaction processing functions in validator. Since emulator mostly copies (not reuses) that code, that new code needs to be added to emulator too in order for send mode 16 to work properly.

Conditions taken from https://github.com/ton-blockchain/ton/blob/4cfe1d1a96acf956e28e2bbc696a143489e23631/validator/impl/validate-query.cpp#L5058