### PR TITLE
TON on RISC-V

### DIFF
--- a/.github/workflows/docker-ubuntu-branch-image.yml
+++ b/.github/workflows/docker-ubuntu-branch-image.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
         with:
-          driver-opts: image=moby/buildkit:v0.11.0
+          driver-opts: image=moby/buildkit:v0.20.2
 
       - name: Fix qemu multiplatform build
         run: |

--- a/.github/workflows/docker-ubuntu-branch-image.yml
+++ b/.github/workflows/docker-ubuntu-branch-image.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:v0.11.0
 
+      - name: Fix qemu multiplatform build
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -54,7 +58,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/riscv64
           push: true
           context: ./
           tags: |

--- a/.github/workflows/docker-ubuntu-image.yml
+++ b/.github/workflows/docker-ubuntu-image.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
 
+      - name: Fix qemu multiplatform build
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-ubuntu-image.yml
+++ b/.github/workflows/docker-ubuntu-image.yml
@@ -60,7 +60,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/riscv64
           push: true
           context: ./
           tags: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,14 +106,21 @@ option(TON_USE_TSAN "Use \"ON\" to enable ThreadSanitizer." OFF)
 option(TON_USE_UBSAN "Use \"ON\" to enable UndefinedBehaviorSanitizer." OFF)
 set(TON_ARCH "native" CACHE STRING "Architecture, will be passed to -march=")
 
-#BEGIN M1 support
+# detect architecture
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 
+#BEGIN M1 support
 if ((ARCHITECTURE MATCHES "arm64") AND (CMAKE_SYSTEM_NAME STREQUAL "Darwin") AND
     (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)) # only clang 13+ supports cpu=apple-m1
     set(TON_ARCH "apple-m1")
 endif()
 #END M1 support
+
+#BEGIN RISC-V support
+if ((ARCHITECTURE MATCHES "riscv64") AND (CMAKE_SYSTEM_NAME STREQUAL "Linux"))
+  set(TON_ARCH "riscv64")
+endif()
+#END RISC-V support
 
 if (TON_USE_ABSEIL)
   message("Add abseil-cpp")
@@ -151,7 +158,7 @@ set(CRC32C_FOUND 1)
 
 if (TON_USE_ROCKSDB)
   if (ANDROID)
-    set(PORTABLE ON CACHE BOOL "portable")
+    set(PORTABLE 0 CACHE STRING "portable")
   endif()
   set(WITH_GFLAGS OFF CACHE BOOL "build with GFlags")
   set(WITH_TESTS OFF CACHE BOOL "build with tests")
@@ -227,10 +234,26 @@ endif()
 
 if (TON_ARCH AND NOT MSVC)
   CHECK_CXX_COMPILER_FLAG( "-march=${TON_ARCH}" COMPILER_OPT_ARCH_SUPPORTED )
+  CHECK_CXX_COMPILER_FLAG( "-mcpu=${TON_ARCH}" COMPILER_OPT_CPU_SUPPORTED )
   if (TON_ARCH STREQUAL "apple-m1")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")	
+    message(STATUS "Found supported Apple Silicon architecture")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")
+  elseif(TON_ARCH STREQUAL "riscv64")
+    execute_process(
+      COMMAND bash -c "cat /proc/cpuinfo | grep -E '^isa\\s*:' | head -1 | cut --delimiter=: -f 2 | cut -b 2-"
+      OUTPUT_VARIABLE RISC_ISA
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    message(STATUS "Found RISC-V architecture with ISA: ${RISC_ISA}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${RISC_ISA}")
+    set(PORTABLE "${RISC_ISA}")
+  elseif(COMPILER_OPT_CPU_SUPPORTED)
+    message(STATUS "Found supported -mcpu=${TON_ARCH}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=${TON_ARCH}")
   elseif(COMPILER_OPT_ARCH_SUPPORTED)
+    message(STATUS "Found supported -march=${TON_ARCH}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${TON_ARCH}")
+    set(PORTABLE "${TON_ARCH}")
   elseif(NOT TON_ARCH STREQUAL "native")
     message(FATAL_ERROR "Compiler doesn't support arch ${TON_ARCH}")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ if (TON_ARCH AND NOT MSVC)
     if(NOT RISC_ISA)
       message(STATUS "RISC-V ISA not detected, using default 'rv64imafdc'")
       set(RISC_ISA "rv64imafdc")
-    endif
+    endif()
     message(STATUS "Found RISC-V architecture with ISA: ${RISC_ISA}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${RISC_ISA}")
     set(PORTABLE "${RISC_ISA}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,10 @@ if (TON_ARCH AND NOT MSVC)
       OUTPUT_VARIABLE RISC_ISA
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    if(NOT RISC_ISA)
+      message(STATUS "RISC-V ISA not detected, using default 'rv64imafdc'")
+      set(RISC_ISA "rv64imafdc")
+    endif
     message(STATUS "Found RISC-V architecture with ISA: ${RISC_ISA}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${RISC_ISA}")
     set(PORTABLE "${RISC_ISA}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
+RUN cat /proc/cpuinfo
 RUN apt-get update && \
     rm /var/lib/dpkg/info/libc-bin.* && \
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-        rm /var/lib/dpkg/info/libc-bin.* && \
-        apt-get clean && \
-        apt-get update && \
-        apt install libc-bin && \
-        apt-get install -y build-essential cmake clang openssl libssl-dev zlib1g-dev gperf wget git \
-        ninja-build libsodium-dev libmicrohttpd-dev liblz4-dev pkg-config autoconf automake libtool \
-        libjemalloc-dev lsb-release software-properties-common gnupg
+    rm /var/lib/dpkg/info/libc-bin.* && \
+    apt-get clean && \
+    apt-get update && \
+    apt-get install -y libc-bin && \
+    apt-get install -y build-essential cmake clang gcc g++ openssl libssl-dev zlib1g-dev gperf wget git \
+    ninja-build libsodium-dev libmicrohttpd-dev liblz4-dev pkg-config autoconf automake libtool \
+    libjemalloc-dev lsb-release software-properties-common gnupg
 
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    ./llvm.sh 16 all && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV CC=/usr/bin/clang-16
-ENV CXX=/usr/bin/clang++-16
+ENV CC=/usr/bin/clang
+ENV CXX=/usr/bin/clang++
 ENV CCACHE_DISABLE=1
 
 WORKDIR /
@@ -31,11 +26,12 @@ RUN mkdir build && \
     generate-random-id dht-server lite-client tolk rldp-http-proxy dht-server proxy-liteserver create-state \
     blockchain-explorer emulator tonlibjson http-proxy adnl-proxy
 
-FROM ubuntu:22.04
+# build image
+FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y wget curl libatomic1 openssl libsodium-dev libmicrohttpd-dev liblz4-dev libjemalloc-dev htop \
-    net-tools netcat iptraf-ng jq tcpdump pv plzip && \
+    net-tools netcat-traditional iptraf-ng jq tcpdump pv plzip && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/ton-work/db /var/ton-work/scripts /usr/share/ton/smartcont/auto /usr/lib/fift/


### PR DESCRIPTION
# TON on RISC-V 

Added support for RISC-V architecture:
* Updated CMakeLists.txt for case of `riscv64` processor.
* Updated `third-party/blst` for newer commit with `riscv64` support.
* Updated Github Actions to build `riscv64` Docker image.
* Bumped version of Ubuntu from 22.04 to 24.04 in Docker image.