### PR TITLE
Add option to build static tonlibjson and emulator

### DIFF
--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-if (NOT OPENSSL_FOUND)
-  find_package(OpenSSL REQUIRED)
-endif()
+option(EMULATOR_STATIC "Build emulator as static library" OFF)
 
 set(EMULATOR_STATIC_SOURCE
   transaction-emulator.cpp
@@ -22,7 +20,7 @@ include(GenerateExportHeader)
 add_library(emulator_static STATIC ${EMULATOR_STATIC_SOURCE})
 target_link_libraries(emulator_static PUBLIC ton_crypto smc-envelope)
 
-if (USE_EMSCRIPTEN)
+if (EMULATOR_STATIC OR USE_EMSCRIPTEN)
   add_library(emulator STATIC ${EMULATOR_SOURCE})
 else()
   add_library(emulator SHARED ${EMULATOR_SOURCE})
@@ -35,7 +33,7 @@ else()
 endif()
 
 generate_export_header(emulator EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/emulator_export.h)
-if (USE_EMSCRIPTEN)
+if (EMULATOR_STATIC OR USE_EMSCRIPTEN)
   target_compile_definitions(emulator PUBLIC EMULATOR_STATIC_DEFINE)
 endif()
 target_include_directories(emulator PUBLIC

--- a/tonlib/CMakeLists.txt
+++ b/tonlib/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 
 install(FILES ${TONLIB_JSON_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/tonlib/tonlibjson_export.h DESTINATION include/tonlib/)
 
-if (NOT USE_EMSCRIPTEN)
+if (NOT USE_EMSCRIPTEN AND NOT TONLIBJSON_STATIC)
   install(EXPORT Tonlib
     FILE TonlibTargets.cmake
     NAMESPACE Tonlib::

--- a/tonlib/CMakeLists.txt
+++ b/tonlib/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
+option(TONLIBJSON_STATIC "Build tonlibjson as static library" OFF)
+
 if (NOT OPENSSL_FOUND)
   find_package(OpenSSL REQUIRED)
 endif()
@@ -90,7 +92,7 @@ set(TONLIB_JSON_HEADERS tonlib/tonlib_client_json.h)
 set(TONLIB_JSON_SOURCE tonlib/tonlib_client_json.cpp)
 
 include(GenerateExportHeader)
-if (USE_EMSCRIPTEN)
+if (TONLIBJSON_STATIC OR USE_EMSCRIPTEN)
   add_library(tonlibjson STATIC ${TONLIB_JSON_SOURCE})
 else()
   add_library(tonlibjson SHARED ${TONLIB_JSON_SOURCE})
@@ -103,7 +105,7 @@ else()
 endif()
 
 generate_export_header(tonlibjson EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/tonlib/tonlibjson_export.h)
-if (USE_EMSCRIPTEN)
+if (TONLIBJSON_STATIC OR USE_EMSCRIPTEN)
   target_compile_definitions(tonlibjson PUBLIC TONLIBJSON_STATIC_DEFINE)
 endif()
 target_include_directories(tonlibjson PUBLIC


### PR DESCRIPTION
This PR adds cmake variables `EMULATOR_STATIC` and `TONLIBJSON_STATIC` to build `tonlibjson` and `emulator` as static libraries (fixes #1526)
