### PR TITLE
Enable bloom filters for CellDB

### DIFF
--- a/tddb/td/db/RocksDb.cpp
+++ b/tddb/td/db/RocksDb.cpp
@@ -82,6 +82,12 @@ Result<RocksDb> RocksDb::open(std::string path, RocksDbOptions options) {
   }
   if (options.enable_bloom_filter) {
     table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
+    if (options.two_level_index_and_filter) {
+      table_options.index_type = rocksdb::BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+      table_options.partition_filters = true;
+      table_options.cache_index_and_filter_blocks = true;
+      table_options.pin_l0_filter_and_index_blocks_in_cache = true;
+    }
   }
   db_options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
 

--- a/tddb/td/db/RocksDb.cpp
+++ b/tddb/td/db/RocksDb.cpp
@@ -24,9 +24,8 @@
 #include "rocksdb/write_batch.h"
 #include "rocksdb/utilities/optimistic_transaction_db.h"
 #include "rocksdb/utilities/transaction.h"
+#include "rocksdb/filter_policy.h"
 #include "td/utils/misc.h"
-
-#include <rocksdb/filter_policy.h>
 
 namespace td {
 namespace {
@@ -80,6 +79,9 @@ Result<RocksDb> RocksDb::open(std::string path, RocksDbOptions options) {
     table_options.no_block_cache = true;
   } else {
     table_options.block_cache = options.block_cache;
+  }
+  if (options.enable_bloom_filter) {
+    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
   }
   db_options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
 

--- a/tddb/td/db/RocksDb.h
+++ b/tddb/td/db/RocksDb.h
@@ -76,6 +76,7 @@ struct RocksDbOptions {
   bool use_direct_reads = false;
   bool no_block_cache = false;
   bool enable_bloom_filter = false;
+  bool two_level_index_and_filter = false;
 };
 
 class RocksDb : public KeyValue {

--- a/tddb/td/db/RocksDb.h
+++ b/tddb/td/db/RocksDb.h
@@ -75,6 +75,7 @@ struct RocksDbOptions {
 
   bool use_direct_reads = false;
   bool no_block_cache = false;
+  bool enable_bloom_filter = false;
 };
 
 class RocksDb : public KeyValue {

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -1470,6 +1470,7 @@ td::Status ValidatorEngine::load_global_config() {
   validator_options_.write().set_celldb_compress_depth(celldb_compress_depth_);
   validator_options_.write().set_celldb_in_memory(celldb_in_memory_);
   validator_options_.write().set_celldb_v2(celldb_v2_);
+  validator_options_.write().set_celldb_disable_bloom_filter(celldb_disable_bloom_filter_);
   validator_options_.write().set_max_open_archive_files(max_open_archive_files_);
   validator_options_.write().set_archive_preload_period(archive_preload_period_);
   validator_options_.write().set_disable_rocksdb_stats(disable_rocksdb_stats_);
@@ -4535,6 +4536,11 @@ int main(int argc, char *argv[]) {
       "use new version off celldb",
       [&]() {
         acts.push_back([&x]() { td::actor::send_closure(x, &ValidatorEngine::set_celldb_v2, true); });
+  p.add_option(
+      '\0', "celldb-disable-bloom-filter",
+      "disable using bloom filter in CellDb. Enabled bloom filter reduces read latency, but increases memory usage", 
+      [&]() {
+        acts.push_back([&x]() { td::actor::send_closure(x, &ValidatorEngine::set_celldb_disable_bloom_filter, true); });
       });
   p.add_checked_option(
       '\0', "catchain-max-block-delay", "delay before creating a new catchain block, in seconds (default: 0.4)",

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -4536,6 +4536,7 @@ int main(int argc, char *argv[]) {
       "use new version off celldb",
       [&]() {
         acts.push_back([&x]() { td::actor::send_closure(x, &ValidatorEngine::set_celldb_v2, true); });
+      });
   p.add_option(
       '\0', "celldb-disable-bloom-filter",
       "disable using bloom filter in CellDb. Enabled bloom filter reduces read latency, but increases memory usage", 

--- a/validator-engine/validator-engine.hpp
+++ b/validator-engine/validator-engine.hpp
@@ -219,6 +219,7 @@ class ValidatorEngine : public td::actor::Actor {
   bool celldb_preload_all_ = false;
   bool celldb_in_memory_ = false;
   bool celldb_v2_ = false;
+  bool celldb_disable_bloom_filter_ = false;
   td::optional<double> catchain_max_block_delay_, catchain_max_block_delay_slow_;
   bool read_config_ = false;
   bool started_keyring_ = false;
@@ -314,6 +315,9 @@ class ValidatorEngine : public td::actor::Actor {
   }
   void set_celldb_v2(bool value) {
     celldb_v2_ = value;
+  }
+  void set_celldb_disable_bloom_filter(bool value) {
+    celldb_disable_bloom_filter_ = value;
   }
   void set_catchain_max_block_delay(double value) {
     catchain_max_block_delay_ = value;

--- a/validator/db/celldb.cpp
+++ b/validator/db/celldb.cpp
@@ -233,6 +233,8 @@ void CellDbIn::start_up() {
   }
   db_options.use_direct_reads = opts_->get_celldb_direct_io();
   db_options.enable_bloom_filter = !opts_->get_celldb_disable_bloom_filter();
+  db_options.two_level_index_and_filter = db_options.enable_bloom_filter 
+                                && opts_->state_ttl() >= 60 * 60 * 24 * 30; // 30 days
 
   // NB: from now on we MUST use this merge operator
   // Only V2 and InMemory BoC actually use them, but it still should be kept for V1,

--- a/validator/db/celldb.cpp
+++ b/validator/db/celldb.cpp
@@ -232,6 +232,7 @@ void CellDbIn::start_up() {
     LOG(WARNING) << "Set CellDb block cache size to " << td::format::as_size(o_celldb_cache_size.value());
   }
   db_options.use_direct_reads = opts_->get_celldb_direct_io();
+  db_options.enable_bloom_filter = !opts_->get_celldb_disable_bloom_filter();
 
   // NB: from now on we MUST use this merge operator
   // Only V2 and InMemory BoC actually use them, but it still should be kept for V1,

--- a/validator/db/celldb.cpp
+++ b/validator/db/celldb.cpp
@@ -227,21 +227,18 @@ void CellDbIn::start_up() {
     LOG(WARNING) << "Using V1 DynamicBagOfCells with options " << *boc_v1_options;
   }
 
+  db_options.enable_bloom_filter = !opts_->get_celldb_disable_bloom_filter();
+  db_options.two_level_index_and_filter = db_options.enable_bloom_filter 
+                                && opts_->state_ttl() >= 60 * 60 * 24 * 30; // 30 days
+  if (db_options.two_level_index_and_filter && !opts_->get_celldb_in_memory()) {
+    o_celldb_cache_size = std::max(o_celldb_cache_size ? o_celldb_cache_size.value() : 0UL, 16UL << 30);
+  }
+
   if (o_celldb_cache_size) {
     db_options.block_cache = td::RocksDb::create_cache(o_celldb_cache_size.value());
     LOG(WARNING) << "Set CellDb block cache size to " << td::format::as_size(o_celldb_cache_size.value());
   }
   db_options.use_direct_reads = opts_->get_celldb_direct_io();
-  db_options.enable_bloom_filter = !opts_->get_celldb_disable_bloom_filter();
-  db_options.two_level_index_and_filter = db_options.enable_bloom_filter 
-                                && opts_->state_ttl() >= 60 * 60 * 24 * 30; // 30 days
-  if (opts_->get_celldb_cache_size()) {
-    db_options.block_cache = td::RocksDb::create_cache(opts_->get_celldb_cache_size().value());
-    LOG(WARNING) << "Set CellDb block cache size to " << td::format::as_size(opts_->get_celldb_cache_size().value());
-  } else if (db_options.two_level_index_and_filter && !opts_->get_celldb_in_memory()) {
-    db_options.block_cache = td::RocksDb::create_cache(16ULL << 30);
-    LOG(WARNING) << "Set CellDb block cache size to 16GB";
-  }
 
   // NB: from now on we MUST use this merge operator
   // Only V2 and InMemory BoC actually use them, but it still should be kept for V1,

--- a/validator/validator-options.hpp
+++ b/validator/validator-options.hpp
@@ -142,6 +142,9 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
   bool get_celldb_v2() const override {
     return celldb_v2_;
   }
+  bool get_celldb_disable_bloom_filter() const override {
+    return celldb_disable_bloom_filter_;
+  }
   td::optional<double> get_catchain_max_block_delay() const override {
     return catchain_max_block_delay_;
   }
@@ -243,6 +246,9 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
   void set_celldb_v2(bool value) override {
     celldb_v2_ = value;
   }
+  void set_celldb_disable_bloom_filter(bool value) override {
+    celldb_disable_bloom_filter_ = value;
+  }
   void set_catchain_max_block_delay(double value) override {
     catchain_max_block_delay_ = value;
   }
@@ -311,6 +317,7 @@ struct ValidatorManagerOptionsImpl : public ValidatorManagerOptions {
   bool celldb_preload_all_ = false;
   bool celldb_in_memory_ = false;
   bool celldb_v2_ = false;
+  bool celldb_disable_bloom_filter_ = false;
   td::optional<double> catchain_max_block_delay_, catchain_max_block_delay_slow_;
   bool state_serializer_enabled_ = true;
   td::Ref<CollatorOptions> collator_options_{true};

--- a/validator/validator.h
+++ b/validator/validator.h
@@ -112,6 +112,7 @@ struct ValidatorManagerOptions : public td::CntObject {
   virtual td::optional<td::uint64> get_celldb_cache_size() const = 0;
   virtual bool get_celldb_direct_io() const = 0;
   virtual bool get_celldb_preload_all() const = 0;
+  virtual bool get_celldb_disable_bloom_filter() const = 0;
   virtual td::optional<double> get_catchain_max_block_delay() const = 0;
   virtual td::optional<double> get_catchain_max_block_delay_slow() const = 0;
   virtual bool get_state_serializer_enabled() const = 0;
@@ -146,6 +147,7 @@ struct ValidatorManagerOptions : public td::CntObject {
   virtual void set_celldb_preload_all(bool value) = 0;
   virtual void set_celldb_in_memory(bool value) = 0;
   virtual void set_celldb_v2(bool value) = 0;
+  virtual void set_celldb_disable_bloom_filter(bool value) = 0;
   virtual void set_catchain_max_block_delay(double value) = 0;
   virtual void set_catchain_max_block_delay_slow(double value) = 0;
   virtual void set_state_serializer_enabled(bool value) = 0;


### PR DESCRIPTION
This PR enables bloom filters in CellDB, resulting in ~35% reduction in read latency. Bloom filters quickly determine the likelihood of a key's existence in an SST file, reducing number of SST files checks. The trade-off is a slight increase in RAM usage (1.5 GB for 230GB CellDB) to store the bloom filter data structures.