### PR TITLE
Improve readability of validator-engine-console commands

### DIFF
--- a/validator-engine-console/validator-engine-console-query.cpp
+++ b/validator-engine-console/validator-engine-console-query.cpp
@@ -1041,8 +1041,7 @@ td::Status ImportCertificateQuery::receive(td::BufferSlice data) {
 
 
 td::Status SignShardOverlayCertificateQuery::run() {
-  TRY_RESULT_ASSIGN(wc_, tokenizer_.get_token<td::int32>());
-  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<td::int64>() );
+  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<ton::ShardIdFull>() );
   TRY_RESULT_ASSIGN(key_, tokenizer_.get_token<ton::PublicKeyHash>());
   TRY_RESULT_ASSIGN(expire_at_, tokenizer_.get_token<td::int32>());
   TRY_RESULT_ASSIGN(max_size_, tokenizer_.get_token<td::uint32>());
@@ -1052,8 +1051,9 @@ td::Status SignShardOverlayCertificateQuery::run() {
 }
 
 td::Status SignShardOverlayCertificateQuery::send() {
-  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_signShardOverlayCertificate>
-             (wc_, shard_, ton::create_tl_object<ton::ton_api::engine_validator_keyHash>(key_.tl()), expire_at_, max_size_);
+  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_signShardOverlayCertificate>(
+      shard_.workchain, shard_.shard, ton::create_tl_object<ton::ton_api::engine_validator_keyHash>(key_.tl()),
+      expire_at_, max_size_);
   td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
   return td::Status::OK();
 }
@@ -1071,8 +1071,7 @@ td::Status SignShardOverlayCertificateQuery::receive(td::BufferSlice data) {
 }
 
 td::Status ImportShardOverlayCertificateQuery::run() {
-  TRY_RESULT_ASSIGN(wc_, tokenizer_.get_token<td::int32>());
-  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<td::int64>() );
+  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<ton::ShardIdFull>());
   TRY_RESULT_ASSIGN(key_, tokenizer_.get_token<ton::PublicKeyHash>());
   TRY_RESULT_ASSIGN(in_file_, tokenizer_.get_token<std::string>());
 
@@ -1083,8 +1082,9 @@ td::Status ImportShardOverlayCertificateQuery::send() {
   TRY_RESULT(data, td::read_file(in_file_));
   TRY_RESULT_PREFIX(cert, ton::fetch_tl_object<ton::ton_api::overlay_Certificate>(data.as_slice(), true),
                     "incorrect certificate");
-  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_importShardOverlayCertificate>
-             (wc_, shard_, ton::create_tl_object<ton::ton_api::engine_validator_keyHash>(key_.tl()), std::move(cert));
+  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_importShardOverlayCertificate>(
+      shard_.workchain, shard_.shard, ton::create_tl_object<ton::ton_api::engine_validator_keyHash>(key_.tl()),
+      std::move(cert));
   td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
   return td::Status::OK();
 }
