### PR TITLE
Added nullptr check for emulation_result

### DIFF
--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -132,18 +132,19 @@ td::Result<TransactionEmulator::EmulationSuccess> TransactionEmulator::emulate_t
     TRY_RESULT(emulation, emulate_transaction(std::move(account), msg_root, utime, lt, trans_type));
 
     auto emulation_result_ptr = dynamic_cast<EmulationSuccess*>(emulation.get());
+    
     if (emulation_result_ptr == nullptr) {
       auto emulation_not_accepted_ptr = dynamic_cast<EmulationExternalNotAccepted*>(emulation.get());
-        if (emulation_not_accepted_ptr == nullptr) {
-          return td::Status::Error("emulation failed");
-        }
-        else {
-          return td::Status::Error( PSTRING()
-            << "VM Log: " << emulation_not_accepted_ptr->vm_log 
-            << ", VM Exit Code: " << emulation_not_accepted_ptr->vm_exit_code 
-            << ", Elapsed Time: " << emulation_not_accepted_ptr->elapsed_time);
-  }
-     
+      
+      if (emulation_not_accepted_ptr == nullptr) {
+        return td::Status::Error("emulation failed");
+      }
+      else {
+        return td::Status::Error( PSTRING()
+          << "VM Log: " << emulation_not_accepted_ptr->vm_log 
+          << ", VM Exit Code: " << emulation_not_accepted_ptr->vm_exit_code 
+          << ", Elapsed Time: " << emulation_not_accepted_ptr->elapsed_time);
+      }
     }
     auto& emulation_result = *emulation_result_ptr;
 

--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -138,8 +138,7 @@ td::Result<TransactionEmulator::EmulationSuccess> TransactionEmulator::emulate_t
       
       if (emulation_not_accepted_ptr == nullptr) {
         return td::Status::Error("emulation failed");
-      }
-      else {
+      } else {
         return td::Status::Error( PSTRING()
           << "VM Log: " << emulation_not_accepted_ptr->vm_log 
           << ", VM Exit Code: " << emulation_not_accepted_ptr->vm_exit_code 

--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -133,7 +133,17 @@ td::Result<TransactionEmulator::EmulationSuccess> TransactionEmulator::emulate_t
 
     auto emulation_result_ptr = dynamic_cast<EmulationSuccess*>(emulation.get());
     if (emulation_result_ptr == nullptr) {
-      return td::Status::Error("emulation failed");
+      auto emulation_not_accepted_ptr = dynamic_cast<EmulationExternalNotAccepted*>(emulation.get());
+        if (emulation_not_accepted_ptr == nullptr) {
+          return td::Status::Error("emulation failed");
+        }
+        else {
+          return td::Status::Error( PSTRING()
+            << "VM Log: " << emulation_not_accepted_ptr->vm_log 
+            << ", VM Exit Code: " << emulation_not_accepted_ptr->vm_exit_code 
+            << ", Elapsed Time: " << emulation_not_accepted_ptr->elapsed_time);
+  }
+     
     }
     auto& emulation_result = *emulation_result_ptr;
 

--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -131,6 +131,12 @@ td::Result<TransactionEmulator::EmulationSuccess> TransactionEmulator::emulate_t
 
     TRY_RESULT(emulation, emulate_transaction(std::move(account), msg_root, utime, lt, trans_type));
 
+    auto emulation_result_ptr = dynamic_cast<EmulationSuccess*>(emulation.get());
+    if (emulation_result_ptr == nullptr) {
+      return td::Status::Error("emulation failed");
+    }
+    auto& emulation_result = *emulation_result_ptr;
+
     auto emulation_result = dynamic_cast<EmulationSuccess&>(*emulation);
     if (td::Bits256(emulation_result.transaction->get_hash().bits()) != td::Bits256(original_trans->get_hash().bits())) {
       return td::Status::Error("transaction hash mismatch");

--- a/emulator/transaction-emulator.cpp
+++ b/emulator/transaction-emulator.cpp
@@ -137,7 +137,6 @@ td::Result<TransactionEmulator::EmulationSuccess> TransactionEmulator::emulate_t
     }
     auto& emulation_result = *emulation_result_ptr;
 
-    auto emulation_result = dynamic_cast<EmulationSuccess&>(*emulation);
     if (td::Bits256(emulation_result.transaction->get_hash().bits()) != td::Bits256(original_trans->get_hash().bits())) {
       return td::Status::Error("transaction hash mismatch");
     }


### PR DESCRIPTION
Tx emulation fails and tonlib json crashes if one tries to get raw acclunt state by tx in some certain cases. 

One of cases is: contract address "EQAezbdnLVsLSq8tnVVzaHxxkKpoSYBNnn1673GXWsA-Lu_w"
Transatction id:  38181629000001:b8382ba10389896401b129adae4a1c373f6a9611fcc197f4cd52d16ac28518ff


test code for tonlib-rs (not unpublished yet)
```
    #[tokio::test]
    async fn test_bad_cast() -> anyhow::Result<()> {
        common::init_logging();
        let client =  common::new_mainnet_client().await;
        let ton_addr = "EQAezbdnLVsLSq8tnVVzaHxxkKpoSYBNnn1673GXWsA-Lu_w"
            .parse::<TonAddress>()
            .unwrap();
        let tx_id = InternalTransactionId::from_lt_hash(
            38181629000001,
            "b8382ba10389896401b129adae4a1c373f6a9611fcc197f4cd52d16ac28518ff",
        )?;
        match client
            .get_raw_account_state_by_transaction(&ton_addr, &tx_id)
            .await
        {
            Ok(raw_acc_tx) => log::info!("raw_acc_tx: {:?}", raw_acc_tx),
            Err(e) => log::info!("error: {:?}", e),
        };

        time::sleep(Duration::from_secs(1)).await;
        Ok(())
    }
```