### PR TITLE
Fix BUILD_SHARED_LIBS issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS FALSE)
 
 #BEGIN internal
+option(BUILD_SHARED_LIBS "Use \"ON\" to build shared libraries instead of static where it's not specified (not recommended)" OFF)
 option(USE_EMSCRIPTEN "Use \"ON\" for config building wasm." OFF)
 option(TON_ONLY_TONLIB "Use \"ON\" to build only tonlib." OFF)
 if (USE_EMSCRIPTEN)

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-option(BUILD_SHARED_LIBS "Use \"OFF\" for a static build." ON)
-
 if (NOT OPENSSL_FOUND)
   find_package(OpenSSL REQUIRED)
 endif()
@@ -9,11 +7,6 @@ endif()
 set(EMULATOR_STATIC_SOURCE
   transaction-emulator.cpp
   tvm-emulator.hpp
-)
-
-set(EMULATOR_HEADERS 
-  transaction-emulator.h
-  emulator-extern.h
 )
 
 set(EMULATOR_SOURCE
@@ -29,10 +22,10 @@ include(GenerateExportHeader)
 add_library(emulator_static STATIC ${EMULATOR_STATIC_SOURCE})
 target_link_libraries(emulator_static PUBLIC ton_crypto smc-envelope)
 
-if (NOT USE_EMSCRIPTEN AND BUILD_SHARED_LIBS)
-  add_library(emulator SHARED ${EMULATOR_SOURCE} ${EMULATOR_HEADERS})
+if (USE_EMSCRIPTEN)
+  add_library(emulator STATIC ${EMULATOR_SOURCE})
 else()
-  add_library(emulator STATIC ${EMULATOR_SOURCE} ${EMULATOR_HEADERS})
+  add_library(emulator SHARED ${EMULATOR_SOURCE})
 endif()
 
 if (PORTABLE AND NOT APPLE)
@@ -42,6 +35,9 @@ else()
 endif()
 
 generate_export_header(emulator EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/emulator_export.h)
+if (USE_EMSCRIPTEN)
+  target_compile_definitions(emulator PUBLIC EMULATOR_STATIC_DEFINE)
+endif()
 target_include_directories(emulator PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/tonlib/CMakeLists.txt
+++ b/tonlib/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-option(BUILD_SHARED_LIBS "Use \"OFF\" for a static build." ON)
-
 if (NOT OPENSSL_FOUND)
   find_package(OpenSSL REQUIRED)
 endif()
@@ -92,10 +90,10 @@ set(TONLIB_JSON_HEADERS tonlib/tonlib_client_json.h)
 set(TONLIB_JSON_SOURCE tonlib/tonlib_client_json.cpp)
 
 include(GenerateExportHeader)
-if (NOT USE_EMSCRIPTEN AND BUILD_SHARED_LIBS)
-  add_library(tonlibjson SHARED ${TONLIB_JSON_SOURCE} ${TONLIB_JSON_HEADERS})
+if (USE_EMSCRIPTEN)
+  add_library(tonlibjson STATIC ${TONLIB_JSON_SOURCE})
 else()
-  add_library(tonlibjson STATIC ${TONLIB_JSON_SOURCE} ${TONLIB_JSON_HEADERS})
+  add_library(tonlibjson SHARED ${TONLIB_JSON_SOURCE})
 endif()
 
 if (PORTABLE AND NOT APPLE)
@@ -105,7 +103,7 @@ else()
 endif()
 
 generate_export_header(tonlibjson EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/tonlib/tonlibjson_export.h)
-if (!BUILD_SHARED_LIBS)
+if (USE_EMSCRIPTEN)
   target_compile_definitions(tonlibjson PUBLIC TONLIBJSON_STATIC_DEFINE)
 endif()
 target_include_directories(tonlibjson PUBLIC
@@ -159,7 +157,7 @@ endif()
 
 install(FILES ${TONLIB_JSON_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/tonlib/tonlibjson_export.h DESTINATION include/tonlib/)
 
-if (NOT USE_EMSCRIPTEN AND BUILD_SHARED_LIBS)
+if (NOT USE_EMSCRIPTEN)
   install(EXPORT Tonlib
     FILE TonlibTargets.cmake
     NAMESPACE Tonlib::


### PR DESCRIPTION
In case `cmake` is called several times `BUILD_SHARED_LIBS` variable sets to `ON` which causes building dependencies as shared libraries (e.g. absl libs), which is undesirable. To fix it BUILD_SHARED_LIBS [should be set to `OFF` in top level ](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) CMakeLists.txt.