### PR TITLE
Avoid CellBuilder during deserialization in CellSerializationInfo

### DIFF
--- a/crypto/vm/boc.cpp
+++ b/crypto/vm/boc.cpp
@@ -89,14 +89,9 @@ td::Result<int> CellSerializationInfo::get_bits(td::Slice cell) const {
 // TODO: check usage when result is empty
 td::Result<Ref<DataCell>> CellSerializationInfo::create_data_cell(td::Slice cell_slice,
                                                                   td::Span<Ref<Cell>> refs) const {
-  CellBuilder cb;
-  TRY_RESULT(bits, get_bits(cell_slice));
-  cb.store_bits(cell_slice.ubegin() + data_offset, bits);
   DCHECK(refs_cnt == (td::int64)refs.size());
-  for (int k = 0; k < refs_cnt; k++) {
-    cb.store_ref(std::move(refs[k]));
-  }
-  TRY_RESULT(res, cb.finalize_novm_nothrow(special));
+  TRY_RESULT(bits, get_bits(cell_slice));
+  TRY_RESULT(res, DataCell::create(cell_slice.substr(data_offset), bits, refs, special));
   CHECK(!res.is_null());
   if (res->is_special() != special) {
     return td::Status::Error("is_special mismatch");


### PR DESCRIPTION
Another free 2.5% of speed-up on block verification.