### PR TITLE
Send AdnlMessageNop instead empty Buffer for reverse pings

### DIFF
--- a/adnl/adnl-peer-table.hpp
+++ b/adnl/adnl-peer-table.hpp
@@ -55,6 +55,10 @@ class AdnlPeerTableImpl : public AdnlPeerTable {
       VLOG(ADNL_WARNING) << "DUMP: " << td::buffer_to_hex(data.as_slice().truncate(128));
       return;
     }
+    if (data.empty()) {
+      send_message_in(src, dst, AdnlMessage{adnlmessage::AdnlMessageNop()}, flags);
+      return;
+    }
     send_message_in(src, dst, AdnlMessage{adnlmessage::AdnlMessageCustom{std::move(data)}}, flags);
   }
   void answer_query(AdnlNodeIdShort src, AdnlNodeIdShort dst, AdnlQueryId query_id, td::BufferSlice data) override;


### PR DESCRIPTION
This commit modifies send_message_ex to use AdnlMessageNop for empty payloads instead of AdnlMessageCustom. This change prevents exceptions in ADNL node implementations that expect non-empty messages, particularly addressing issues with reverse-ping operations from DHT nodes. Using AdnlMessageNop ensures proper handling of empty messages