@@ -1173,14 +1173,12 @@ td::Status GetPerfTimerStatsJsonQuery::receive(td::BufferSlice data) {
 }
 
 td::Status GetShardOutQueueSizeQuery::run() {
-  TRY_RESULT_ASSIGN(block_id_.workchain, tokenizer_.get_token<int>());
-  TRY_RESULT_ASSIGN(block_id_.shard, tokenizer_.get_token<long long>());
+  TRY_RESULT(shard, tokenizer_.get_token<ton::ShardIdFull>());
+  block_id_.workchain = shard.workchain;
+  block_id_.shard = shard.shard;
   TRY_RESULT_ASSIGN(block_id_.seqno, tokenizer_.get_token<int>());
   if (!tokenizer_.endl()) {
-    ton::ShardIdFull dest;
-    TRY_RESULT_ASSIGN(dest.workchain, tokenizer_.get_token<int>());
-    TRY_RESULT_ASSIGN(dest.shard, tokenizer_.get_token<long long>());
-    dest_ = dest;
+    TRY_RESULT_ASSIGN(dest_, tokenizer_.get_token<ton::ShardIdFull>());
   }
   TRY_STATUS(tokenizer_.check_endl());
   return td::Status::OK();
@@ -1188,8 +1186,7 @@ td::Status GetShardOutQueueSizeQuery::run() {
 
 td::Status GetShardOutQueueSizeQuery::send() {
   auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_getShardOutQueueSize>(
-      dest_ ? 1 : 0, ton::create_tl_block_id_simple(block_id_), dest_ ? dest_.value().workchain : 0,
-      dest_ ? dest_.value().shard : 0);
+      dest_.is_valid() ? 1 : 0, ton::create_tl_block_id_simple(block_id_), dest_.workchain, dest_.shard);
   td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
   return td::Status::OK();
 }
@@ -1563,14 +1560,13 @@ td::Status GetAdnlStatsQuery::receive(td::BufferSlice data) {
 }
 
 td::Status AddShardQuery::run() {
-  TRY_RESULT_ASSIGN(wc_, tokenizer_.get_token<td::int32>());
-  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<td::int64>());
+  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<ton::ShardIdFull>());
+  TRY_STATUS(tokenizer_.check_endl());
   return td::Status::OK();
 }
 
 td::Status AddShardQuery::send() {
-  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_addShard>(
-      ton::create_tl_shard_id(ton::ShardIdFull(wc_, shard_)));
+  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_addShard>(ton::create_tl_shard_id(shard_));
   td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
   return td::Status::OK();
 }
@@ -1583,14 +1579,13 @@ td::Status AddShardQuery::receive(td::BufferSlice data) {
 }
 
 td::Status DelShardQuery::run() {
-  TRY_RESULT_ASSIGN(wc_, tokenizer_.get_token<td::int32>());
-  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<td::int64>());
+  TRY_RESULT_ASSIGN(shard_, tokenizer_.get_token<ton::ShardIdFull>());
+  TRY_STATUS(tokenizer_.check_endl());
   return td::Status::OK();
 }
 
 td::Status DelShardQuery::send() {
-  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_delShard>(
-      ton::create_tl_shard_id(ton::ShardIdFull(wc_, shard_)));
+  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_delShard>(ton::create_tl_shard_id(shard_));
   td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
   return td::Status::OK();
 }

--- a/validator-engine-console/validator-engine-console-query.h
+++ b/validator-engine-console/validator-engine-console-query.h
@@ -36,6 +36,7 @@
 #include "ton/ton-types.h"
 
 #include "keys/keys.hpp"
+#include "td/utils/base64.h"
 
 class ValidatorEngineConsole;
 
@@ -95,27 +96,25 @@ inline td::Result<td::SharedSlice> Tokenizer::get_token() {
 }
 
 template <>
