### PR TITLE
Remove "proto_version" from deserialize_candidate

### DIFF
--- a/validator-session/candidate-serializer.cpp
+++ b/validator-session/candidate-serializer.cpp
@@ -45,8 +45,7 @@ td::Result<td::BufferSlice> serialize_candidate(const tl_object_ptr<ton_api::val
 
 td::Result<tl_object_ptr<ton_api::validatorSession_candidate>> deserialize_candidate(td::Slice data,
                                                                                      bool compression_enabled,
-                                                                                     int max_decompressed_data_size,
-                                                                                     int proto_version) {
+                                                                                     int max_decompressed_data_size) {
   if (!compression_enabled) {
     auto t_decompression_start = td::Time::now();
     TRY_RESULT(res, fetch_tl_object<ton_api::validatorSession_candidate>(data, true));
@@ -68,7 +67,7 @@ td::Result<tl_object_ptr<ton_api::validatorSession_candidate>> deserialize_candi
                     return td::Status::Error("decompressed size is too big");
                   }
                   TRY_RESULT(p, decompress_candidate_data(c.data_, false, c.decompressed_size_,
-                                                          max_decompressed_data_size, proto_version, c.root_hash_));
+                                                          max_decompressed_data_size, c.root_hash_));
                   return create_tl_object<ton_api::validatorSession_candidate>(c.src_, c.round_, c.root_hash_,
                                                                                std::move(p.first), std::move(p.second));
                 }();
@@ -78,8 +77,7 @@ td::Result<tl_object_ptr<ton_api::validatorSession_candidate>> deserialize_candi
                   if (c.data_.size() > max_decompressed_data_size) {
                     return td::Status::Error("Compressed data is too big");
                   }
-                  TRY_RESULT(p, decompress_candidate_data(c.data_, true, 0, max_decompressed_data_size, proto_version,
-                                                          c.root_hash_));
+                  TRY_RESULT(p, decompress_candidate_data(c.data_, true, 0, max_decompressed_data_size, c.root_hash_));
                   return create_tl_object<ton_api::validatorSession_candidate>(c.src_, c.round_, c.root_hash_,
                                                                                std::move(p.first), std::move(p.second));
                 }();
@@ -110,9 +108,11 @@ td::Result<td::BufferSlice> compress_candidate_data(td::Slice block, td::Slice c
   return compressed;
 }
 
-td::Result<std::pair<td::BufferSlice, td::BufferSlice>> decompress_candidate_data(
-    td::Slice compressed, bool improved_compression, int decompressed_size, int max_decompressed_size,
-    int proto_version, td::Bits256 root_hash) {
+td::Result<std::pair<td::BufferSlice, td::BufferSlice>> decompress_candidate_data(td::Slice compressed,
+                                                                                  bool improved_compression,
+                                                                                  int decompressed_size,
+                                                                                  int max_decompressed_size,
+                                                                                  td::Bits256 root_hash) {
   std::vector<td::Ref<vm::Cell>> roots;
   auto t_decompression_start = td::Time::now();
   if (!improved_compression) {
@@ -135,8 +135,7 @@ td::Result<std::pair<td::BufferSlice, td::BufferSlice>> decompress_candidate_dat
   }
   TRY_RESULT(block_data, vm::std_boc_serialize(roots[0], 31));
   roots.erase(roots.begin());
-  int collated_data_mode = proto_version >= 5 ? 2 : 31;
-  TRY_RESULT(collated_data, vm::std_boc_serialize_multi(std::move(roots), collated_data_mode));
+  TRY_RESULT(collated_data, vm::std_boc_serialize_multi(std::move(roots), 2));
   LOG(DEBUG) << "Decompressing block candidate " << (improved_compression ? "V2:" : ":") << compressed.size() << " -> "
              << block_data.size() + collated_data.size();
   return std::make_pair(std::move(block_data), std::move(collated_data));

--- a/validator-session/candidate-serializer.h
+++ b/validator-session/candidate-serializer.h
@@ -24,13 +24,14 @@ td::Result<td::BufferSlice> serialize_candidate(const tl_object_ptr<ton_api::val
                                                 bool compression_enabled);
 td::Result<tl_object_ptr<ton_api::validatorSession_candidate>> deserialize_candidate(td::Slice data,
                                                                                      bool compression_enabled,
-                                                                                     int max_decompressed_data_size,
-                                                                                     int proto_version);
+                                                                                     int max_decompressed_data_size);
 
 td::Result<td::BufferSlice> compress_candidate_data(td::Slice block, td::Slice collated_data, size_t& decompressed_size,
                                                     td::Bits256 root_hash);
-td::Result<std::pair<td::BufferSlice, td::BufferSlice>> decompress_candidate_data(
-    td::Slice compressed, bool improved_compression, int decompressed_size, int max_decompressed_size,
-    int proto_version, td::Bits256 root_hash);
+td::Result<std::pair<td::BufferSlice, td::BufferSlice>> decompress_candidate_data(td::Slice compressed,
+                                                                                  bool improved_compression,
+                                                                                  int decompressed_size,
+                                                                                  int max_decompressed_size,
+                                                                                  td::Bits256 root_hash);
 
 }  // namespace ton::validatorsession

