### PR TITLE
Depricate macOS-13 gh actions

### DIFF
--- a/.github/workflows/build-ton-macos-15-x86-64-portable.yml
+++ b/.github/workflows/build-ton-macos-15-x86-64-portable.yml
@@ -1,10 +1,10 @@
-name: MacOS-13 TON build (portable, x86-64)
+name: MacOS-15 TON build (portable, x86-64)
 
 on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
       - name: Check out repository
@@ -28,15 +28,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: 3pp
-          key: ${{ runner.os }}-${{ runner.arch }}-13-3pp-${{ hashFiles('**/assembly/native/build-macos-portable.sh') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-15-3pp-${{ hashFiles('**/assembly/native/build-macos-portable.sh') }}
 
       - name: Cache TON test
         id: cache-ton
         uses: actions/cache@v4
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-${{ runner.arch }}-13-portable-ccache-${{ steps.date-stamp.outputs.timestamp }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-13-portable-ccache
+          key: ${{ runner.os }}-${{ runner.arch }}-15-portable-ccache-${{ steps.date-stamp.outputs.timestamp }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-15-portable-ccache
 
       - name: Build TON
         run: |
@@ -44,7 +44,7 @@ jobs:
           git submodule update
           cp assembly/native/build-macos-portable.sh .
           chmod +x build-macos-portable.sh
-          ./build-macos-portable.sh -t -a -c -o 13.0
+          ./build-macos-portable.sh -t -a -c -o 15.0
           ccache -sp
 
       - name: Run Tests

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Download Mac x86-64 artifacts
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build-ton-macos-13-x86-64-portable.yml
+          workflow: build-ton-macos-15-x86-64-portable.yml
           path: artifacts
           workflow_conclusion: success
           branch: master
@@ -71,7 +71,7 @@ jobs:
       - name: Download and unzip Mac x86-64 artifacts
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build-ton-macos-13-x86-64-portable.yml
+          workflow: build-ton-macos-15-x86-64-portable.yml
           path: artifacts
           workflow_conclusion: success
           branch: master

--- a/.github/workflows/create-tolk-release.yml
+++ b/.github/workflows/create-tolk-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download and unzip Mac x86-64 artifacts
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build-ton-macos-13-x86-64-portable.yml
+          workflow: build-ton-macos-15-x86-64-portable.yml
           path: artifacts
           workflow_conclusion: success
           branch: master


### PR DESCRIPTION
Since the macOS 13 runner image will be retired by December 4th, 2025