### PR TITLE
Pvs studio

### DIFF
--- a/crypto/Ed25519.cpp
+++ b/crypto/Ed25519.cpp
@@ -73,6 +73,7 @@ static Result<SecureString> X25519_key_from_PKEY(EVP_PKEY *pkey, bool is_private
   if (func(pkey, result.as_mutable_slice().ubegin(), &len) == 0) {
     return Status::Error("Failed to get raw key");
   }
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. Ed25519.cpp 76
   return std::move(result);
 }
 

--- a/crypto/block/block-db.cpp
+++ b/crypto/block/block-db.cpp
@@ -85,6 +85,7 @@ td::Result<td::BufferSlice> load_binary_file(std::string filename, td::int64 max
     if (r != static_cast<td::uint64>(size)) {
       return td::Status::Error(PSLICE() << "read " << r << " bytes out of " << size);
     }
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. block-db.cpp 88
     return std::move(res);
   }();
   LOG_IF(ERROR, res.is_error()) << "error reading file `" << filename << "` : " << res.error();

--- a/crypto/block/block.cpp
+++ b/crypto/block/block.cpp
@@ -2242,6 +2242,7 @@ td::Result<Ref<vm::Cell>> get_config_data_from_smc(Ref<vm::Cell> acc_root) {
         "configuration smart contract does not contain a valid configuration in the first reference of its persistent "
         "data");
   }
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. block.cpp 2245
   return std::move(res);
 }
 

