### PR TITLE
Fix promise_type ambiguity in coroutine declarations for GCC 11+ comp…

### DIFF
--- a/tdactor/td/actor/coro_task.h
+++ b/tdactor/td/actor/coro_task.h
@@ -292,7 +292,7 @@ template <class T>
 struct [[nodiscard]] Task {
   using value_type = T;
 
-  using promise_type = promise_type<T>;
+  using promise_type = td::actor::promise_type<T>;
   using Handle = std::coroutine_handle<promise_type>;
   Handle h{};
 
@@ -364,7 +364,7 @@ template <class T>
 struct [[nodiscard]] StartedTask {
   using value_type = T;
 
-  using promise_type = promise_type<T>;
+  using promise_type = td::actor::promise_type<T>;
   using Handle = std::coroutine_handle<promise_type>;
   Handle h{};
 


### PR DESCRIPTION
## Summary
This PR fixes a compilation error in `tdactor/td/actor/coro_task.h` that occurs when building with GCC 11 or newer. The issue stems
from ambiguous `promise_type` declarations in the coroutine implementation.

## Problem
When compiling TON with GCC 11.4.0 (and likely other modern GCC versions), the build fails with the following error:

error: declaration of 'using promise_type = struct td::actor::promise_type'
changes meaning of 'promise_type' [-fpermissive]

This error occurs at lines 295 and 367 in `tdactor/td/actor/coro_task.h`.

## Root Cause
The issue is caused by circular type aliasing in the coroutine promise type declarations:

```cpp
template <class T>
struct promise_type : promise_value<td::Result<T>> {
  // ... implementation
};

template <class T>
struct [[nodiscard]] Task {
  using promise_type = promise_type<T>;  // ❌ Ambiguous: refers to itself
  // ...
};
```

GCC's stricter interpretation of the C++ standard (with -fpermissive warnings treated as errors) rejects this pattern as the inner
promise_type alias shadows the outer template struct of the same name.

Solution

Replace the ambiguous type alias with a fully-qualified name:

```
template <class T>
struct [[nodiscard]] Task {
  using promise_type = td::actor::promise_type<T>;  // ✅ Explicit namespace qualification
  // ...
};
```

This change is made at two locations:
- Line 295 in the Task struct
- Line 367 in the StartedTask struct

Testing

- ✅ Successfully compiled with GCC 11.4.0 on Ubuntu 22.04
- ✅ Successfully compiled with Clang 14.0.0 (backward compatible)
- ✅ Validator-engine binary runs without issues on testnet
- ✅ All related components (lite-client, fift, func, validator-engine-console) compile successfully

Impact

- Scope: Build system compatibility
- Risk: Low - This is a purely syntactic change that maintains identical semantics
- Benefit: Enables compilation with modern GCC versions (11+), which are default on recent Linux distributions (Ubuntu 22.04+, Debian
12+, Fedora 35+)

Compatibility

This fix maintains full backward compatibility:
- ✅ Clang 14+ (existing builds continue to work)
- ✅ GCC 11+ (now supported)
- ✅ No changes to runtime behavior or API

Checklist

- Code compiles successfully with both GCC 11+ and Clang 14+
- No functional changes to the codebase
- Tested on testnet validator node
- Follows existing code style
- Commit message follows project conventions

Related Context

This fix resolves build failures encountered when upgrading validator nodes running on systems with GCC 11 or newer, which is becoming
increasingly common as distributions update their default toolchains.