### PR TITLE
Update License year in GPLv2

### DIFF
--- a/GPLv2
+++ b/GPLv2
@@ -23,5 +23,5 @@
     exception statement from your version. If you delete this exception statement
     from all source files in the program, then also delete it here.
 
-    Copyright 2017-2020 Telegram Systems LLP
+    Copyright 2017-2024 Telegram Systems LLP
 */


### PR DESCRIPTION
Just noticed that the year in the license file is outdated. 