### PR TITLE
chore(crypto): ignore `unknown pragma` warning in `MSVC`

### DIFF
--- a/crypto/openssl/digest.hpp
+++ b/crypto/openssl/digest.hpp
@@ -128,8 +128,10 @@ typedef HashCtx<OpensslEVP_SHA512> SHA512;
 
 struct SHA256Tag {};
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 template <>
 struct HashCtx<SHA256Tag> {
@@ -177,7 +179,9 @@ struct HashCtx<SHA256Tag> {
   SHA256_CTX ctx_;
 };
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
 typedef HashCtx<SHA256Tag> SHA256;
 


### PR DESCRIPTION
Removed the display of `warning C4068: unknown pragma 'GCC'` for the `MSVC` compiler