-inline td::Result<ton::PublicKeyHash> Tokenizer::get_token() {
-  TRY_RESULT(S, get_raw_token());
-  TRY_RESULT(F, td::hex_decode(S));
-  if (F.size() == 32) {
-    return ton::PublicKeyHash{td::Slice{F}};
+inline td::Result<td::Bits256> Tokenizer::get_token() {
+  TRY_RESULT(word, get_raw_token());
+  std::string data;
+  if (word.size() == 64) {
+    TRY_RESULT_ASSIGN(data, td::hex_decode(word));
+  } else if (word.size() == 44) {
+    TRY_RESULT_ASSIGN(data, td::base64_decode(word));
   } else {
     return td::Status::Error("cannot parse keyhash: bad length");
   }
+  td::Bits256 v;
+  v.as_slice().copy_from(data);
+  return v;
 }
 
 template <>
-inline td::Result<td::Bits256> Tokenizer::get_token() {
-  TRY_RESULT(S, get_raw_token());
-  TRY_RESULT(F, td::hex_decode(S));
-  if (F.size() == 32) {
-    td::Bits256 v;
-    v.as_slice().copy_from(F);
-    return v;
-  } else {
-    return td::Status::Error("cannot parse keyhash: bad length");
-  }
+inline td::Result<ton::PublicKeyHash> Tokenizer::get_token() {
+  TRY_RESULT(x, get_token<td::Bits256>());
+  return ton::PublicKeyHash{x};
 }
 
 template <>
@@ -144,6 +143,18 @@ inline td::Result<std::vector<T>> Tokenizer::get_token_vector() {
     TRY_RESULT(val, get_token<T>());
     res.push_back(std::move(val));
   }
+}
+
+template <>
+inline td::Result<ton::ShardIdFull> Tokenizer::get_token() {
+  TRY_RESULT(word, get_raw_token());
+  auto r_wc = td::to_integer_safe<ton::WorkchainId>(word);
+  if (r_wc.is_ok()) {
+    TRY_RESULT_ASSIGN(word, get_raw_token());
+    TRY_RESULT(shard, td::to_integer_safe<ton::ShardId>(word));
+    return ton::ShardIdFull{r_wc.move_as_ok(), shard};
+  }
+  return ton::ShardIdFull::parse(word);
 }
 
 class QueryRunner {
@@ -222,10 +233,10 @@ class GetTimeQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice R) override;
   static std::string get_name() {
-    return "gettime";
+    return "get-time";
   }
   static std::string get_help() {
-    return "gettime\tshows current server unixtime";
+    return "get-time\tshows current server unixtime";
   }
   std::string name() const override {
     return get_name();
@@ -287,10 +298,10 @@ class NewKeyQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice R) override;
   static std::string get_name() {
-    return "newkey";
+    return "new-key";
   }
   static std::string get_help() {
-    return "newkey\tgenerates new key pair on server";
+    return "new-key\tgenerates new key pair on server";
   }
   std::string name() const override {
     return get_name();
@@ -308,10 +319,10 @@ class ImportPrivateKeyFileQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice R) override;
   static std::string get_name() {
-    return "importf";
+    return "import-f";
   }
   static std::string get_help() {
-    return "importf <filename>\timport private key";
+    return "import-f <filename>\timport private key";
   }
   std::string name() const override {
     return get_name();
@@ -330,10 +341,10 @@ class ExportPublicKeyQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice R) override;
   static std::string get_name() {
-    return "exportpub";
+    return "export-pub";
   }
   static std::string get_help() {
-    return "exportpub <keyhash>\texports public key by key hash";
+    return "export-pub <keyhash>\texports public key by key hash";
   }
   std::string name() const override {
     return get_name();
@@ -352,10 +363,10 @@ class ExportPublicKeyFileQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice R) override;
   static std::string get_name() {
-    return "exportpubf";
+    return "export-pubf";
   }
   static std::string get_help() {
-    return "exportpubf <keyhash> <filename>\texports public key by key hash";
+    return "export-pub-f <keyhash> <filename>\texports public key by key hash";
   }
   std::string name() const override {
     return get_name();
@@ -398,10 +409,10 @@ class SignFileQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "signf";
+    return "sign-f";
   }
   static std::string get_help() {
-    return "signf <keyhash> <infile> <outfile>\tsigns bytestring with privkey";
+    return "sign-f <keyhash> <infile> <outfile>\tsigns bytestring with privkey";
   }
   std::string name() const override {
     return get_name();
@@ -422,10 +433,10 @@ class ExportAllPrivateKeysQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice R) override;
   static std::string get_name() {
-    return "exportallprivatekeys";
+    return "export-all-private-keys";
   }
   static std::string get_help() {
-    return "exportallprivatekeys <directory>\texports all private keys from validator engine and stores them to "
+    return "export-all-private-keys <directory>\texports all private keys from validator engine and stores them to "
            "<directory>";
   }
   std::string name() const override {
@@ -446,10 +457,10 @@ class AddAdnlAddrQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addadnl";
+    return "add-adnl";
   }
   static std::string get_help() {
-    return "addadnl <keyhash> <category>\tuse key as ADNL addr";
+    return "add-adnl <keyhash> <category>\tuse key as ADNL addr";
   }
   std::string name() const override {
     return get_name();
@@ -469,10 +480,10 @@ class AddDhtIdQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "adddht";
+    return "add-dht";
   }
   static std::string get_help() {
-    return "adddht <keyhash>\tcreate DHT node with specified ADNL addr";
+    return "add-dht <keyhash>\tcreate DHT node with specified ADNL addr";
   }
   std::string name() const override {
     return get_name();
@@ -491,10 +502,10 @@ class AddValidatorPermanentKeyQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addpermkey";
+    return "add-perm-key";
   }
   static std::string get_help() {
-    return "addpermkey <keyhash> <election-date> <expire-at>\tadd validator permanent key";
+    return "add-perm-key <keyhash> <election-date> <expire-at>\tadd validator permanent key";
   }
   std::string name() const override {
     return get_name();
@@ -515,10 +526,10 @@ class AddValidatorTempKeyQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addtempkey";
+    return "add-temp-key";
   }
   static std::string get_help() {
-    return "addtempkey <permkeyhash> <keyhash> <expireat>\tadd validator temp key";
+    return "add-temp-key <permkeyhash> <keyhash> <expireat>\tadd validator temp key";
   }
   std::string name() const override {
     return get_name();
@@ -539,10 +550,10 @@ class AddValidatorAdnlAddrQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addvalidatoraddr";
+    return "add-validator-addr";
   }
   static std::string get_help() {
-    return "addvalidatoraddr <permkeyhash> <keyhash> <expireat>\tadd validator ADNL addr";
+    return "add-validator-addr <permkeyhash> <keyhash> <expireat>\tadd validator ADNL addr";
   }
   std::string name() const override {
     return get_name();
@@ -563,10 +574,10 @@ class ChangeFullNodeAdnlAddrQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "changefullnodeaddr";
+    return "change-full-node-addr";
   }
   static std::string get_help() {
-    return "changefullnodeaddr <keyhash>\tchanges fullnode ADNL address";
+    return "change-full-node-addr <keyhash>\tchanges fullnode ADNL address";
   }
   std::string name() const override {
     return get_name();
@@ -585,10 +596,10 @@ class AddLiteServerQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addliteserver";
+    return "add-liteserver";
   }
   static std::string get_help() {
-    return "addliteserver <port> <keyhash>\tadd liteserver";
+    return "add-liteserver <port> <keyhash>\tadd liteserver";
   }
   std::string name() const override {
     return get_name();
@@ -608,10 +619,10 @@ class DelAdnlAddrQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "deladnl";
+    return "del-adnl";
   }
   static std::string get_help() {
-    return "deladnl <keyhash>\tdel unused ADNL addr";
+    return "del-adnl <keyhash>\tdel unused ADNL addr";
   }
   std::string name() const override {
     return get_name();
@@ -630,10 +641,10 @@ class DelDhtIdQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "deldht";
+    return "del-dht";
   }
   static std::string get_help() {
-    return "deldht <keyhash>\tdel unused DHT node";
+    return "del-dht <keyhash>\tdel unused DHT node";
   }
   std::string name() const override {
     return get_name();
@@ -652,10 +663,10 @@ class DelValidatorPermanentKeyQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "delpermkey";
+    return "del-perm-key";
   }
   static std::string get_help() {
-    return "delpermkey <keyhash>\tforce del unused validator permanent key";
+    return "del-perm-key <keyhash>\tforce del unused validator permanent key";
   }
   std::string name() const override {
     return get_name();
@@ -674,10 +685,10 @@ class DelValidatorTempKeyQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "deltempkey";
+    return "del-temp-key";
   }
   static std::string get_help() {
-    return "deltempkey <permkeyhash> <keyhash>\tforce del unused validator temp key";
+    return "del-temp-key <permkeyhash> <keyhash>\tforce del unused validator temp key";
   }
   std::string name() const override {
     return get_name();
@@ -697,10 +708,10 @@ class DelValidatorAdnlAddrQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "delvalidatoraddr";
+    return "del-validator-addr";
   }
   static std::string get_help() {
-    return "delvalidatoraddr <permkeyhash> <keyhash>\tforce del unused validator ADNL addr";
+    return "del-validator-addr <permkeyhash> <keyhash>\tforce del unused validator ADNL addr";
   }
   std::string name() const override {
     return get_name();
@@ -720,10 +731,10 @@ class GetConfigQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getconfig";
+    return "get-config";
   }
   static std::string get_help() {
-    return "getconfig\tdownloads current config";
+    return "get-config\tdownloads current config";
   }
   std::string name() const override {
     return get_name();
@@ -741,10 +752,10 @@ class SetVerbosityQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "setverbosity";
+    return "set-verbosity";
   }
   static std::string get_help() {
-    return "setverbosity <value>\tchanges verbosity level";
+    return "set-verbosity <value>\tchanges verbosity level";
   }
   std::string name() const override {
     return get_name();
@@ -763,10 +774,10 @@ class GetStatsQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getstats";
+    return "get-stats";
   }
   static std::string get_help() {
-    return "getstats\tprints stats";
+    return "get-stats\tprints stats";
   }
   std::string name() const override {
     return get_name();
@@ -807,10 +818,10 @@ class AddNetworkAddressQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addaddr";
+    return "add-addr";
   }
   static std::string get_help() {
-    return "addaddr <ip> {cats...} {priocats...}\tadds ip address to address list";
+    return "add-addr <ip> {cats...} {priocats...}\tadds ip address to address list";
   }
   std::string name() const override {
     return get_name();
@@ -831,10 +842,10 @@ class AddNetworkProxyAddressQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addproxyaddr";
+    return "add-proxy-addr";
   }
   static std::string get_help() {
-    return "addproxyaddr <inip> <outip> <id> <secret> {cats...} {priocats...}\tadds ip address to address list";
+    return "add-proxy-addr <inip> <outip> <id> <secret> {cats...} {priocats...}\tadds ip address to address list";
   }
   std::string name() const override {
     return get_name();
@@ -858,10 +869,10 @@ class CreateElectionBidQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "createelectionbid";
+    return "create-election-bid";
   }
   static std::string get_help() {
-    return "createelectionbid <date> <elector> <wallet> <fname>\tcreate election bid";
+    return "create-election-bid <date> <elector> <wallet> <fname>\tcreate election bid";
   }
   std::string name() const override {
     return get_name();
@@ -883,10 +894,10 @@ class CreateProposalVoteQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "createproposalvote";
+    return "create-proposal-vote";
   }
   static std::string get_help() {
-    return "createproposalvote <data> <fname>\tcreate proposal vote";
+    return "create-proposal-vote <data> <fname>\tcreate proposal vote";
   }
   std::string name() const override {
     return get_name();
@@ -906,10 +917,10 @@ class CreateComplaintVoteQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "createcomplaintvote";
+    return "create-complaint-vote";
   }
   static std::string get_help() {
-    return "createcomplaintvote <election-id> <data> <fname>\tcreate proposal vote";
+    return "create-complaint-vote <election-id> <data> <fname>\tcreate proposal vote";
   }
   std::string name() const override {
     return get_name();
@@ -930,10 +941,10 @@ class CheckDhtServersQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "checkdht";
+    return "check-dht";
   }
   static std::string get_help() {
-    return "checkdht <adnlid>\tchecks, which root DHT servers are accessible from this ADNL addr";
+    return "check-dht <adnlid>\tchecks, which root DHT servers are accessible from this ADNL addr";
   }
   std::string name() const override {
     return get_name();
@@ -952,10 +963,10 @@ class GetOverlaysStatsQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getoverlaysstats";
+    return "get-overlays-stats";
   }
   static std::string get_help() {
-    return "getoverlaysstats\tgets stats for all overlays";
+    return "get-overlays-stats\tgets stats for all overlays";
   }
   std::string name() const override {
     return get_name();
@@ -971,10 +982,10 @@ class GetOverlaysStatsJsonQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getoverlaysstatsjson";
+    return "get-overlays-stats-json";
   }
   static std::string get_help() {
-    return "getoverlaysstatsjson <outfile>\tgets stats for all overlays and writes to json file";
+    return "get-overlays-stats-json <outfile>\tgets stats for all overlays and writes to json file";
   }
   std::string name() const override {
     return get_name();
@@ -993,10 +1004,11 @@ class SignCertificateQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "signcert";
+    return "sign-cert";
   }
   static std::string get_help() {
-    return "signcert <overlayid> <adnlid> <expireat> <maxsize> <signwith> <outfile>\tsign overlay certificate by <signwith> key";
+    return "sign-cert <overlayid> <adnlid> <expireat> <maxsize> <signwith> <outfile>\tsign overlay certificate by "
+           "<signwith> key";
   }
   std::string name() const override {
     return get_name();
@@ -1029,10 +1041,10 @@ class ImportCertificateQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "importcert";
+    return "import-cert";
   }
   static std::string get_help() {
-    return "importcert <overlayid> <adnlid> <key> <certfile>\timport overlay certificate for specific key";
+    return "import-cert <overlayid> <adnlid> <key> <certfile>\timport overlay certificate for specific key";
   }
   std::string name() const override {
     return get_name();
@@ -1054,10 +1066,11 @@ class SignShardOverlayCertificateQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "signshardoverlaycert";
+    return "sign-shard-overlay-cert";
   }
   static std::string get_help() {
-    return "signshardoverlaycert <workchain> <shardprefix> <key> <expireat> <maxsize> <outfile>\tsign certificate for <key> in currently active shard overlay";
+    return "sign-shard-overlay-cert <wc>:<shard> <key> <expireat> <maxsize> <outfile>\tsign certificate "
+           "for <key> in currently active shard overlay";
   }
   std::string name() const override {
     return get_name();
@@ -1065,8 +1078,7 @@ class SignShardOverlayCertificateQuery : public Query {
 
  private:
 
-  td::int32 wc_;
-  td::int64 shard_;
+  ton::ShardIdFull shard_;
   td::int32 expire_at_;
   ton::PublicKeyHash key_;
   td::uint32 max_size_;
@@ -1083,10 +1095,11 @@ class ImportShardOverlayCertificateQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "importshardoverlaycert";
+    return "import-shard-overlay-cert";
   }
   static std::string get_help() {
-    return "importshardoverlaycert <workchain> <shardprefix> <key> <certfile>\timport certificate for <key> in currently active shard overlay";
+    return "import-shard-overlay-cert <wc>:<shard> <key> <certfile>\timport certificate for <key> in "
+           "currently active shard overlay";
   }
   std::string name() const override {
     return get_name();
@@ -1094,8 +1107,7 @@ class ImportShardOverlayCertificateQuery : public Query {
 
  private:
 
-  td::int32 wc_;
-  td::int64 shard_;
+  ton::ShardIdFull shard_;
   ton::PublicKeyHash key_;
   std::string in_file_;
 };
@@ -1109,10 +1121,10 @@ class GetActorStatsQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getactorstats";
+    return "get-actor-stats";
   }
   static std::string get_help() {
-    return "getactorstats [<outfile>]\tget actor stats and print it either in stdout or in <outfile>";
+    return "get-actor-stats [<outfile>]\tget actor stats and print it either in stdout or in <outfile>";
   }
   std::string name() const override {
     return get_name();
@@ -1131,10 +1143,11 @@ class GetPerfTimerStatsJsonQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getperftimerstatsjson";
+    return "get-perf-timer-stats-json";
   }
   static std::string get_help() {
-    return "getperftimerstatsjson <outfile>\tgets min, average and max event processing time for last 60, 300 and 3600 seconds and writes to json file";
+    return "get-perf-timer-stats-json <outfile>\tgets min, average and max event processing time for last 60, 300 and "
+           "3600 seconds and writes to json file";
   }
   std::string name() const override {
     return get_name();
@@ -1153,10 +1166,10 @@ class GetShardOutQueueSizeQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getshardoutqueuesize";
+    return "get-shard-out-queue-size";
   }
   static std::string get_help() {
-    return "getshardoutqueuesize <wc> <shard> <seqno> [<dest_wc> <dest_shard>]\treturns number of messages in the "
+    return "get-shard-out-queue-size <wc>:<shard> <seqno> [<dest_wc>:<dest_shard>]\treturns number of messages in the "
            "queue of the given shard. Destination shard is optional.";
   }
   std::string name() const override {
@@ -1165,7 +1178,7 @@ class GetShardOutQueueSizeQuery : public Query {
 
  private:
   ton::BlockId block_id_;
-  td::optional<ton::ShardIdFull> dest_;
+  ton::ShardIdFull dest_ = ton::ShardIdFull{ton::workchainInvalid};
 };
 
 class SetExtMessagesBroadcastDisabledQuery : public Query {
@@ -1177,11 +1190,11 @@ class SetExtMessagesBroadcastDisabledQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "setextmessagesbroadcastdisabled";
+    return "set-ext-messages-broadcast-disabled";
   }
   static std::string get_help() {
-    return "setextmessagesbroadcastdisabled <value>\tdisable broadcasting and rebroadcasting ext messages; value is 0 "
-           "or 1.";
+    return "set-ext-messages-broadcast-disabled <value>\tdisable broadcasting and rebroadcasting ext messages; value "
+           "is 0 or 1.";
   }
   std::string name() const override {
     return get_name();
@@ -1200,10 +1213,10 @@ class AddCustomOverlayQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addcustomoverlay";
+    return "add-custom-overlay";
   }
   static std::string get_help() {
-    return "addcustomoverlay <filename>\tadd custom overlay with config from file <filename>";
+    return "add-custom-overlay <filename>\tadd custom overlay with config from file <filename>";
   }
   std::string name() const override {
     return get_name();
@@ -1222,10 +1235,10 @@ class DelCustomOverlayQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "delcustomoverlay";
+    return "del-custom-overlay";
   }
   static std::string get_help() {
-    return "delcustomoverlay <name>\tdelete custom overlay with name <name>";
+    return "del-custom-overlay <name>\tdelete custom overlay with name <name>";
   }
   std::string name() const override {
     return get_name();
@@ -1244,10 +1257,10 @@ class ShowCustomOverlaysQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "showcustomoverlays";
+    return "show-custom-overlays";
   }
   static std::string get_help() {
-    return "showcustomoverlays\tshow all custom overlays";
+    return "show-custom-overlays\tshow all custom overlays";
   }
   std::string name() const override {
     return get_name();
@@ -1263,10 +1276,10 @@ class SetStateSerializerEnabledQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "setstateserializerenabled";
+    return "set-state-serializer-enabled";
   }
   static std::string get_help() {
-    return "setstateserializerenabled <value>\tdisable or enable persistent state serializer; value is 0 or 1";
+    return "set-state-serializer-enabled <value>\tdisable or enable persistent state serializer; value is 0 or 1";
   }
   std::string name() const override {
     return get_name();
@@ -1285,10 +1298,10 @@ class SetCollatorOptionsJsonQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "setcollatoroptionsjson";
+    return "set-collator-options-json";
   }
   static std::string get_help() {
-    return "setcollatoroptionsjson <filename>\tset collator options from file <filename>";
+    return "set-collator-options-json <filename>\tset collator options from file <filename>";
   }
   std::string name() const override {
     return get_name();
@@ -1307,10 +1320,10 @@ class ResetCollatorOptionsQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "resetcollatoroptions";
+    return "reset-collator-options";
   }
   static std::string get_help() {
-    return "resetcollatoroptions\tset collator options to default values";
+    return "reset-collator-options\tset collator options to default values";
   }
   std::string name() const override {
     return get_name();
@@ -1326,10 +1339,10 @@ class GetCollatorOptionsJsonQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getcollatoroptionsjson";
+    return "get-collator-options-json";
   }
   static std::string get_help() {
-    return "getcollatoroptionsjson <filename>\tsave current collator options to file <filename>";
+    return "get-collator-options-json <filename>\tsave current collator options to file <filename>";
   }
   std::string name() const override {
     return get_name();
@@ -1348,11 +1361,11 @@ class GetAdnlStatsJsonQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getadnlstatsjson";
+    return "get-adnl-stats-json";
   }
   static std::string get_help() {
-    return "getadnlstatsjson <filename> [all]\tsave adnl stats to <filename>. all - returns all peers (default - only "
-           "peers with traffic in the last 10 minutes)";
+    return "get-adnl-stats-json <filename> [all]\tsave adnl stats to <filename>. all - returns all peers (default - "
+           "only peers with traffic in the last 10 minutes)";
   }
   std::string name() const override {
     return get_name();
@@ -1372,11 +1385,11 @@ class GetAdnlStatsQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "getadnlstats";
+    return "get-adnl-stats";
   }
   static std::string get_help() {
-    return "getadnlstats [all]\tdisplay adnl stats. all - returns all peers (default - only peers with traffic in the "
-           "last 10 minutes)";
+    return "get-adnl-stats [all]\tdisplay adnl stats. all - returns all peers (default - only peers with traffic in "
+           "the last 10 minutes)";
   }
   std::string name() const override {
     return get_name();
@@ -1396,18 +1409,17 @@ class AddShardQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "addshard";
+    return "add-shard";
   }
   static std::string get_help() {
-    return "addshard <workchain> <shard>\tstart monitoring shard";
+    return "add-shard <wc>:<shard>\tstart monitoring shard";
   }
   std::string name() const override {
     return get_name();
   }
 
  private:
-  td::int32 wc_;
-  td::int64 shard_;
+  ton::ShardIdFull shard_;
 };
 
 class DelShardQuery : public Query {
@@ -1419,16 +1431,15 @@ class DelShardQuery : public Query {
   td::Status send() override;
   td::Status receive(td::BufferSlice data) override;
   static std::string get_name() {
-    return "delshard";
+    return "del-shard";
   }
   static std::string get_help() {
-    return "delshard <workchain> <shard>\tstop monitoring shard";
+    return "del-shard <wc>:<shard>\tstop monitoring shard";
   }
   std::string name() const override {
     return get_name();
   }
 
  private:
-  td::int32 wc_;
-  td::int64 shard_;
+  ton::ShardIdFull shard_;
 };

--- a/validator-engine-console/validator-engine-console.cpp
+++ b/validator-engine-console/validator-engine-console.cpp
@@ -206,9 +206,8 @@ void ValidatorEngineConsole::show_help(std::string command, td::Promise<td::Buff
       td::TerminalIO::out() << cmd.second->help() << "\n";
     }
   } else {
-    auto it = query_runners_.find(command);
-    if (it != query_runners_.end()) {
-      td::TerminalIO::out() << it->second->help() << "\n";
+    if (auto query = get_query(command)) {
+      td::TerminalIO::out() << query->help() << "\n";
     } else {
       td::TerminalIO::out() << "unknown command '" << command << "'\n";
     }
@@ -232,10 +231,9 @@ void ValidatorEngineConsole::parse_line(td::BufferSlice data) {
   }
   auto name = tokenizer.get_token<std::string>().move_as_ok();
 
-  auto it = query_runners_.find(name);
-  if (it != query_runners_.end()) {
+  if (auto query = get_query(name)) {
     running_queries_++;
-    it->second->run(actor_id(this), std::move(tokenizer));
+    query->run(actor_id(this), std::move(tokenizer));
   } else {
     td::TerminalIO::out() << "unknown command '" << name << "'\n";
   }

--- a/validator-engine-console/validator-engine-console.h
+++ b/validator-engine-console/validator-engine-console.h
@@ -57,9 +57,23 @@ class ValidatorEngineConsole : public td::actor::Actor {
   std::unique_ptr<ton::adnl::AdnlExtClient::Callback> make_callback();
 
   std::map<std::string, std::unique_ptr<QueryRunner>> query_runners_;
+  std::map<std::string, std::string> alternate_names_;
+  static std::string simplify_name(std::string name) {
+    std::erase_if(name, [](char c) { return c == '-'; });
+    return name;
+  }
   void add_query_runner(std::unique_ptr<QueryRunner> runner) {
     auto name = runner->name();
     query_runners_[name] = std::move(runner);
+    alternate_names_[simplify_name(name)] = name;
+  }
+  QueryRunner* get_query(std::string name) {
+    auto it = alternate_names_.find(name);
+    if (it != alternate_names_.end()) {
+      name = it->second;
+    }
+    auto it2 = query_runners_.find(name);
+    return it2 == query_runners_.end() ? nullptr : it2->second.get();
   }
 
  public:


### PR DESCRIPTION
1. Add dashes to command names (old names still work for compatibility)
2. Better shard format (0:8000000000000000 instead of 0 -9223372036854775808)
3. Allow base64 in some parameters