### PR TITLE
Fix floating point equality comparison

### DIFF
--- a/crypto/block/block.cpp
+++ b/crypto/block/block.cpp
@@ -1713,17 +1713,18 @@ bool MtCarloComputeShare::compute() {
 }
 
 void MtCarloComputeShare::gen_vset() {
-  double total_wt = 1.;
+  constexpr int precision = 1000000;
+  int total_wt = precision;
   int hc = 0;
   for (int i = 0; i < K; i++) {
     CHECK(total_wt > 0);
-    double inv_wt = 1. / total_wt;
+    double inv_wt = (double)precision / total_wt;
     R0 += inv_wt;
     for (int j = 0; j < i; j++) {
       RW[A[j]] -= inv_wt;
     }
     // double p = drand48() * total_wt;
-    double p = (double)td::Random::fast_uint64() * total_wt / (1. * (1LL << 32) * (1LL << 32));
+    double p = (double)td::Random::fast_uint64() / precision * total_wt / (1. * (1LL << 32) * (1LL << 32));
     for (int h = 0; h < hc; h++) {
       if (p < H[h].first) {
         break;
@@ -1740,8 +1741,9 @@ void MtCarloComputeShare::gen_vset() {
       }
     }
     CHECK(a >= 0 && a < N);
-    CHECK(total_wt >= W[a]);
-    total_wt -= W[a];
+    const int Wa = static_cast<int>(W[a] * precision);
+    CHECK(total_wt >= Wa);
+    total_wt -= Wa;
     double x = CW[a];
     c = hc++;
     while (c > 0 && H[c - 1].first > x) {


### PR DESCRIPTION
Equal comparison on floating point numbers is problematic, they cannot be easy comparable via operator== instead it should be used an epsilon. I don't find critical path (in consensus nor in full node/validator) using floating point equality comparison, here in lite-client is *not a big dial* but still bothers mytonctrl time-to-time. 
```
[error]   14.04.2025, 08:09:48.592 (UTC)  <MainThread>  args: ['/usr/bin/ton/lite-client/lite-client', '--addr', '127.0.0.1:36892', '--pub', '/var/ton-work/keys/liteserver.pub', '--verbosity', '0', '--cmd', 'checkloadall 1744616128 1744618128 ']
Error: LiteClient error: [ 0][t 1][2025-04-14 08:09:48.588702271][block.cpp:1691][!testnode]    Check `total_wt >= W[a]` failed
[pid 3221836] [time 1744618188] Signal: 6
```