--- a/validator-session/validator-session.cpp
+++ b/validator-session/validator-session.cpp
@@ -242,8 +242,7 @@ void ValidatorSessionImpl::process_broadcast(PublicKeyHash src, td::BufferSlice 
   td::Timer deserialize_timer;
   auto R =
       deserialize_candidate(data, compress_block_candidates_,
-                            description().opts().max_block_size + description().opts().max_collated_data_size + 1024,
-                            description().opts().proto_version);
+                            description().opts().max_block_size + description().opts().max_collated_data_size + 1024);
   double deserialize_time = deserialize_timer.elapsed();
   if (R.is_error()) {
     VLOG(VALIDATOR_SESSION_WARNING) << this << "[node " << src << "][broadcast " << sha256_bits256(data.as_slice())

--- a/validator/collation-manager.hpp
+++ b/validator/collation-manager.hpp
@@ -40,13 +40,12 @@ class CollationManager : public td::actor::Actor {
   void collate_block(ShardIdFull shard, BlockIdExt min_masterchain_block_id, std::vector<BlockIdExt> prev,
                      Ed25519_PublicKey creator, BlockCandidatePriority priority, td::Ref<ValidatorSet> validator_set,
                      td::uint64 max_answer_size, td::CancellationToken cancellation_token,
-                     td::Promise<GeneratedCandidate> promise, int proto_version);
+                     td::Promise<GeneratedCandidate> promise);
 
   void collate_block_optimistic(ShardIdFull shard, BlockIdExt min_masterchain_block_id, BlockIdExt prev_block_id,
                                 td::BufferSlice prev_block, Ed25519_PublicKey creator, BlockCandidatePriority priority,
                                 td::Ref<ValidatorSet> validator_set, td::uint64 max_answer_size,
-                                td::CancellationToken cancellation_token, td::Promise<GeneratedCandidate> promise,
-                                int proto_version);
+                                td::CancellationToken cancellation_token, td::Promise<GeneratedCandidate> promise);
 
   void update_options(td::Ref<ValidatorManagerOptions> opts);
 
@@ -68,7 +67,7 @@ class CollationManager : public td::actor::Actor {
                            Ed25519_PublicKey creator, BlockCandidatePriority priority,
                            td::Ref<ValidatorSet> validator_set, td::uint64 max_answer_size,
                            td::CancellationToken cancellation_token, td::Promise<GeneratedCandidate> promise,
-                           td::Timestamp timeout, int proto_version, bool is_optimistic = false);
+                           td::Timestamp timeout, bool is_optimistic = false);
 
   void update_collators_list(const CollatorsList& collators_list);
 

--- a/validator/collator-node/collator-node-session.cpp
+++ b/validator/collator-node/collator-node-session.cpp
@@ -293,8 +293,7 @@ void CollatorNodeSession::process_request_optimistic_cont2(BlockIdExt prev_block
                             "failed to download prev block data for optimistic collation: ");
   TRY_RESULT_PROMISE_PREFIX(promise, f, fetch_tl_object<ton_api::collatorNode_Candidate>(response, true),
                             "failed to download prev block data for optimistic collation: ");
