### PR TITLE
Fix calculating normalized hash

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -3308,7 +3308,7 @@ td::Status TonlibClient::do_request(const tonlib_api::raw_sendMessage& request,
   return td::Status::OK();
 }
 
-td::Result<td::Bits256> get_hash_norm(td::Ref<vm::Cell> ext_in_msg_cell) {
+td::Result<td::Bits256> get_ext_in_msg_hash_norm(td::Ref<vm::Cell> ext_in_msg_cell) {
   block::gen::Message::Record message;
   if (!tlb::type_unpack_cell(ext_in_msg_cell, block::gen::t_Message_Any, message)) {
     return td::Status::Error("Failed to unpack Message");
@@ -3350,7 +3350,7 @@ td::Status TonlibClient::do_request(const tonlib_api::raw_sendMessageReturnHash&
                                     td::Promise<object_ptr<tonlib_api::raw_extMessageInfo>>&& promise) {
   TRY_RESULT_PREFIX(body, vm::std_boc_deserialize(request.body_), TonlibError::InvalidBagOfCells("body"));
   auto hash = body->get_hash().as_slice().str();
-  TRY_RESULT(hash_norm, get_hash_norm(body));
+  TRY_RESULT(hash_norm, get_ext_in_msg_hash_norm(body));
 
   make_request(int_api::SendMessage{std::move(body)},
     promise.wrap([hash = std::move(hash), hash_norm = std::move(hash_norm)](auto res) {

--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -3308,14 +3308,9 @@ td::Status TonlibClient::do_request(const tonlib_api::raw_sendMessage& request,
   return td::Status::OK();
 }
 
-td::Status TonlibClient::do_request(const tonlib_api::raw_sendMessageReturnHash& request,
-                                    td::Promise<object_ptr<tonlib_api::raw_extMessageInfo>>&& promise) {
-  TRY_RESULT_PREFIX(body, vm::std_boc_deserialize(request.body_), TonlibError::InvalidBagOfCells("body"));
-  auto hash = body->get_hash().as_slice().str();
-
-  // compute hash normalized
+td::Result<td::Bits256> get_hash_norm(td::Ref<vm::Cell> ext_in_msg_cell) {
   block::gen::Message::Record message;
-  if (!tlb::type_unpack_cell(body, block::gen::t_Message_Any, message)) {
+  if (!tlb::type_unpack_cell(ext_in_msg_cell, block::gen::t_Message_Any, message)) {
     return td::Status::Error("Failed to unpack Message");
   }
   auto tag = block::gen::CommonMsgInfo().get_tag(*message.info);
@@ -3327,32 +3322,39 @@ td::Status TonlibClient::do_request(const tonlib_api::raw_sendMessageReturnHash&
     return td::Status::Error("Failed to unpack CommonMsgInfo::ext_in_msg_info");
   }
 
-  td::Ref<vm::Cell> body_norm;
+  td::Ref<vm::Cell> body;
   auto body_cs = message.body.write();
-  if (body_cs.fetch_long(1) == 1) {
-    body_norm = body_cs.fetch_ref();
+  if (body_cs.fetch_ulong(1) == 1) {
+    body = body_cs.fetch_ref();
   } else {
-    body_norm = vm::CellBuilder().append_cellslice(body_cs).finalize();
+    body = vm::CellBuilder().append_cellslice(body_cs).finalize();
   }
 
   auto cb = vm::CellBuilder();
-  bool status =
+  bool status = 
     cb.store_long_bool(2, 2) &&                 // message$_ -> info:CommonMsgInfo -> ext_in_msg_info$10
     cb.store_long_bool(0, 2) &&                 // message$_ -> info:CommonMsgInfo -> src:MsgAddressExt -> addr_none$00
     cb.append_cellslice_bool(msg_info.dest) &&  // message$_ -> info:CommonMsgInfo -> dest:MsgAddressInt
     cb.store_long_bool(0, 4) &&                 // message$_ -> info:CommonMsgInfo -> import_fee:Grams -> 0
     cb.store_long_bool(0, 1) &&                 // message$_ -> init:(Maybe (Either StateInit ^StateInit)) -> nothing$0
     cb.store_long_bool(1, 1) &&                 // message$_ -> body:(Either X ^X) -> right$1
-    cb.store_ref_bool(body_norm);
+    cb.store_ref_bool(body);
 
   if (!status) {
     return td::Status::Error("Failed to build normalized message");
   }
-  auto hash_norm = cb.finalize()->get_hash().as_slice().str();
+  return cb.finalize()->get_hash().bits();
+}
+
+td::Status TonlibClient::do_request(const tonlib_api::raw_sendMessageReturnHash& request,
+                                    td::Promise<object_ptr<tonlib_api::raw_extMessageInfo>>&& promise) {
+  TRY_RESULT_PREFIX(body, vm::std_boc_deserialize(request.body_), TonlibError::InvalidBagOfCells("body"));
+  auto hash = body->get_hash().as_slice().str();
+  TRY_RESULT(hash_norm, get_hash_norm(body));
 
   make_request(int_api::SendMessage{std::move(body)},
     promise.wrap([hash = std::move(hash), hash_norm = std::move(hash_norm)](auto res) {
-      return tonlib_api::make_object<tonlib_api::raw_extMessageInfo>(std::move(hash), std::move(hash_norm));
+      return tonlib_api::make_object<tonlib_api::raw_extMessageInfo>(std::move(hash), hash_norm.as_slice().str());
     }));
   return td::Status::OK();
 }

--- a/tonlib/tonlib/TonlibClient.h
+++ b/tonlib/tonlib/TonlibClient.h
@@ -59,6 +59,7 @@ class RunEmulator;
 td::Result<tonlib_api::object_ptr<tonlib_api::dns_EntryData>> to_tonlib_api(
     const ton::ManualDns::EntryData& entry_data);
 td::Result<ton::ManualDns::EntryData> to_dns_entry_data(tonlib_api::dns_EntryData& entry_data);
+td::Result<td::Bits256> get_ext_in_msg_hash_norm(td::Ref<vm::Cell> ext_in_msg_cell);
 
 class TonlibClient : public td::actor::Actor {
  public:


### PR DESCRIPTION
- Replaced `fetch_long` with `fetch_ulong` since former returns `-1` when reading 1 bit
- Extracted calculation to `get_hash_norm` function