### PR TITLE
Fix saving `с0` on deep jump

### DIFF
--- a/crypto/vm/vm.cpp
+++ b/crypto/vm/vm.cpp
@@ -257,6 +257,11 @@ int VmState::jump(Ref<Continuation> cont) {
 
 // general jump to continuation cont
 int VmState::jump(Ref<Continuation> cont, int pass_args) {
+  cont = adjust_jump_cont(std::move(cont), pass_args);
+  return jump_to(std::move(cont));
+}
+
+Ref<Continuation> VmState::adjust_jump_cont(Ref<Continuation> cont, int pass_args) {
   const ControlData* cont_data = cont->get_cdata();
   if (cont_data) {
     // first do the checks
@@ -297,7 +302,7 @@ int VmState::jump(Ref<Continuation> cont, int pass_args) {
         consume_stack_gas(copy);
       }
     }
-    return jump_to(std::move(cont));
+    return cont;
   } else {
     // have no continuation data, situation is somewhat simpler
     if (pass_args >= 0) {
@@ -309,7 +314,7 @@ int VmState::jump(Ref<Continuation> cont, int pass_args) {
         consume_stack_gas(pass_args);
       }
     }
-    return jump_to(std::move(cont));
+    return cont;
   }
 }
 

--- a/crypto/vm/vm.h
+++ b/crypto/vm/vm.h
@@ -352,6 +352,7 @@ class VmState final : public VmStateInterface {
   int call(Ref<Continuation> cont, int pass_args, int ret_args = -1);
   int jump(Ref<Continuation> cont);
   int jump(Ref<Continuation> cont, int pass_args);
+  Ref<Continuation> adjust_jump_cont(Ref<Continuation> cont, int pass_args);
   int ret();
   int ret(int ret_args);
   int ret_alt();
@@ -378,6 +379,14 @@ class VmState final : public VmStateInterface {
       cnt++;
       if (cnt > free_nested_cont_jump && global_version >= 9) {
         consume_gas(1);
+      }
+
+      if (cont.not_null()) {
+        const ControlData* cont_data = cont->get_cdata();
+        if (cont_data && (cont_data->stack.not_null() || cont_data->nargs >= 0)) {
+          // if cont has non-empty stack or expects fixed number of arguments, jump is not simple
+          cont = adjust_jump_cont(std::move(cont), -1);
+        }
       }
     }
     return res;


### PR DESCRIPTION
Before b5734d2e30b9c93cfdacb4ea37c9ebdf11ca5d49 the following code produced an empty stack after the execution:

```fif
"Asm.fif" include

<{
    CONT:<{
        4 PUSHINT
        REPEATEND
        1 INT
        DUMPSTK
    }>
    0 0 CALLXARGS
    DUMPSTK
}>s

100000 8 runvmx .s
``` 

> * `DApr` — `CALLXARGS p,r` `(c – )`, calls continuation `c` with `p` parameters and expecting `r` return values, `0 ≤ p ≤ 15`, `0 ≤ r ≤ 15`.

<details>
  <summary>Before (expected to be correct, see the docs quote above)</summary>

```
#DEBUG#: stack(1 values) : 1 
#DEBUG#: stack(2 values) : 1 1 
#DEBUG#: stack(3 values) : 1 1 1 
#DEBUG#: stack(4 values) : 1 1 1 1 
#DEBUG#: stack(0 values) : 
[ 3][t 0][2025-01-21 01:05:16.385535784][vm.cpp:606]    steps: 18 gas: used=307, max=100000, limit=100000, credit=0
0 307
```

</details>

<details>
  <summary>After (seems to be incorrect)</summary>

```
#DEBUG#: stack(1 values) : 1 
#DEBUG#: stack(2 values) : 1 1 
#DEBUG#: stack(3 values) : 1 1 1 
#DEBUG#: stack(4 values) : 1 1 1 1 
#DEBUG#: stack(4 values) : 1 1 1 1 
[ 3][t 0][2025-01-21 01:04:49.914613416][vm.cpp:601]    steps: 18 gas: used=307, max=100000, limit=100000, credit=0
1 1 1 1 0 307
```

</details>

But since it was changed to a non-recursive flow, it doesn't respect a continuation control data:
https://github.com/ton-blockchain/ton/blob/1b7c46f4961422d99ededd576484dfe235220af8/crypto/vm/vm.h#L374-L384

I moved this adjustment logic into a separate method which is now called both from direct jump and on its deep version.