### PR TITLE
Do not recompute validator set in MasterchainStateQ::mc_reinit

### DIFF
--- a/crypto/block/mc-config.h
+++ b/crypto/block/mc-config.h
@@ -643,8 +643,8 @@ class Config {
   const WorkchainSet& get_workchain_list() const {
     return workchains_;
   }
-  const ValidatorSet* get_cur_validator_set() const {
-    return cur_validators_.get();
+  std::shared_ptr<ValidatorSet> const& get_cur_validator_set() const& {
+    return cur_validators_;
   }
   std::pair<ton::UnixTime, ton::UnixTime> get_validator_set_start_stop(int next = 0) const;
   ton::ValidatorSessionConfig get_consensus_config() const;

--- a/validator/impl/shard.cpp
+++ b/validator/impl/shard.cpp
@@ -388,11 +388,8 @@ td::Status MasterchainStateQ::mc_reinit() {
   CHECK(config_);
   CHECK(config_->set_block_id_ext(get_block_id()));
 
-  auto cv_root = config_->get_config_param(35, 34);
-  if (cv_root.not_null()) {
-    TRY_RESULT(validators, block::Config::unpack_validator_set(std::move(cv_root), true));
-    cur_validators_ = std::move(validators);
-  }
+  cur_validators_ = config_->get_cur_validator_set();
+
   auto nv_root = config_->get_config_param(37, 36);
   if (nv_root.not_null()) {
     TRY_RESULT(validators, block::Config::unpack_validator_set(std::move(nv_root), true));


### PR DESCRIPTION
This does not improve performance (as unpack_validator_set result is cached regardless) but makes the code clearer.