### PR TITLE
use zero-autotools approach when compiling libsodium on mac

### DIFF
--- a/assembly/native/build-macos-portable.sh
+++ b/assembly/native/build-macos-portable.sh
@@ -67,18 +67,17 @@ fi
 
 if [ ! -d "../3pp/libsodium" ]; then
   export LIBSODIUM_FULL_BUILD=1
-  git clone https://github.com/jedisct1/libsodium.git ../3pp/libsodium
   cd ../3pp/libsodium
+  curl -LO https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz
+  tar -xzf libsodium-1.0.18.tar.gz
+  cd libsodium-1.0.18
   sodiumPath=`pwd`
-  git checkout 1.0.18
-  ./autogen.sh
-  chmod +x ./build-aux/config.sub
   ./configure --with-pic --enable-static
   make -j4
   test $? -eq 0 || { echo "Can't compile libsodium"; exit 1; }
-  cd ../../build
+  cd ../../../build
 else
-  sodiumPath=$(pwd)/../3pp/libsodium
+  sodiumPath=$(pwd)/../3pp/libsodium/libsodium-1.0.18
   echo "Using compiled libsodium"
 fi
 

--- a/assembly/native/build-macos-portable.sh
+++ b/assembly/native/build-macos-portable.sh
@@ -71,6 +71,7 @@ if [ ! -d "../3pp/libsodium" ]; then
   cd ../3pp/libsodium
   sodiumPath=`pwd`
   git checkout 1.0.18
+  autoupdate
   ./autogen.sh
   ./configure --with-pic --enable-static
   make -j4

--- a/assembly/native/build-macos-portable.sh
+++ b/assembly/native/build-macos-portable.sh
@@ -65,9 +65,9 @@ else
   echo "Using compiled lz4"
 fi
 
-if [ ! -d "../3pp/libsodium" ]; then
+if [ ! -d "../3pp/libsodium-1.0.18" ]; then
   export LIBSODIUM_FULL_BUILD=1
-  cd ../3pp/libsodium
+  cd ../3pp
   curl -LO https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz
   tar -xzf libsodium-1.0.18.tar.gz
   cd libsodium-1.0.18
@@ -75,9 +75,9 @@ if [ ! -d "../3pp/libsodium" ]; then
   ./configure --with-pic --enable-static
   make -j4
   test $? -eq 0 || { echo "Can't compile libsodium"; exit 1; }
-  cd ../../../build
+  cd ../../build
 else
-  sodiumPath=$(pwd)/../3pp/libsodium/libsodium-1.0.18
+  sodiumPath=$(pwd)/../3pp/libsodium-1.0.18
   echo "Using compiled libsodium"
 fi
 

--- a/assembly/native/build-macos-portable.sh
+++ b/assembly/native/build-macos-portable.sh
@@ -71,8 +71,8 @@ if [ ! -d "../3pp/libsodium" ]; then
   cd ../3pp/libsodium
   sodiumPath=`pwd`
   git checkout 1.0.18
-  autoupdate
   ./autogen.sh
+  chmod +x ./build-aux/config.sub
   ./configure --with-pic --enable-static
   make -j4
   test $? -eq 0 || { echo "Can't compile libsodium"; exit 1; }


### PR DESCRIPTION
Fixing issues when autogen.sh tries to download config.sub