### PR TITLE
set Config::config_addr from ConfigParams if it wasn't set before

### DIFF
--- a/crypto/block/mc-config.cpp
+++ b/crypto/block/mc-config.cpp
@@ -249,6 +249,17 @@ td::Status Config::unpack() {
     return td::Status::Error("configuration root not set");
   }
   config_dict = std::make_unique<vm::Dictionary>(config_root, 32);
+
+  if (config_addr.is_zero()) {
+    auto cell = get_config_param(0);
+    if (cell.not_null()) {
+      auto cs = load_cell_slice(std::move(cell));
+      if (!cs.fetch_bits_to(config_addr.bits(), 256)) {
+        return td::Status::Error("cannot extract config address configuration parameter #0");
+      }
+    }
+  }
+
   if (mode & needValidatorSet) {
     auto vset_res = unpack_validator_set(get_config_param(35, 34));
     if (vset_res.is_error()) {


### PR DESCRIPTION
Good day,

I encountered some issues (`hash mismatch` error) with emulating TikTock transactions while simulating states.

I tested it on [Ef9VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVbxn](https://tonviewer.com/Ef9VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVbxn). The transaction in question is [f4a32e26502b28cf619218bf7da850e663e2d37efa80ab172b0c0fe0df624e38](https://tonviewer.com/transaction/f4a32e26502b28cf619218bf7da850e663e2d37efa80ab172b0c0fe0df624e38).

While digging through the logs, I found that the local emulator does not recognize this account as special. The function `Config::is_special_smart_contract()` (see [here](https://github.com/ton-blockchain/ton/blob/5c392e0f2d946877bb79a09ed35068f7b0bd333a/emulator/emulator-extern.cpp#L230)) returns false, and consequently, the emulator calculates gas incorrectly.

From my findings, it seems that the `Config::unwrap()` function does not set up required `config_addr` field

After MR changes everything started working correctly