### PR TITLE
chore: Add submodule notice to README, Add build-macos-shared.sh to .gitignore if in root to match docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ libsodium-1.0.18-stable-msvc.zip
 libmicrohttpd-0.9.77-w32-bin.zip
 openssl-3.1.4.zip
 readline-5.0-1-lib.zip
+# Only ignore in root directory (see README.md)
+/build-macos-shared.sh
+/build-ubuntu-shared.sh
+/build-windows.bat

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Usually, the response to your pull request will indicate which section it falls 
 * Thou shall make sure that workflows are cleanly completed for your PR before considering merge
 
 ## Build TON blockchain
+Make sure to have loaded relevant submodules before: 
+```bash
+git submodule update --init --recursive
+```
 
 ### Ubuntu 20.4, 22.04, 24.04 (x86-64, aarch64)
 Install additional system libraries


### PR DESCRIPTION
# Changelog
[X] No dependencies added
[X] No changes to code

## Changes
- Added notice that user needs to load Git-submodules before executing documented build commands in order for them to work. 
- Added `build-*-shared.sh` files when in **root** to `.gitignore` since your `README.md` suggests copying them to root to execute.

Would love some feedback on this.

We've collaborated with several TON projects in the past and love how fast you were able to build such a thriving ecosystem!

Hope you find this helpful! 

--

Subtle sale (sorry for the shameless promotion): 
**We help with your QA while you can focus on what you do best - pushing forward your roadmap.** 

- What we do: [QA Services](https://wavect.io/services/software-quality-assurance/)
- [Simple subscription at 750€ / week](https://app-eu1.hubspot.com/payments/XwYYTHbMgzRq?referrer=PAYMENT_LINK), cancel anytime and get last week refunded if not happy

![test](https://github.com/user-attachments/assets/aee880f7-552e-4c6e-992c-1d74ad73894b)

