### PR TITLE
Double FD limit

### DIFF
--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -5228,7 +5228,7 @@ int main(int argc, char *argv[]) {
     td::log_interface = td::default_log_interface;
   };
 
-  LOG_STATUS(td::change_maximize_rlimit(td::RlimitType::nofile, 786432));
+  LOG_STATUS(td::change_maximize_rlimit(td::RlimitType::nofile, 1572864));
 
   std::vector<std::function<void()>> acts;
 


### PR DESCRIPTION
This update is required to ensure proper functionality of archival nodes where previous limit of 786432 file descriptors is already causing issues.