### PR TITLE
Suppress clang warning "ATOMIC_FLAG_INIT marked deprecated"

### DIFF
--- a/tdutils/td/utils/SpinLock.h
+++ b/tdutils/td/utils/SpinLock.h
@@ -63,7 +63,10 @@ class SpinLock {
   }
 
  private:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-pragma"
   std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
+#pragma clang diagnostic pop
   void unlock() {
     flag_.clear(std::memory_order_release);
   }

--- a/tdutils/td/utils/logging.cpp
+++ b/tdutils/td/utils/logging.cpp
@@ -176,7 +176,10 @@ void TsCerr::enterCritical() {
 void TsCerr::exitCritical() {
   lock_.clear(std::memory_order_release);
 }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-pragma"
 TsCerr::Lock TsCerr::lock_ = ATOMIC_FLAG_INIT;
+#pragma clang diagnostic pop
 
 class DefaultLog : public LogInterface {
  public:

--- a/tdutils/td/utils/logging.h
+++ b/tdutils/td/utils/logging.h
@@ -343,7 +343,10 @@ class TsLog : public LogInterface {
 
  private:
   LogInterface *log_ = nullptr;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-pragma"
   std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
+#pragma clang diagnostic pop
   void enter_critical() {
     while (lock_.test_and_set(std::memory_order_acquire)) {
       // spin

--- a/tdutils/td/utils/port/detail/PollableFd.h
+++ b/tdutils/td/utils/port/detail/PollableFd.h
@@ -149,7 +149,10 @@ class PollableFdInfo : private ListNode {
 
  private:
   NativeFd fd_{};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-pragma"
   std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
+#pragma clang diagnostic pop
   PollFlagsSet flags_;
 #if TD_PORT_WINDOWS
   SpinLock observer_lock_;


### PR DESCRIPTION
In C++20, macro `ATOMIC_FLAG_INIT` has been marked as deprecated. We need still to use it to be able to compile for C++17 (its absence is not the fix, this behavior changed in C++20 only). 
Since it's present in a header file, it produces lots of warnings throughout all compilation process (for clang under mac and in wasm compilation).
For now, just suppress this warning for clang.
