### PR TITLE
Fix selecting shard overlays after decreasing monitor_min_split

### DIFF
--- a/validator/full-node.hpp
+++ b/validator/full-node.hpp
@@ -131,7 +131,7 @@ class FullNodeImpl : public FullNode {
   FileHash zero_state_file_hash_;
 
   td::actor::ActorId<FullNodeShard> get_shard(AccountIdPrefixFull dst);
-  td::actor::ActorId<FullNodeShard> get_shard(ShardIdFull shard);
+  td::actor::ActorId<FullNodeShard> get_shard(ShardIdFull shard, bool historical = false);
   std::map<ShardIdFull, ShardInfo> shards_;
   int wc_monitor_min_split_ = 0;
 


### PR DESCRIPTION
When node is out of sync (e.g., during initial sync), it may try to use shard overlays that do not exist anymore because monitor min split was decreased. "Download state", "download archive" and "download proof link" are the types of requests that are necessary to sync.