### PR TITLE
Make td/actor/core/ActorTypeStat.h usable as a standalone header

### DIFF
--- a/tdactor/td/actor/core/ActorTypeStat.h
+++ b/tdactor/td/actor/core/ActorTypeStat.h
@@ -1,8 +1,11 @@
 #pragma once
+
 #include <algorithm>
+#include <atomic>
 #include <map>
 #include <typeindex>
 
+#include "td/utils/common.h"
 #include "td/utils/int_types.h"
 #include "td/utils/port/Clocks.h"
 


### PR DESCRIPTION
We will need ActorTypeStatManager::get_class_name demangler from it in the future.