### PR TITLE
Fix lite client crashing when block lookup error

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -5563,6 +5563,11 @@ td::Status TonlibClient::do_request(const tonlib_api::blocks_lookupBlock& reques
   client_.with_last_block(
     [self = this, blkid, lite_block = std::move(lite_block), mode = request.mode_, lt = (td::uint64)request.lt_, 
     utime = (td::uint32)request.utime_, promise = std::move(promise)](td::Result<LastBlockState> r_last_block) mutable { 
+      if (r_last_block.is_error()) {
+        promise.set_error(r_last_block.move_as_error_prefix(TonlibError::Internal("get last block failed ")));
+        return;
+      }
+
       self->client_.send_query(ton::lite_api::liteServer_lookupBlockWithProof(mode, std::move(lite_block), ton::create_tl_lite_block_id(r_last_block.ok().last_block_id), lt, utime),
         promise.wrap([blkid, mode, utime, lt, last_block = r_last_block.ok().last_block_id](lite_api_ptr<ton::lite_api::liteServer_lookupBlockResult>&& result) 
                                           -> td::Result<object_ptr<tonlib_api::ton_blockIdExt>> {


### PR DESCRIPTION
Here is a line: https://github.com/ton-blockchain/ton/blob/037053fffec58dedf8e72051fb695a4a42d3d9f3/tonlib/tonlib/TonlibClient.cpp#L5567C60-L5567C77

If the liteserver did not succeed in looking up the block, `.ok()` will perform a check and crash the app.