### PR TITLE
Fix for tonlib-cli 'transfer' command

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -268,7 +268,7 @@ td::Result<td::Ref<vm::Cell>> add_extra_currencies(const td::Ref<vm::Cell> &e1, 
   block::CurrencyCollection c1{td::zero_refint(), e1};
   block::CurrencyCollection c2{td::zero_refint(), e2};
   TRY_RESULT_ASSIGN(c1, TRY_VM(td::Result<block::CurrencyCollection>{c1 + c2}));
-  if (c1.is_valid()) {
+  if (!c1.is_valid()) {
     return td::Status::Error("Failed to add extra currencies");
   }
   return c1.extra;


### PR DESCRIPTION
Fix for '**transfer**' command of **tonlib-cli**.

Before fix:
```bash
transferf 0 1 100000000
synchronization: 100%
Change destination address from bounceable to non-bounceable
synchronization: DONE in 8501.3us
Query {transferf 0 1 100000000} FAILED:
        [Error : 0 : Failed to add extra currencies]
``` 

After fix:
```bash
transferf 0 1 100000000
synchronization: 100%
synchronization: DONE in 38.7ms
Change destination address from bounceable to non-bounceable
Transfer sent: ok {
}
``` 
