### PR TITLE
Do not require approve signatures in run_accept_block_query

### DIFF
--- a/validator/fabric.h
+++ b/validator/fabric.h
@@ -85,8 +85,8 @@ void run_check_external_message(td::Ref<ExtMessage> message, td::actor::ActorId<
 
 void run_accept_block_query(BlockIdExt id, td::Ref<BlockData> data, std::vector<BlockIdExt> prev,
                             td::Ref<ValidatorSet> validator_set, td::Ref<BlockSignatureSet> signatures,
-                            td::Ref<BlockSignatureSet> approve_signatures, int send_broadcast_mode, bool apply,
-                            td::actor::ActorId<ValidatorManager> manager, td::Promise<td::Unit> promise);
+                            int send_broadcast_mode, bool apply, td::actor::ActorId<ValidatorManager> manager,
+                            td::Promise<td::Unit> promise);
 void run_fake_accept_block_query(BlockIdExt id, td::Ref<BlockData> data, std::vector<BlockIdExt> prev,
                                  td::Ref<ValidatorSet> validator_set, td::actor::ActorId<ValidatorManager> manager,
                                  td::Promise<td::Unit> promise);

--- a/validator/impl/accept-block.cpp
+++ b/validator/impl/accept-block.cpp
@@ -39,14 +39,13 @@ using namespace std::literals::string_literals;
 
 AcceptBlockQuery::AcceptBlockQuery(BlockIdExt id, td::Ref<BlockData> data, std::vector<BlockIdExt> prev,
                                    td::Ref<ValidatorSet> validator_set, td::Ref<BlockSignatureSet> signatures,
-                                   td::Ref<BlockSignatureSet> approve_signatures, int send_broadcast_mode, bool apply,
-                                   td::actor::ActorId<ValidatorManager> manager, td::Promise<td::Unit> promise)
+                                   int send_broadcast_mode, bool apply, td::actor::ActorId<ValidatorManager> manager,
+                                   td::Promise<td::Unit> promise)
     : id_(id)
     , data_(std::move(data))
     , prev_(std::move(prev))
     , validator_set_(std::move(validator_set))
     , signatures_(std::move(signatures))
-    , approve_signatures_(std::move(approve_signatures))
     , is_fake_(false)
     , is_fork_(false)
     , send_broadcast_mode_(send_broadcast_mode)

--- a/validator/impl/accept-block.hpp
+++ b/validator/impl/accept-block.hpp
@@ -50,9 +50,8 @@ class AcceptBlockQuery : public td::actor::Actor {
   struct IsFake {};
   struct ForceFork {};
   AcceptBlockQuery(BlockIdExt id, td::Ref<BlockData> data, std::vector<BlockIdExt> prev,
-                   td::Ref<ValidatorSet> validator_set, td::Ref<BlockSignatureSet> signatures,
-                   td::Ref<BlockSignatureSet> approve_signatures, int send_broadcast_mode, bool apply,
-                   td::actor::ActorId<ValidatorManager> manager, td::Promise<td::Unit> promise);
+                   td::Ref<ValidatorSet> validator_set, td::Ref<BlockSignatureSet> signatures, int send_broadcast_mode,
+                   bool apply, td::actor::ActorId<ValidatorManager> manager, td::Promise<td::Unit> promise);
   AcceptBlockQuery(IsFake fake, BlockIdExt id, td::Ref<BlockData> data, std::vector<BlockIdExt> prev,
                    td::Ref<ValidatorSet> validator_set, td::actor::ActorId<ValidatorManager> manager,
                    td::Promise<td::Unit> promise);
@@ -98,7 +97,6 @@ class AcceptBlockQuery : public td::actor::Actor {
   std::vector<BlockIdExt> prev_;
   Ref<ValidatorSetQ> validator_set_;
   Ref<BlockSignatureSetQ> signatures_;
-  Ref<BlockSignatureSetQ> approve_signatures_;
   bool is_fake_;
   bool is_fork_;
   int send_broadcast_mode_{0};

--- a/validator/impl/fabric.cpp
+++ b/validator/impl/fabric.cpp
@@ -131,11 +131,11 @@ td::Result<td::Ref<IhrMessage>> create_ihr_message(td::BufferSlice data) {
 
 void run_accept_block_query(BlockIdExt id, td::Ref<BlockData> data, std::vector<BlockIdExt> prev,
                             td::Ref<ValidatorSet> validator_set, td::Ref<BlockSignatureSet> signatures,
-                            td::Ref<BlockSignatureSet> approve_signatures, int send_broadcast_mode, bool apply,
-                            td::actor::ActorId<ValidatorManager> manager, td::Promise<td::Unit> promise) {
-  td::actor::create_actor<AcceptBlockQuery>(
-      PSTRING() << "accept" << id.id.to_str(), id, std::move(data), prev, std::move(validator_set),
-      std::move(signatures), std::move(approve_signatures), send_broadcast_mode, apply, manager, std::move(promise))
+                            int send_broadcast_mode, bool apply, td::actor::ActorId<ValidatorManager> manager,
+                            td::Promise<td::Unit> promise) {
+  td::actor::create_actor<AcceptBlockQuery>(PSTRING() << "accept" << id.id.to_str(), id, std::move(data), prev,
+                                            std::move(validator_set), std::move(signatures), send_broadcast_mode, apply,
+                                            manager, std::move(promise))
       .release();
 }
 

--- a/validator/validator-group.cpp
+++ b/validator/validator-group.cpp
@@ -345,7 +345,7 @@ void ValidatorGroup::accept_block_query(BlockIdExt block_id, td::Ref<BlockData> 
   });
 
   run_accept_block_query(block_id, std::move(block), std::move(prev), validator_set_, std::move(sig_set),
-                         std::move(approve_sig_set), send_broadcast_mode, monitoring_shard_, manager_, std::move(P));
+                         send_broadcast_mode, monitoring_shard_, manager_, std::move(P));
 }
 
 void ValidatorGroup::skip_round(td::uint32 round_id) {


### PR DESCRIPTION
They are unused in AcceptBlockQuery.