### PR TITLE
fix(build): bug in scripts for `Windows`

### DIFF
--- a/assembly/native/build-windows-2019.bat
+++ b/assembly/native/build-windows-2019.bat
@@ -35,8 +35,8 @@ IF %errorlevel% NEQ 0 (
 
 echo Installing nasm...
 choco install -y nasm
-where nasm
 SET PATH=%PATH%;C:\Program Files\NASM
+where nasm
 IF %errorlevel% NEQ 0 (
   echo Can't install nasm
   exit /b %errorlevel%

--- a/assembly/native/build-windows-2022.bat
+++ b/assembly/native/build-windows-2022.bat
@@ -35,8 +35,8 @@ IF %errorlevel% NEQ 0 (
 
 echo Installing nasm...
 choco install -y nasm
-where nasm
 SET PATH=%PATH%;C:\Program Files\NASM
+where nasm
 IF %errorlevel% NEQ 0 (
   echo Can't install nasm
   exit /b %errorlevel%

--- a/assembly/native/build-windows.bat
+++ b/assembly/native/build-windows.bat
@@ -35,8 +35,8 @@ IF %errorlevel% NEQ 0 (
 
 echo Installing nasm...
 choco install -y nasm
-where nasm
 SET PATH=%PATH%;C:\Program Files\NASM
+where nasm
 IF %errorlevel% NEQ 0 (
   echo Can't install nasm
   exit /b %errorlevel%


### PR DESCRIPTION
Error in the logic of checking that `nasm` exists in the system. Currently, it is checked that the `SET` command worked successfully, not `where nasm`... now, search paths are added to `PATH` first, and only then is the presence of `nasm` checked. 