### PR TITLE
Switch last remaining MacOS 13 pipeline to MacOS 15

### DIFF
--- a/.github/workflows/build-ton-macos-15-x86-64-shared.yml
+++ b/.github/workflows/build-ton-macos-15-x86-64-shared.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
This causes CI failures otherwise: https://github.com/ton-blockchain/ton/actions/runs/19470205113/job/55715079514?pr=1897.