-  TRY_RESULT_PROMISE_PREFIX(promise, candidate,
-                            deserialize_candidate(std::move(f), max_candidate_size_, proto_version_),
+  TRY_RESULT_PROMISE_PREFIX(promise, candidate, deserialize_candidate(std::move(f), max_candidate_size_),
                             "failed to download prev block data for optimistic collation: ");
   TRY_RESULT_PROMISE_PREFIX(promise, prev_block, create_block(prev_block_id, std::move(candidate.data)),
                             "invalid prev block data from validator: ");

--- a/validator/collator-node/utils.cpp
+++ b/validator/collator-node/utils.cpp
@@ -39,57 +39,57 @@ tl_object_ptr<ton_api::collatorNode_Candidate> serialize_candidate(const BlockCa
 }
 
 td::Result<BlockCandidate> deserialize_candidate(tl_object_ptr<ton_api::collatorNode_Candidate> f,
-                                                 int max_decompressed_data_size, int proto_version) {
+                                                 int max_decompressed_data_size) {
   td::Result<BlockCandidate> res;
-  ton_api::downcast_call(*f, td::overloaded(
-                                 [&](ton_api::collatorNode_candidate& c) {
-                                   res = [&]() -> td::Result<BlockCandidate> {
-                                     auto hash = td::sha256_bits256(c.collated_data_);
-                                     auto key = PublicKey{c.source_};
-                                     if (!key.is_ed25519()) {
-                                       return td::Status::Error("invalid pubkey");
-                                     }
-                                     auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
-                                     return BlockCandidate{e_key, create_block_id(c.id_), hash, std::move(c.data_),
-                                                           std::move(c.collated_data_)};
-                                   }();
-                                 },
-                                 [&](ton_api::collatorNode_compressedCandidate& c) {
-                                   res = [&]() -> td::Result<BlockCandidate> {
-                                     if (c.decompressed_size_ <= 0) {
-                                       return td::Status::Error("invalid decompressed size");
-                                     }
-                                     if (c.decompressed_size_ > max_decompressed_data_size) {
-                                       return td::Status::Error("decompressed size is too big");
-                                     }
-                                     TRY_RESULT(p, validatorsession::decompress_candidate_data(
-                                                       c.data_, false, c.decompressed_size_, max_decompressed_data_size,
-                                                       proto_version, create_block_id(c.id_).root_hash));
-                                     auto collated_data_hash = td::sha256_bits256(p.second);
-                                     auto key = PublicKey{c.source_};
-                                     if (!key.is_ed25519()) {
-                                       return td::Status::Error("invalid pubkey");
-                                     }
-                                     auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
-                                     return BlockCandidate{e_key, create_block_id(c.id_), collated_data_hash,
-                                                           std::move(p.first), std::move(p.second)};
-                                   }();
-                                 },
-                                 [&](ton_api::collatorNode_compressedCandidateV2& c) {
-                                   res = [&]() -> td::Result<BlockCandidate> {
-                                     TRY_RESULT(p, validatorsession::decompress_candidate_data(
-                                                       c.data_, true, 0, max_decompressed_data_size, proto_version,
-                                                       create_block_id(c.id_).root_hash));
-                                     auto collated_data_hash = td::sha256_bits256(p.second);
-                                     auto key = PublicKey{c.source_};
-                                     if (!key.is_ed25519()) {
-                                       return td::Status::Error("invalid pubkey");
-                                     }
-                                     auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
-                                     return BlockCandidate{e_key, create_block_id(c.id_), collated_data_hash,
-                                                           std::move(p.first), std::move(p.second)};
-                                   }();
-                                 }));
+  ton_api::downcast_call(
+      *f, td::overloaded(
+              [&](ton_api::collatorNode_candidate& c) {
+                res = [&]() -> td::Result<BlockCandidate> {
+                  auto hash = td::sha256_bits256(c.collated_data_);
+                  auto key = PublicKey{c.source_};
+                  if (!key.is_ed25519()) {
+                    return td::Status::Error("invalid pubkey");
+                  }
+                  auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
+                  return BlockCandidate{e_key, create_block_id(c.id_), hash, std::move(c.data_),
+                                        std::move(c.collated_data_)};
+                }();
+              },
+              [&](ton_api::collatorNode_compressedCandidate& c) {
+                res = [&]() -> td::Result<BlockCandidate> {
+                  if (c.decompressed_size_ <= 0) {
+                    return td::Status::Error("invalid decompressed size");
+                  }
+                  if (c.decompressed_size_ > max_decompressed_data_size) {
+                    return td::Status::Error("decompressed size is too big");
+                  }
+                  TRY_RESULT(p, validatorsession::decompress_candidate_data(c.data_, false, c.decompressed_size_,
+                                                                            max_decompressed_data_size,
+                                                                            create_block_id(c.id_).root_hash));
+                  auto collated_data_hash = td::sha256_bits256(p.second);
+                  auto key = PublicKey{c.source_};
+                  if (!key.is_ed25519()) {
+                    return td::Status::Error("invalid pubkey");
+                  }
+                  auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
+                  return BlockCandidate{e_key, create_block_id(c.id_), collated_data_hash, std::move(p.first),
+                                        std::move(p.second)};
+                }();
+              },
+              [&](ton_api::collatorNode_compressedCandidateV2& c) {
+                res = [&]() -> td::Result<BlockCandidate> {
+                  TRY_RESULT(p, validatorsession::decompress_candidate_data(
+                                    c.data_, true, 0, max_decompressed_data_size, create_block_id(c.id_).root_hash));
+                  auto collated_data_hash = td::sha256_bits256(p.second);
+                  auto key = PublicKey{c.source_};
+                  if (!key.is_ed25519()) {
+                    return td::Status::Error("invalid pubkey");
+                  }
+                  auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
+                  return BlockCandidate{e_key, create_block_id(c.id_), collated_data_hash, std::move(p.first),
+                                        std::move(p.second)};
+                }();
+              }));
   return res;
 }
 

--- a/validator/collator-node/utils.hpp
+++ b/validator/collator-node/utils.hpp
@@ -23,5 +23,5 @@ namespace ton::validator {
 
 tl_object_ptr<ton_api::collatorNode_Candidate> serialize_candidate(const BlockCandidate& block, bool compress);
 td::Result<BlockCandidate> deserialize_candidate(tl_object_ptr<ton_api::collatorNode_Candidate> f,
-                                                 int max_decompressed_data_size, int proto_version);
+                                                 int max_decompressed_data_size);
 }  // namespace ton::validator