--- a/crypto/block/check-proof.cpp
+++ b/crypto/block/check-proof.cpp
@@ -93,6 +93,7 @@ td::Result<Ref<vm::Cell>> check_extract_state_proof(ton::BlockIdExt blkid, td::S
     if (state_hash != state_virt_root->get_hash().bits()) {
       return td::Status::Error("root hash mismatch in the shardchain state proof");
     }
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. check-proof.cpp 96
     return std::move(state_virt_root);
   } catch (vm::VmError& err) {
     return td::Status::Error(PSLICE() << "error scanning shard state proof: " << err.get_msg());

--- a/crypto/block/create-state.cpp
+++ b/crypto/block/create-state.cpp
@@ -926,6 +926,7 @@ int main(int argc, char* const argv[]) {
     preload_preamble(fift, "CreateState.fif", false);
   }
 
+  // V836 Expression's value is copied at the 'source' variable declaration. The variable is never modified. Consider declaring it as a reference. create-state.cpp 929
   for (auto source : library_source_files) {
     auto status = fift.interpret_file(source, "");
     if (status.is_error()) {

--- a/crypto/block/transaction.cpp
+++ b/crypto/block/transaction.cpp
@@ -1438,6 +1438,7 @@ bool Transaction::unpack_msg_state(const ComputePhaseConfig& cfg, bool lib_only,
  */
 std::vector<Ref<vm::Cell>> Transaction::compute_vm_libraries(const ComputePhaseConfig& cfg) {
   std::vector<Ref<vm::Cell>> lib_set;
+  // V827 Maximum size of the 'lib_set' vector is known at compile time. Consider pre-allocating it by calling lib_set.reserve(3) transaction.cpp 1440
   if (in_msg_library.not_null()) {
     lib_set.push_back(in_msg_library);
   }

--- a/crypto/fift/fift-main.cpp
+++ b/crypto/fift/fift-main.cpp
@@ -172,6 +172,7 @@ int main(int argc, char* const argv[]) {
     }
   }
 
+  // V836 Expression's value is copied at the 'source' variable declaration. The variable is never modified. Consider declaring it as a reference. fift-main.cpp 175
   for (auto source : library_source_files) {
     auto status = fift.interpret_file(source, "");
     if (status.is_error()) {

--- a/crypto/fift/utils.cpp
+++ b/crypto/fift/utils.cpp
@@ -160,6 +160,7 @@ td::Result<fift::SourceLookup> create_source_lookup(std::string main, bool need_
   }
   auto res = fift::SourceLookup(std::move(loader));
   res.add_include_path("/");
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. utils.cpp 163
   return std::move(res);
 }
 
@@ -194,6 +195,7 @@ td::Result<FiftOutput> mem_run_fift(std::string source, std::vector<std::string>
   FiftOutput res;
   res.source_lookup = std::move(source_lookup);
   res.output = ss.str();
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. utils.cpp 197
   return std::move(res);
 }
 td::Result<FiftOutput> mem_run_fift(SourceLookup source_lookup, std::vector<std::string> args) {
@@ -202,6 +204,7 @@ td::Result<FiftOutput> mem_run_fift(SourceLookup source_lookup, std::vector<std:
   FiftOutput res;
   res.source_lookup = std::move(source_lookup);
   res.output = ss.str();
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. utils.cpp 205
   return std::move(res);
 }
 td::Result<fift::SourceLookup> create_mem_source_lookup(std::string main, std::string fift_dir, bool need_preamble,

--- a/crypto/func/optimize.cpp
+++ b/crypto/func/optimize.cpp
@@ -633,6 +633,7 @@ AsmOpConsList optimize_code(AsmOpConsList op_list, int mode) {
   for (auto it = v.rbegin(); it < v.rend(); ++it) {
     op_list = AsmOpCons::cons(std::move(*it), std::move(op_list));
   }
+  // V828 Redundant code. Function parameter will be implicitly moved without calling the 'std::move' function. optimize.cpp 636
   return std::move(op_list);
 }
 

--- a/crypto/func/parse-func.cpp
+++ b/crypto/func/parse-func.cpp
@@ -1693,6 +1693,7 @@ void parse_pragma(Lexer& lex) {
         }
         break;
     }
+    // V728 An excessive check can be simplified. The '(A && B) || (!A && !B)' expression is equivalent to the 'bool(A) == bool(B)' expression. parse-func.cpp 1696
     if ((match && negate) || (!match && !negate)) {
       pragma.error(std::string("FunC version ") + func_ver_test + " does not satisfy condition " + semver_expr);
     }

--- a/crypto/util/pow-miner.cpp
+++ b/crypto/util/pow-miner.cpp
@@ -69,6 +69,7 @@ td::RefInt256 parse_bigint(std::string str, int bits) {
 td::RefInt256 parse_bigint_chk(std::string str, int bits) {
   auto x = parse_bigint(std::move(str), bits);
   if (x.is_null()) {
+    // V1030 The 'str' variable is used after it was moved. pow-miner.cpp 72
     std::cerr << "fatal: `" << str << "` is not an integer" << std::endl;
     usage();
   }

--- a/crypto/vm/boc.cpp
+++ b/crypto/vm/boc.cpp
@@ -294,6 +294,7 @@ void BagOfCells::reorder_cells() {
   for (auto& root_info : roots) {
     auto& cell_info = cell_list_[root_info.idx];
     if (cell_info.is_root_cell) {
+      // V1048 The 'cell_info.is_root_cell' variable was assigned the same value. boc.cpp 306
       cell_info.is_root_cell = true;
       if (cell_info.wt) {
         top_hashes += cell_info.hcnt;
@@ -650,6 +651,7 @@ long long BagOfCells::Info::parse_serialized_header(const td::Slice& slice) {
   }
   td::uint8 byte = ptr[4];
   if (magic == boc_generic) {
+    // V1064 The '(byte >> 7)' operand of the modulo operation is less than the '2' operand. The result is always equal to the left operand. boc.cpp 679
     has_index = (byte >> 7) % 2 == 1;
     has_crc32c = (byte >> 6) % 2 == 1;
     has_cache_bits = (byte >> 5) % 2 == 1;
@@ -949,6 +951,7 @@ td::Result<Ref<Cell>> std_boc_deserialize(td::Slice data, bool can_be_empty, boo
   if (!allow_nonzero_level && root->get_level() != 0) {
     return td::Status::Error("bag of cells has a root with non-zero level");
   }
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. boc.cpp 978
   return std::move(root);
 }
 
@@ -973,6 +976,7 @@ td::Result<std::vector<Ref<Cell>>> std_boc_deserialize_multi(td::Slice data, int
     }
     roots.emplace_back(std::move(root));
   }
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. boc.cpp 1002
   return std::move(roots);
 }
 

--- a/crypto/vm/excno.hpp
+++ b/crypto/vm/excno.hpp
@@ -57,6 +57,7 @@ class VmError {
   VmError(Excno _excno, const char* _msg, long long _arg) : exc_no(_excno), msg(_msg), arg(_arg) {
   }
   VmError(Excno _excno, std::string _msg, long long _arg = 0) : exc_no(_excno), msg_alloc(true), arg(_arg) {
+    // V1048 The 'msg_alloc' variable was assigned the same value. excno.hpp 60
     msg_alloc = true;
     char* p = (char*)malloc(_msg.size() + 1);
     memcpy(p, _msg.data(), _msg.size());

--- a/crypto/vm/large-boc-serializer.cpp
+++ b/crypto/vm/large-boc-serializer.cpp
@@ -204,6 +204,7 @@ void LargeBocSerializer::reorder_cells() {
   for (auto& root_info : roots) {
     auto& cell_info = cell_list[root_info.idx]->second;
     if (cell_info.is_root_cell) {
+      // V1048 The 'cell_info.is_root_cell' variable was assigned the same value. large-boc-serializer.cpp 203
       cell_info.is_root_cell = true;
       if (cell_info.wt) {
         top_hashes += cell_info.hcnt;

--- a/crypto/vm/tonops.cpp
+++ b/crypto/vm/tonops.cpp
@@ -1486,12 +1486,14 @@ int exec_parse_message_addr(VmState* st, bool quiet) {
 // replaces first bits of `addr` with those of `prefix`
 Ref<CellSlice> do_rewrite_addr(Ref<CellSlice> addr, Ref<CellSlice> prefix) {
   if (prefix.is_null() || !prefix->size()) {
+    // V828 Redundant code. Function parameter will be implicitly moved without calling the 'std::move' function. tonops.cpp 1489
     return std::move(addr);
   }
   if (prefix->size() > addr->size()) {
     return {};
   }
   if (prefix->size() == addr->size()) {
+    // V828 Redundant code. Function parameter will be implicitly moved without calling the 'std::move' function. tonops.cpp 1495
     return std::move(prefix);
   }
   vm::CellBuilder cb;

--- a/lite-client/lite-client-common.cpp
+++ b/lite-client/lite-client-common.cpp
@@ -92,6 +92,7 @@ td::Result<std::unique_ptr<block::BlockProofChain>> deserialize_proof_chain(
                << " signatures";
   }
   LOG(DEBUG) << "deserialized a BlkProofChain of " << chain->link_count() << " links";
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. lite-client-common.cpp 95
   return std::move(chain);
 }
 

--- a/overlay/overlay.cpp
+++ b/overlay/overlay.cpp
@@ -103,6 +103,7 @@ OverlayImpl::OverlayImpl(td::actor::ActorId<keyring::Keyring> keyring, td::actor
 
   update_root_member_list(std::move(nodes), std::move(root_public_keys), std::move(cert));
 
+  // V1030 The 'nodes' variable is used after it was moved. overlay.cpp 106
   update_neighbours(static_cast<td::uint32>(nodes.size()));
 }
 

--- a/tdutils/td/utils/Hints.cpp
+++ b/tdutils/td/utils/Hints.cpp
@@ -62,6 +62,7 @@ vector<string> Hints::get_words(Slice name, bool is_search) {
     if (code == ' ') {
       if (in_word) {
         words.push_back(std::move(word));
+        // V1030 The 'word' variable is used after it was moved. Hints.cpp 65
         word.clear();
         in_word = false;
       }
@@ -161,6 +162,7 @@ void Hints::add_search_results(vector<KeyT> &results, const string &word,
 vector<Hints::KeyT> Hints::search_word(const string &word) const {
   vector<KeyT> results;
   add_search_results(results, word, translit_word_to_keys_);
+  // V836 Expression's value is copied at the 'w' variable declaration. The variable is never modified. Consider declaring it as a reference. Hints.cpp 164
   for (auto w : get_word_transliterations(word, true)) {
     add_search_results(results, w, word_to_keys_);
   }

--- a/tdutils/td/utils/crypto.cpp
+++ b/tdutils/td/utils/crypto.cpp
@@ -921,6 +921,7 @@ Result<BufferSlice> rsa_encrypt_pkcs1_oaep(Slice public_key, Slice data) {
 #endif
     return Status::Error("Cannot encrypt");
   }
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. crypto.cpp 924
   return std::move(res);
 }
 
@@ -977,6 +978,7 @@ Result<BufferSlice> rsa_decrypt_pkcs1_oaep(Slice private_key, Slice data) {
     return Status::Error("Cannot decrypt");
   }
 #endif
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. crypto.cpp 980
   return std::move(res);
 }
 

--- a/tdutils/td/utils/date.h
+++ b/tdutils/td/utils/date.h
@@ -1127,6 +1127,7 @@ trunc(T t) NOEXCEPT
     CONSTDATA auto max = I{1} << (digits-1);
     CONSTDATA auto min = -max;
     const auto negative = t < T{0};
+    // V501 There are identical sub-expressions to the left and to the right of the '==' operator: t == t date.h 1130
     if (min <= t && t <= max && t != 0 && t == t)
     {
         t = static_cast<T>(static_cast<I>(t));

--- a/tdutils/td/utils/misc.cpp
+++ b/tdutils/td/utils/misc.cpp
@@ -107,6 +107,7 @@ Result<string> hex_decode(Slice hex) {
     }
     result[i] = static_cast<char>(high * 16 + low);  // TODO implementation-defined
   }
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. misc.cpp 110
   return std::move(result);
 }
 

--- a/tdutils/td/utils/translit.cpp
+++ b/tdutils/td/utils/translit.cpp
@@ -77,6 +77,7 @@ static void add_word_transliterations(vector<string> &result, Slice word, bool a
   }
   if (!s.empty()) {
     result.push_back(std::move(s));
+    // V1030 The 's' variable is used after it was moved. translit.cpp 80
     s.clear();
   }
 

--- a/tl-utils/common-utils.hpp
+++ b/tl-utils/common-utils.hpp
@@ -61,6 +61,7 @@ td::Result<tl_object_ptr<std::enable_if_t<std::is_constructible<T>::value, T>>> 
   }
   p.fetch_end();
   if (p.get_status().is_ok()) {
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 64
     return std::move(R);
   } else {
     return p.get_status();
@@ -76,6 +77,7 @@ td::Result<tl_object_ptr<std::enable_if_t<!std::is_constructible<T>::value, T>>>
   R = move_tl_object_as<T>(T::fetch(p));
   p.fetch_end();
   if (p.get_status().is_ok()) {
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 79
     return std::move(R);
   } else {
     return p.get_status();
@@ -94,6 +96,7 @@ td::Result<tl_object_ptr<std::enable_if_t<std::is_constructible<T>::value, T>>> 
   }
   p.fetch_end();
   if (p.get_status().is_ok()) {
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 97
     return std::move(R);
   } else {
     return p.get_status();
@@ -109,6 +112,7 @@ td::Result<tl_object_ptr<std::enable_if_t<!std::is_constructible<T>::value, T>>>
   R = move_tl_object_as<T>(T::fetch(p));
   p.fetch_end();
   if (p.get_status().is_ok()) {
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 112
     return std::move(R);
   } else {
     return p.get_status();
@@ -127,6 +131,7 @@ td::Result<tl_object_ptr<std::enable_if_t<std::is_constructible<T>::value, T>>> 
   }
   if (p.get_status().is_ok()) {
     data.confirm_read(data.size() - p.get_left_len());
+    // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 130
     return std::move(R);
   } else {
     return p.get_status();
@@ -203,6 +208,7 @@ td::Result<typename T::ReturnType> fetch_result(td::Slice message, bool check_en
     return td::Status::Error(500, td::Slice(error));
   }
 
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 206
   return std::move(result);
 }
 
@@ -220,6 +226,7 @@ td::Result<typename T::ReturnType> fetch_result(const td::BufferSlice &message, 
     return td::Status::Error(500, td::Slice(error));
   }
 
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. common-utils.hpp 223
   return std::move(result);
 }
 

--- a/tl/generate/tl_writer_td.cpp
+++ b/tl/generate/tl_writer_td.cpp
@@ -99,6 +99,7 @@ std::vector<std::string> TD_TL_writer::get_parsers() const {
 
 std::vector<std::string> TD_TL_writer::get_storers() const {
   std::vector<std::string> storers;
+  // V827 Maximum size of the 'storers' vector is known at compile time. Consider pre-allocating it by calling storers.reserve(3) tl_writer_td.cpp 101
   if (tl_name == "ton_api" || tl_name == "lite_api") {
     storers.push_back("td::TlStorerCalcLength");
     storers.push_back("td::TlStorerUnsafe");

--- a/tonlib/tonlib/KeyStorage.cpp
+++ b/tonlib/tonlib/KeyStorage.cpp
@@ -128,6 +128,7 @@ td::Status KeyStorage::delete_all_keys() {
     }
   });
   td::Status status;
+  // V836 Expression's value is copied at the 'key' variable declaration. The variable is never modified. Consider declaring it as a reference. KeyStorage.cpp 131
   for (auto key : keys) {
     LOG(WARNING) << "Delete private key stored at " << key;
     auto err = kv_->erase(key);

--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -226,6 +226,7 @@ td::Result<ton::WalletV3::InitData> to_init_data(const tonlib_api::wallet_v3_ini
   ton::WalletV3::InitData init_data;
   init_data.public_key = td::SecureString(key_bytes.key);
   init_data.wallet_id = static_cast<td::uint32>(wallet_state.wallet_id_);
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. TonlibClient.cpp 229
   return std::move(init_data);
 }
 
@@ -234,6 +235,7 @@ td::Result<ton::WalletV4::InitData> to_init_data(const tonlib_api::wallet_v4_ini
   ton::WalletV4::InitData init_data;
   init_data.public_key = td::SecureString(key_bytes.key);
   init_data.wallet_id = static_cast<td::uint32>(wallet_state.wallet_id_);
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. TonlibClient.cpp 237
   return std::move(init_data);
 }
 
@@ -244,6 +246,7 @@ td::Result<ton::RestrictedWallet::InitData> to_init_data(const tonlib_api::rwall
   init_data.init_key = td::SecureString(init_key_bytes.key);
   init_data.main_key = td::SecureString(key_bytes.key);
   init_data.wallet_id = static_cast<td::uint32>(rwallet_state.wallet_id_);
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. TonlibClient.cpp 247
   return std::move(init_data);
 }
 
@@ -276,6 +279,7 @@ td::Result<ton::pchan::Config> to_pchan_config(const tonlib_api::pchan_initialAc
   config.channel_id = pchan_state.config_->channel_id_;
   config.init_timeout = pchan_state.config_->init_timeout_;
   config.close_timeout = pchan_state.config_->close_timeout_;
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. TonlibClient.cpp 279
   return std::move(config);
 }
 

--- a/validator/impl/collator.cpp
+++ b/validator/impl/collator.cpp
@@ -3196,6 +3196,7 @@ bool Collator::enqueue_transit_message(Ref<vm::Cell> msg, Ref<vm::Cell> old_msg_
   } else {
     LOG(DEBUG) << "enqueueing transit message " << msg->get_hash().bits().to_hex(256);
   }
+  // V501 There are identical sub-expressions '!from_dispatch_queue' to the left and to the right of the '&&' operator. collator.cpp 3199
   bool requeue = !from_dispatch_queue && is_our_address(prev_prefix) && !from_dispatch_queue;
   // 1. perform hypercube routing
   auto route_info = block::perform_hypercube_routing(cur_prefix, dest_prefix, shard_);

--- a/validator/impl/fabric.cpp
+++ b/validator/impl/fabric.cpp
@@ -126,6 +126,7 @@ void run_check_external_message(Ref<ExtMessage> message, td::actor::ActorId<Vali
 
 td::Result<td::Ref<IhrMessage>> create_ihr_message(td::BufferSlice data) {
   TRY_RESULT(res, IhrMessageQ::create_ihr_message(std::move(data)));
+  // V828 Decreased performance. Moving a local object in a return statement prevents copy elision. fabric.cpp 129
   return std::move(res);
 }
 

--- a/validator/impl/liteserver.cpp
+++ b/validator/impl/liteserver.cpp
@@ -2142,6 +2142,7 @@ void LiteQuery::continue_lookupBlockWithProof_getHeaderProof(Ref<ton::validator:
 
 void LiteQuery::continue_lookupBlockWithProof_gotPrevBlockData(Ref<BlockData> prev_block, BlockSeqno masterchain_ref_seqno) {
   if (prev_block.not_null()) {
+    //V637 Two opposite conditions were encountered. The second condition is always false. Check lines: 2144, 2145. liteserver.cpp 2144
     CHECK(prev_block.not_null());
     if (prev_block->root_cell().is_null()) {
       fatal_error("block has no valid root cell");


### PR DESCRIPTION
All of these errors was generated by PVS Studio - automatic analysis tool i used to check the code. These are just a small fraction of what was found. The most interested for me. Some may be false-positive though most of them were filtered by me.
Please someone with experience and code knowledge take a look. 
If community is interested i can share a full log and anyone with PVS installed can fix them. 

There is a lot of performace-related issues such as trying to move const or const ref (&) objects (which results in simple copying), passing large objects by value (such as strings). _I have zero interest in PVS, just a TON user who decide to spend couple of hours setting up windows build and checking for mistakes and errors. In hope this will make TON better_ 