### PR TITLE
storage: optimize PartsHelper by using vector instead of set for rare…

### DIFF
--- a/storage/PartsHelper.h
+++ b/storage/PartsHelper.h
@@ -238,7 +238,7 @@ struct PartsHelper {
         return key() < other.key();
       }
     };
-    std::set<Key> rarest_parts;  // TODO: use vector instead of set
+    std::vector<Key> rarest_parts;  // Using vector for better performance
   };
 
   std::vector<Part> parts_;


### PR DESCRIPTION
…st_parts

Replace std::set with std::vector for storing rarest_parts in PartsHelper.
This change follows the TODO comment and improves performance since
vectors generally provide better cache locality and lower memory overhead
compared to sets for this use case.