--- a/validator/impl/collator.cpp
+++ b/validator/impl/collator.cpp
@@ -6411,8 +6411,7 @@ bool Collator::create_block_candidate() {
     if (res.is_error()) {
       return fatal_error(res.move_as_error());
     }
-    int cdata_serialize_mode = consensus_config.proto_version >= 5 ? 2 : 31;
-    auto cdata_res = boc_collated.serialize_to_slice(cdata_serialize_mode);
+    auto cdata_res = boc_collated.serialize_to_slice(2);
     if (cdata_res.is_error()) {
       LOG(ERROR) << "cannot serialize collated data";
       return fatal_error(cdata_res.move_as_error());

--- a/validator/validator-group.cpp
+++ b/validator/validator-group.cpp
@@ -99,7 +99,7 @@ void ValidatorGroup::generate_block_candidate_cont(validatorsession::BlockSource
   td::actor::send_closure(collation_manager_, &CollationManager::collate_block, shard_, min_masterchain_block_id_,
                           prev_block_ids_, Ed25519_PublicKey{local_id_full_.ed25519_value().raw()},
                           source_info.priority, validator_set_, max_answer_size, std::move(cancellation_token),
-                          std::move(promise), config_.proto_version);
+                          std::move(promise));
 }
 
 void ValidatorGroup::generated_block_candidate(validatorsession::BlockSourceInfo source_info,
@@ -394,7 +394,7 @@ void ValidatorGroup::generate_block_optimistic(validatorsession::BlockSourceInfo
                           min_masterchain_block_id_, block_id, std::move(prev_block),
                           Ed25519_PublicKey{local_id_full_.ed25519_value().raw()}, source_info.priority, validator_set_,
                           max_answer_size, optimistic_generation_->cancellation_token_source.get_cancellation_token(),
-                          std::move(P), config_.proto_version);
+                          std::move(P));
 }
 
 void ValidatorGroup::generated_block_optimistic(validatorsession::BlockSourceInfo source_info,


### PR DESCRIPTION
proto_version was passed there for consensus reasons and is not needed anymore. Removing this simplifies code.