### PR TITLE
using multiple CellDb to concurrency read from celldb

### DIFF
--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -4237,6 +4237,7 @@ int main(int argc, char *argv[]) {
         threads = v;
         return td::Status::OK();
       });
+  acts.push_back([&x, &threads]() { td::actor::send_closure(x, &ValidatorEngine::set_cpu_threads_count, threads); });
   p.add_checked_option('u', "user", "change user", [&](td::Slice user) { return td::change_user(user.str()); });
   p.add_checked_option('\0', "shutdown-at", "stop validator at the given time (unix timestamp)", [&](td::Slice arg) {
     TRY_RESULT(at, td::to_integer_safe<td::uint32>(arg));

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -1487,6 +1487,8 @@ td::Status ValidatorEngine::load_global_config() {
   }
   validator_options_.write().set_fast_state_serializer_enabled(fast_state_serializer_enabled_);
 
+  validator_options_.write().set_cpu_threads_count(cpu_threads_count_);
+
   return td::Status::OK();
 }
 

--- a/validator-engine/validator-engine.hpp
+++ b/validator-engine/validator-engine.hpp
@@ -223,6 +223,8 @@ class ValidatorEngine : public td::actor::Actor {
   std::string session_logs_file_;
   bool fast_state_serializer_enabled_ = false;
 
+  size_t cpu_threads_count_;
+
   std::set<ton::CatchainSeqno> unsafe_catchains_;
   std::map<ton::BlockSeqno, std::pair<ton::CatchainSeqno, td::uint32>> unsafe_catchain_rotations_;
 
@@ -309,6 +311,9 @@ class ValidatorEngine : public td::actor::Actor {
   }
   void set_fast_state_serializer_enabled(bool value) {
     fast_state_serializer_enabled_ = value;
+  }
+  void set_cpu_threads_count(size_t cpu_threads_count) {
+    cpu_threads_count_ = cpu_threads_count;
   }
   void start_up() override;
   ValidatorEngine() {
@@ -401,8 +406,8 @@ class ValidatorEngine : public td::actor::Actor {
 
   void load_custom_overlays_config();
   td::Status write_custom_overlays_config();
-  void add_custom_overlay_to_config(
-      ton::tl_object_ptr<ton::ton_api::engine_validator_customOverlay> overlay, td::Promise<td::Unit> promise);
+  void add_custom_overlay_to_config(ton::tl_object_ptr<ton::ton_api::engine_validator_customOverlay> overlay,
+                                    td::Promise<td::Unit> promise);
   void del_custom_overlay_from_config(std::string name, td::Promise<td::Unit> promise);
   void load_collator_options();
 

--- a/validator/db/celldb.cpp
+++ b/validator/db/celldb.cpp
@@ -90,9 +90,9 @@ CellDbIn::CellDbIn(td::actor::ActorId<RootDb> root_db, td::actor::ActorId<CellDb
     , path_(std::move(path))
     , obj_id_(obj_id)
     , boc_(inmem_info.boc_)
-    , in_memory_load_time_(inmem_info.in_memory_load_time_)
+    , cell_db_(rocks_db)
     , rocks_db_(rocks_db->raw_db())
-    , cell_db_(std::move(rocks_db)) {
+    , in_memory_load_time_(inmem_info.in_memory_load_time_) {
   statistics_ = rdb_opts.statistics;
   statistics_flush_at_ = td::Timestamp::in(60.0);
   snapshot_statistics_ = rdb_opts.snapshot_statistics;
@@ -649,6 +649,7 @@ void CellDb::start_up() {
   CellDbBase::start_up();
   boc_ = vm::DynamicBagOfCellsDb::create();
   boc_->set_celldb_compress_depth(opts_->get_celldb_compress_depth());
+
   cell_db_ = td::actor::create_actor<CellDbIn>("celldbin", root_db_, actor_id(this), path_, obj_id_, inmem_info_,
                                                rocks_db_, rdb_opts_, opts_);
   on_load_callback_ = [actor = std::make_shared<td::actor::ActorOwn<CellDbIn::MigrationProxy>>(

--- a/validator/db/celldb.hpp
+++ b/validator/db/celldb.hpp
@@ -216,12 +216,12 @@ class CellDb : public CellDbBase {
 
   CellDb(td::actor::ActorId<RootDb> root_db, std::string path, int obj_id, InMemoryInfo inmem_info,
          std::shared_ptr<td::RocksDb> rocks_db, td::RocksDbOptions rdb_opts, td::Ref<ValidatorManagerOptions> opts)
-      : root_db_(root_db)
-      , path_(path)
-      , obj_id_(obj_id)
+      : obj_id_(obj_id)
       , inmem_info_(inmem_info)
       , rocks_db_(rocks_db)
       , rdb_opts_(rdb_opts)
+      , path_(path)
+      , root_db_(root_db)
       , opts_(opts) {
   }
 
@@ -234,8 +234,8 @@ class CellDb : public CellDbBase {
   std::shared_ptr<td::RocksDb> rocks_db_;
   td::RocksDbOptions rdb_opts_;
 
-  td::actor::ActorId<RootDb> root_db_;
   std::string path_;
+  td::actor::ActorId<RootDb> root_db_;
   td::Ref<ValidatorManagerOptions> opts_;
 
   td::actor::ActorOwn<CellDbIn> cell_db_;

--- a/validator/db/rootdb.cpp
+++ b/validator/db/rootdb.cpp
@@ -438,7 +438,8 @@ void RootDb::start_up() {
 
   cell_db_writer_ = td::actor::create_actor<CellDb>("celldbwriter", actor_id(this), celldb_path, 0, inmem_info,
                                                     rocks_db, db_options, opts_);
-  for (auto i = 0; i < 10; i++) {
+  const auto reader_count = 0 == opts_->get_cpu_threads_count() ? 1 : opts_->get_cpu_threads_count();
+  for (size_t i = 0; i < reader_count; i++) {
     cell_db_readers_.push_back(td::actor::create_actor<CellDb>("celldbreader", actor_id(this), celldb_path, i + 1,
                                                                inmem_info, rocks_db, db_options, opts_));
   }

--- a/validator/db/rootdb.cpp
+++ b/validator/db/rootdb.cpp
@@ -434,7 +434,7 @@ void RootDb::start_up() {
     LOG(WARNING) << "Set CellDb block cache size to " << td::format::as_size(opts_->get_celldb_cache_size().value());
   }
   db_options.use_direct_reads = opts_->get_celldb_direct_io();
-  auto rocks_db = std::make_shared<td::RocksDb>(td::RocksDb::open(celldb_path, std::move(db_options)).move_as_ok());
+  auto rocks_db = std::make_shared<td::RocksDb>(td::RocksDb::open(celldb_path, db_options).move_as_ok());
 
   cell_db_writer_ = td::actor::create_actor<CellDb>("celldbwriter", actor_id(this), celldb_path, 0, inmem_info,
                                                     rocks_db, db_options, opts_);

--- a/validator/db/rootdb.hpp
+++ b/validator/db/rootdb.hpp
@@ -141,7 +141,7 @@ class RootDb : public Db {
 
  public:
   void update_snapshot() {
-    // we don't update snapshot of writer because the update action must be sent from writer.
+    // we don't update snapshot of writer because the update action is triggered by writer.
     for (const auto& reader : cell_db_readers_) {
       td::actor::send_closure(reader, &CellDb::update_snapshot);
     }

--- a/validator/validator-options.hpp
+++ b/validator/validator-options.hpp
@@ -156,6 +156,9 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
   bool get_fast_state_serializer_enabled() const override {
     return fast_state_serializer_enabled_;
   }
+  size_t get_cpu_threads_count() const override {
+    return cpu_threads_count_;
+  }
 
   void set_zero_block_id(BlockIdExt block_id) override {
     zero_block_id_ = block_id;
@@ -197,7 +200,8 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
     unsafe_catchains_.insert(seqno);
   }
   void add_unsafe_catchain_rotate(BlockSeqno seqno, CatchainSeqno cc_seqno, td::uint32 value) override {
-    VLOG(INFO) << "Add unsafe catchain rotation: Master block seqno " << seqno<<" Catchain seqno " << cc_seqno << " New value "<< value;
+    VLOG(INFO) << "Add unsafe catchain rotation: Master block seqno " << seqno << " Catchain seqno " << cc_seqno
+               << " New value " << value;
     unsafe_catchain_rotates_[cc_seqno] = std::make_pair(seqno, value);
   }
   void truncate_db(BlockSeqno seqno) override {
@@ -251,6 +255,9 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
   void set_fast_state_serializer_enabled(bool value) override {
     fast_state_serializer_enabled_ = value;
   }
+  void set_cpu_threads_count(size_t cpu_threads_count) override {
+    cpu_threads_count_ = cpu_threads_count;
+  }
 
   ValidatorManagerOptionsImpl *make_copy() const override {
     return new ValidatorManagerOptionsImpl(*this);
@@ -258,9 +265,8 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
 
   ValidatorManagerOptionsImpl(BlockIdExt zero_block_id, BlockIdExt init_block_id,
                               std::function<bool(ShardIdFull, CatchainSeqno, ShardCheckMode)> check_shard,
-                              bool allow_blockchain_init, double sync_blocks_before,
-                              double block_ttl, double state_ttl, double max_mempool_num,
-                              double archive_ttl, double key_proof_ttl,
+                              bool allow_blockchain_init, double sync_blocks_before, double block_ttl, double state_ttl,
+                              double max_mempool_num, double archive_ttl, double key_proof_ttl,
                               bool initial_sync_disabled)
       : zero_block_id_(zero_block_id)
       , init_block_id_(init_block_id)
@@ -306,6 +312,7 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
   bool state_serializer_enabled_ = true;
   td::Ref<CollatorOptions> collator_options_{true};
   bool fast_state_serializer_enabled_ = false;
+  size_t cpu_threads_count_;
 };
 
 }  // namespace validator

--- a/validator/validator.h
+++ b/validator/validator.h
@@ -48,7 +48,7 @@ class DownloadToken {
 
 struct PerfTimerStats {
   std::string name;
-  std::deque<std::pair<double, double>> stats; // <Time::now(), duration>
+  std::deque<std::pair<double, double>> stats;  // <Time::now(), duration>
 };
 
 struct CollatorOptions : public td::CntObject {
@@ -115,6 +115,7 @@ struct ValidatorManagerOptions : public td::CntObject {
   virtual bool get_state_serializer_enabled() const = 0;
   virtual td::Ref<CollatorOptions> get_collator_options() const = 0;
   virtual bool get_fast_state_serializer_enabled() const = 0;
+  virtual size_t get_cpu_threads_count() const = 0;
 
   virtual void set_zero_block_id(BlockIdExt block_id) = 0;
   virtual void set_init_block_id(BlockIdExt block_id) = 0;
@@ -148,6 +149,7 @@ struct ValidatorManagerOptions : public td::CntObject {
   virtual void set_state_serializer_enabled(bool value) = 0;
   virtual void set_collator_options(td::Ref<CollatorOptions> value) = 0;
   virtual void set_fast_state_serializer_enabled(bool value) = 0;
+  virtual void set_cpu_threads_count(size_t cpu_threads_count) = 0;
 
   static td::Ref<ValidatorManagerOptions> create(
       BlockIdExt zero_block_id, BlockIdExt init_block_id,
@@ -155,8 +157,7 @@ struct ValidatorManagerOptions : public td::CntObject {
                                                                                        ShardCheckMode) { return true; },
       bool allow_blockchain_init = false, double sync_blocks_before = 3600, double block_ttl = 86400,
       double state_ttl = 86400, double archive_ttl = 86400 * 7, double key_proof_ttl = 86400 * 3650,
-      double max_mempool_num = 999999,
-      bool initial_sync_disabled = false);
+      double max_mempool_num = 999999, bool initial_sync_disabled = false);
 };
 
 class ValidatorManagerInterface : public td::actor::Actor {


### PR DESCRIPTION
## Background
When using the TON liteserver built by ourself, we noticed that when the access count increases, the response time of some requests (such as GetAccountState) get slower, with many timeout errors.

After investigation, we found that the longest processing time for a single GetAccountState request is the scheduling of `CellDb::load_cell`. Below is a timing statistics we added for a specific GetAccountState request:
```
ton-node-1  | [ 2][t27][2024-10-30 06:04:20.001725500][query_stat.cpp:105][!litequery]        query stat counter:1205. perform_getAccountState schedule cost: 1463946μs
ton-node-1  | ValidatorManagerImpl::get_block_data_for_litequery schedule cost: 19310μs
ton-node-1  | LiteQuery::request_mc_block_data cost: 9μs. 
ton-node-1  | ValidatorManagerImpl::get_block_state_for_litequery schedule cost: 19319μs
ton-node-1  | LiteQuery::request_mc_block_state cost: 0μs. 
ton-node-1  | LiteQuery::request_mc_block_data_state cost: 30μs. 
ton-node-1  | ValidatorManagerImpl::get_block_data_from_db schedule cost: 30753μs
ton-node-1  | ValidatorManagerImpl::get_block_handle cost: 1μs. 
ton-node-1  | ValidatorManagerImpl::get_block_handle_for_litequery cost: 1μs. 
ton-node-1  | ValidatorManagerImpl::get_block_data_for_litequery cost: 3μs. 
ton-node-1  | ValidatorManagerImpl::get_shard_state_from_db schedule cost: 30886μs
ton-node-1  | ValidatorManagerImpl::get_block_handle cost: 1μs. 
ton-node-1  | ValidatorManagerImpl::get_block_handle_for_litequery cost: 1μs. 
ton-node-1  | ValidatorManagerImpl::get_block_state_for_litequery cost: 1μs. 
ton-node-1  | RootDb::get_block_data schedule cost: 9480μs
ton-node-1  | RootDb::get_block_state schedule cost: 9547μs
ton-node-1  | ValidatorManagerImpl::get_shard_state_from_db cost: 0μs. 
ton-node-1  | ArchiveManager::get_file schedule cost: 2197μs
ton-node-1  | RootDb::get_block_data cost: 0μs. 
ton-node-1  | CellDb::load_cell schedule cost: 1400909μs
ton-node-1  | RootDb::get_block_state cost: 4μs. 
ton-node-1  | ArchiveSlice::get_file schedule cost: 568μs
ton-node-1  | ArchiveManager::get_file cost: 1μs. 
ton-node-1  | PackageReader reader schedule cost: 20μs
ton-node-1  | ArchiveSlice::get_file cost: 8μs. 
ton-node-1  | LiteQuery::got_mc_block_data schedule cost: 56μs
ton-node-1  | PackageReader::start_up cost: 181μs. 
ton-node-1  | LiteQuery::got_mc_block_data cost: 0μs. 
ton-node-1  | LiteQuery::got_mc_block_state schedule cost: 1516μs
ton-node-1  | CellDb::load_cell cost: 1477μs. 
ton-node-1  | LiteQuery::finish_query cost: 6μs. 
```
We could see that `perform_getAccountState` cost 1463946μs totally, during which `CellDb::load_cell schedule` const 1400909μs. So the schedule of `CellDb::load_cell` wast most of the time.

## Fix
As we know, the task send to the same actor id is executed one by one. Since there's only one CellDb, so all the load cell operation will queued and executed one by one, but there are too many load cell operation waiting to be executed, that why the `CellDb::load_cell` schedule cost so much time.

So the solution is clear, we increased the number of CellDb objects to allow `CellDb::load_cell` calls to execute concurrently.

## Result
Below is our test result (the test method involves sending 5000 `GetAccountState` requests simultaneously, then recording the response time for each request, and finally calculating the number of timeout errors and the average response time).

before optimization：
```
request count: 5000. failed count: 3292. failed rate: 65.84%. avg cost: 3804ms
```
after optimization：
```
request count: 5000. failed count: 0. failed rate: 0.00%. avg cost: 1021ms
```

We can see that after enabling concurrent `CellDb::load_cell` calls, the average response time dropped from 3.8 seconds to around 1 second.