### PR TITLE
Fix bad clang-format formatting

### DIFF
--- a/quic/quic-pimpl.cpp
+++ b/quic/quic-pimpl.cpp
@@ -281,7 +281,7 @@ ngtcp2_path QuicConnectionPImpl::make_path() const {
 }
 
 td::Status QuicConnectionPImpl::write_one_packet(UdpMessageBuffer& msg_out, QuicStreamID sid) {
-  if (streams_blocked_) { // same as NGTCP2_ERR_STREAM_DATA_BLOCKED by its nature
+  if (streams_blocked_) {  // same as NGTCP2_ERR_STREAM_DATA_BLOCKED by its nature
     msg_out.storage.truncate(0);
     return td::Status::OK();
   }
@@ -384,16 +384,15 @@ QuicConnectionId QuicConnectionPImpl::get_primary_scid() const {
   return primary_scid_;
 }
 
-void QuicConnectionPImpl::block_streams(){
+void QuicConnectionPImpl::block_streams() {
   CHECK(!streams_blocked_);
   streams_blocked_ = true;
 }
 
-void QuicConnectionPImpl::unblock_streams(){
+void QuicConnectionPImpl::unblock_streams() {
   CHECK(streams_blocked_);
   streams_blocked_ = false;
 }
-
 
 td::Result<QuicStreamID> QuicConnectionPImpl::open_stream() {
   QuicStreamID sid;

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -2186,8 +2186,9 @@ void ValidatorEngine::start_validator() {
                                                           !state_serializer_disabled_flag_);
   load_collator_options();
 
-  validator_manager_ = ton::validator::ValidatorManagerFactory::create(
-      validator_options_, db_root_, keyring_.get(), adnl_.get(), rldp_.get(), rldp2_.get(), quic_.get(), overlay_manager_.get());
+  validator_manager_ =
+      ton::validator::ValidatorManagerFactory::create(validator_options_, db_root_, keyring_.get(), adnl_.get(),
+                                                      rldp_.get(), rldp2_.get(), quic_.get(), overlay_manager_.get());
 
   for (auto &v : config_.validators) {
     td::actor::send_closure(validator_manager_, &ton::validator::ValidatorManagerInterface::add_permanent_key, v.first,

--- a/validator-session/validator-session.cpp
+++ b/validator-session/validator-session.cpp
@@ -548,8 +548,8 @@ void ValidatorSessionImpl::candidate_decision_ok(td::uint32 round, ValidatorSess
   td::actor::send_closure(keyring_, &keyring::Keyring::sign_message, local_id(), std::move(data), std::move(P));
 }
 
-void ValidatorSessionImpl::candidate_approved_signed(td::uint32 round, ValidatorSessionCandidateId hash,
-                                                     double ok_from, td::BufferSlice signature) {
+void ValidatorSessionImpl::candidate_approved_signed(td::uint32 round, ValidatorSessionCandidateId hash, double ok_from,
+                                                     td::BufferSlice signature) {
   pending_approve_.erase(hash);
   approved_[hash] = std::pair<double, td::BufferSlice>{ok_from, std::move(signature)};
 


### PR DESCRIPTION
The commits that introduces unformatted changes would have failed in CI if CI didn't fail on any run because of OpenSSL 3.5.