### PR TITLE
Deterministic large boc serialization algorithm

### DIFF
--- a/crypto/vm/large-boc-serializer.cpp
+++ b/crypto/vm/large-boc-serializer.cpp
@@ -115,7 +115,7 @@ td::Status LargeBocSerializer::import_cells() {
 
 td::Result<int> LargeBocSerializer::import_cell(Hash root_hash, int root_depth) {
   const int start_ind = cell_count;
-  td::HashMap<Hash, std::pair<int, bool>> current_depth_hashes;
+  td::BTreeMap<Hash, std::pair<int, bool>> current_depth_hashes;
 
   auto existing_it = cells.find(root_hash);
   if (existing_it != cells.end()) {
@@ -131,7 +131,7 @@ td::Result<int> LargeBocSerializer::import_cell(Hash root_hash, int root_depth) 
     }
     
     cell_list.resize(cell_list.size() + current_depth_hashes.size());
-    td::HashMap<Hash, std::pair<int, bool>> next_depth_hashes;
+    td::BTreeMap<Hash, std::pair<int, bool>> next_depth_hashes;
     auto batch_start = current_depth_hashes.begin();
     while (batch_start != current_depth_hashes.end()) {
       std::vector<td::Slice> batch_hashes;

--- a/tdutils/td/utils/HashMap.h
+++ b/tdutils/td/utils/HashMap.h
@@ -23,8 +23,10 @@
 #if TD_HAVE_ABSL
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
+#include <absl/container/btree_map.h>
 #else
 #include <unordered_map>
+#include <map>
 #endif
 
 namespace td {
@@ -34,11 +36,15 @@ template <class Key, class Value, class H = Hash<Key>>
 using HashMap = absl::flat_hash_map<Key, Value, H>;
 template <class Key, class Value, class H = Hash<Key>, class E = std::equal_to<>>
 using NodeHashMap = absl::node_hash_map<Key, Value, H, E>;
+template <class Key, class Value>
+using BTreeMap = absl::btree_map<Key, Value>;
 #else
 template <class Key, class Value, class H = Hash<Key>>
 using HashMap = std::unordered_map<Key, Value, H>;
 template <class Key, class Value, class H = Hash<Key>>
 using NodeHashMap = std::unordered_map<Key, Value, H>;
+template <class Key, class Value>
+using BTreeMap = std::map<Key, Value>;
 #endif
 
 }  // namespace td


### PR DESCRIPTION
The new large BOC serialization algorithm is not deterministic. This indeterminism may cause problems, for example, if some node wants to load persistent state BOC from two peers in parallel or continue loading after a failure. It is caused by using a hash map with an unstable iteration order. This PR fixes it by replacing the hash map with B-tree map.