### PR TITLE
Add `reverse-continue-to-actor-caller` GDB command

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,1 @@
+source assembly/gdb/rc_to_actor_caller.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(TON_USE_COVERAGE "Use \"ON\" to enable code coverage with gcov." OFF)
 set(TON_ARCH "native" CACHE STRING "Architecture, will be passed to -march=")
 
 option(TON_PRINT_BACKTRACE_ON_CRASH "Attempt to print a backtrace when a fatal signal is caught" ON)
+option(TON_INSERT_GDB_HOOKS "Insert GDB hooks" OFF)
 
 option(TON_USE_LLD "Use LLD for linking" OFF)
 
@@ -298,6 +299,10 @@ endif()
 
 if (NOT ANDROID) # _FILE_OFFSET_BITS is broken in ndk r15 and r15b and doesn't work prior to Android 7.0
   add_definitions(-D_FILE_OFFSET_BITS=64)
+endif()
+
+if (TON_INSERT_GDB_HOOKS)
+  add_compile_definitions(-DTON_INSERT_GDB_HOOKS=1)
 endif()
 
 set(INTERNAL_COMPILE "0")

--- a/assembly/gdb/rc_to_actor_caller.py
+++ b/assembly/gdb/rc_to_actor_caller.py
@@ -1,0 +1,84 @@
+import contextlib
+from typing import final, override
+
+import gdb  # pyright: ignore[reportMissingModuleSource]
+
+MESSAGE_RUN_HOOK = "td::actor::core::gdb::hook_message_run"
+MESSAGE_PUSHED_HOOK = "td::actor::core::gdb::hook_message_pushed_to_mailbox"
+MESSAGE_DELAYED_HOOK = "td::actor::core::gdb::hook_message_delayed"
+
+FLUSH_FN = "td::actor::core::ActorExecutor::flush_one_message"
+
+
+def has_flush_frame():
+    f = gdb.newest_frame()
+    while f:
+        if f.name() == FLUSH_FN:
+            return True
+        f = f.older()
+    return False
+
+
+@final
+class MallocReturnBP(gdb.Breakpoint):
+    def __init__(self, addr: int):
+        super().__init__("malloc", internal=True)
+        self.condition = f"$_retval == (void*){addr}"
+        self.silent = True
+
+
+def reverse_continue_until_any(breakpoints: list[gdb.Breakpoint]):
+    while True:
+        _ = gdb.execute("reverse-continue", to_string=True)
+        if any(bp.hit_count > 0 for bp in breakpoints):
+            return
+
+
+@contextlib.contextmanager
+def with_breakpoint(bp: gdb.Breakpoint):
+    try:
+        yield bp
+    finally:
+        bp.delete()
+
+
+def run():
+    if not has_flush_frame():
+        print("flush_one_message not present in the backtrace")
+        return
+
+    thread_name = gdb.selected_thread().num
+
+    with with_breakpoint(gdb.Breakpoint(MESSAGE_RUN_HOOK, internal=True)) as bp:
+        bp.silent = True
+        bp.thread = thread_name
+        reverse_continue_until_any([bp])
+
+    mailbox = gdb.parse_and_eval("&mailbox")
+    message = gdb.parse_and_eval("message.impl_.get()")
+
+    with (
+        with_breakpoint(gdb.Breakpoint(MESSAGE_PUSHED_HOOK, internal=True)) as bp_pushed,
+        with_breakpoint(gdb.Breakpoint(MESSAGE_DELAYED_HOOK, internal=True)) as bp_delayed,
+    ):
+        bp_pushed.silent = True
+        bp_pushed.condition = f"&mailbox == {mailbox} && message.impl_.get() == {message}"
+
+        bp_delayed.silent = True
+        bp_delayed.condition = f"&mailbox == {mailbox} && message.impl_.get() == {message}"
+
+        reverse_continue_until_any([bp_pushed, bp_delayed])
+
+
+class ActorTraceCmd(gdb.Command):
+    def __init__(self):
+        super().__init__("reverse-continue-to-actor-caller", gdb.COMMAND_USER)
+
+    @override
+    def invoke(self, argument: str, from_tty: bool):
+        run()
+
+
+_ = ActorTraceCmd()
+_ = gdb.execute("alias rc-actor = reverse-continue-to-actor-caller", to_string=True)
+_ = gdb.execute("alias rca = reverse-continue-to-actor-caller", to_string=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "pytest>=9.0.1",
     "pytest-asyncio",
     "tontester",
+    "types-gdb>=16.3.0.20250920",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "tontester" },
+    { name = "types-gdb" },
 ]
 
 [package.dev-dependencies]
@@ -156,6 +157,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-asyncio" },
     { name = "tontester", editable = "test/tontester" },
+    { name = "types-gdb", specifier = ">=16.3.0.20250920" },
 ]
 
 [package.metadata.requires-dev]
@@ -168,3 +170,12 @@ dev = [
 name = "tontester"
 version = "0.1.0"
 source = { editable = "test/tontester" }
+
+[[package]]
+name = "types-gdb"
+version = "16.3.0.20250920"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9c/f1fbeedd534f7228c04cfb11281a47a1f4338238d27635199958c247b0e5/types_gdb-16.3.0.20250920.tar.gz", hash = "sha256:4c16cd289428ff6c0cb2fac26e1913d5eab2d890da9951091a11133d5d0a589c", size = 25335, upload-time = "2025-09-20T02:45:11.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a5/e0246aece6b052e4b8251fbb0c80f490b6b7bae9a9c3d92978d04dfc930d/types_gdb-16.3.0.20250920-py3-none-any.whl", hash = "sha256:10873fd469cdccb0b7e5ad2321eeb751cb6676cb05a67f3589e753d5f4482ae7", size = 31308, upload-time = "2025-09-20T02:45:10.034Z" },
+]


### PR DESCRIPTION
This obviously only works under rr.

Debug flow looks like this:
```
Thread 2 received signal SIGABRT, Aborted.
(rr) where
...
#6  0x00005646dea4a2aa in ton::adnl::AdnlPeerTableImpl::subscribe
<frame from actor runtime>
#8  0x00005646dea1e82b in td::actor::core::ActorExecutor::flush_one_message
<other useless frames from actor scheduler; note that the caller location seems to be completely lost>
(rr) reverse-continue-to-actor-caller
(rr) where
<actor runtime internals>
#8  0x00005646de992953 in send_closure<td::actor::ActorId<ton::adnl::Adnl>&, <...>)
#9  ton::overlay::OverlayManager::register_overlay
<synchronous callers of `register_overlay`, frames from actor scheduler>
```
and honestly feels like magic if you ever tried to figure out actor caller manually. 