### PR TITLE
Fix empty collated data

### DIFF
--- a/crypto/block/adjust-block.cpp
+++ b/crypto/block/adjust-block.cpp
@@ -76,7 +76,7 @@ td::Ref<vm::Cell> load_block(std::string filename, ton::BlockIdExt& id) {
   if (res.is_error()) {
     throw IntError{PSTRING() << "cannot deserialize bag-of-cells " << res.move_as_error()};
   }
-  if (res.move_as_ok() <= 0 || boc.get_root_cell().is_null()) {
+  if (boc.get_root_cell().is_null()) {
     throw IntError{"cannot deserialize bag-of-cells"};
   }
   auto root = boc.get_root_cell();

--- a/crypto/block/block-db.cpp
+++ b/crypto/block/block-db.cpp
@@ -141,7 +141,7 @@ td::Status ZerostateInfo::base_check() {
   }
   vm::BagOfCells boc;
   auto res = boc.deserialize(data);
-  if (!res.is_ok() || boc.get_root_count() != 1) {
+  if (res.is_error() || boc.get_root_count() != 1) {
     return td::Status::Error("zerostate is not a valid bag of cells");  // not a valid bag-of-Cells
   }
   data_hash = boc.get_root_cell()->get_hash().bits();

--- a/crypto/block/dump-block.cpp
+++ b/crypto/block/dump-block.cpp
@@ -68,7 +68,7 @@ td::Ref<vm::Cell> load_boc(std::string filename) {
   if (res.is_error()) {
     throw IntError{PSTRING() << "cannot deserialize bag-of-cells " << res.move_as_error()};
   }
-  if (res.move_as_ok() <= 0 || boc.get_root_cell().is_null()) {
+  if (boc.get_root_cell().is_null()) {
     throw IntError{"cannot deserialize bag-of-cells "};
   }
   return boc.get_root_cell();

--- a/crypto/block/test-block.cpp
+++ b/crypto/block/test-block.cpp
@@ -59,7 +59,7 @@ td::Ref<vm::Cell> load_boc(std::string filename) {
   if (res.is_error()) {
     throw IntError{PSTRING() << "cannot deserialize bag-of-cells " << res.move_as_error()};
   }
-  if (res.move_as_ok() <= 0 || boc.get_root_cell().is_null()) {
+  if (boc.get_root_cell().is_null()) {
     throw IntError{"cannot deserialize bag-of-cells "};
   }
   return boc.get_root_cell();

--- a/crypto/fift/words.cpp
+++ b/crypto/fift/words.cpp
@@ -1387,7 +1387,7 @@ void interpret_boc_deserialize(vm::Stack& stack) {
   if (res.is_error()) {
     throw IntError{(PSLICE() << "cannot deserialize bag-of-cells " << res.error()).c_str()};
   }
-  if (res.ok() <= 0 || boc.get_root_cell().is_null()) {
+  if (boc.get_root_cell().is_null()) {
     throw IntError{"cannot deserialize bag-of-cells "};
   }
   stack.push_cell(boc.get_root_cell());

--- a/crypto/test/test-db.cpp
+++ b/crypto/test/test-db.cpp
@@ -890,6 +890,26 @@ TEST(TonDb, BocFuzz) {
           .move_as_ok())
       .ensure_error();
 }
+
+TEST(TonDb, BocDeserializeTruncated) {
+  td::Random::Xorshift128plus rnd{123};
+  auto serialized = serialize_boc(gen_random_cell(8, rnd), 31);
+  CHECK(serialized.size() > 1);
+
+  auto truncated = td::Slice{serialized}.substr(0, serialized.size() - 1);
+
+  // Truncated data deserialization causes error
+  vm::BagOfCells boc;
+  boc.deserialize(truncated).ensure_error();
+  vm::std_boc_deserialize(truncated).ensure_error();
+  vm::std_boc_deserialize_multi(truncated).ensure_error();
+
+  // Empty data deserializes into empty vector of roots
+  td::BufferSlice empty;
+  auto empty_roots = vm::std_boc_deserialize_multi(empty.as_slice()).move_as_ok();
+  CHECK(empty_roots.empty());
+}
+
 void test_parse_prefix(td::Slice boc) {
   for (size_t i = 0; i <= boc.size(); i++) {
     auto prefix = boc.substr(0, i);

--- a/crypto/vm/boc.cpp
+++ b/crypto/vm/boc.cpp
@@ -799,22 +799,18 @@ td::Result<td::Ref<vm::DataCell>> BagOfCells::deserialize_cell(int idx, td::Slic
 td::Result<long long> BagOfCells::deserialize(const td::Slice& data, int max_roots) {
   clear();
   long long size_est = info.parse_serialized_header(data);
-  //LOG(INFO) << "estimated size " << size_est << ", true size " << data.size();
   if (size_est == 0) {
     return td::Status::Error(PSLICE() << "cannot deserialize bag-of-cells: invalid header, error " << size_est);
   }
   if (size_est < 0) {
-    //LOG(ERROR) << "cannot deserialize bag-of-cells: not enough bytes (" << data.size() << " present, " << -size_est
-    //<< " required)";
-    return size_est;
+    return td::Status::Error(PSLICE() << "cannot deserialize bag-of-cells: not enough bytes (" << data.size()
+                                      << " present, " << -size_est << " required)");
   }
 
   if (size_est > (long long)data.size()) {
-    //LOG(ERROR) << "cannot deserialize bag-of-cells: not enough bytes (" << data.size() << " present, " << size_est
-    //<< " required)";
-    return -size_est;
+    return td::Status::Error(PSLICE() << "cannot deserialize bag-of-cells: not enough bytes (" << data.size()
+                                      << " present, " << size_est << " required)");
   }
-  //LOG(INFO) << "estimated size " << size_est << ", true size " << data.size();
   if (info.root_count > max_roots) {
     return td::Status::Error("Bag-of-cells has more root cells than expected");
   }

--- a/crypto/vm/db/StaticBagOfCellsDb.cpp
+++ b/crypto/vm/db/StaticBagOfCellsDb.cpp
@@ -195,10 +195,7 @@ td::Result<std::shared_ptr<StaticBagOfCellsDb>> StaticBagOfCellsDbBaseline::crea
 
 td::Result<std::shared_ptr<StaticBagOfCellsDb>> StaticBagOfCellsDbBaseline::create(td::Slice data) {
   BagOfCells boc;
-  TRY_RESULT(x, boc.deserialize(data));
-  if (x <= 0) {
-    return td::Status::Error("failed to deserialize");
-  }
+  TRY_STATUS(boc.deserialize(data));
   std::vector<Ref<Cell>> roots(boc.get_root_count());
   for (int i = 0; i < boc.get_root_count(); i++) {
     roots[i] = boc.get_root_cell(i);

--- a/crypto/vm/db/TonDb.cpp
+++ b/crypto/vm/db/TonDb.cpp
@@ -117,10 +117,9 @@ void SmartContractDbImpl::sync_root_with_db() {
     } else {
       std::string boc_serialized;
       kv_->get("boc", boc_serialized);
-      BagOfCells boc;
-      //TODO: check error
-      boc.deserialize(boc_serialized);
-      db_root_ = boc.get_root_cell();
+      auto r_root = std_boc_deserialize(boc_serialized);
+      CHECK(r_root.is_ok());
+      db_root_ = r_root.move_as_ok();
     }
     CHECK(db_root_->get_hash().as_slice() == root_hash);
     new_root_ = db_root_;

--- a/validator-session/candidate-serializer.cpp
+++ b/validator-session/candidate-serializer.cpp
@@ -98,16 +98,14 @@ td::Result<tl_object_ptr<ton_api::validatorSession_candidate>> deserialize_candi
 
 td::Result<td::BufferSlice> compress_candidate_data(td::Slice block, td::Slice collated_data, size_t& decompressed_size,
                                                     std::string called_from, td::Bits256 root_hash) {
-  vm::BagOfCells boc1, boc2;
+  vm::BagOfCells boc1;
   TRY_STATUS(boc1.deserialize(block));
   if (boc1.get_root_count() != 1) {
     return td::Status::Error("block candidate should have exactly one root");
   }
   std::vector<td::Ref<vm::Cell>> roots = {boc1.get_root_cell()};
-  TRY_STATUS(boc2.deserialize(collated_data));
-  for (int i = 0; i < boc2.get_root_count(); ++i) {
-    roots.push_back(boc2.get_root_cell(i));
-  }
+  TRY_RESULT(collated_roots, vm::std_boc_deserialize_multi(collated_data));
+  roots.insert(roots.end(), collated_roots.begin(), collated_roots.end());
   auto t_compression_start = td::Time::now();
   TRY_RESULT(data, vm::std_boc_serialize_multi(std::move(roots), 2));
   decompressed_size = data.size();

--- a/validator/impl/validate-query.cpp
+++ b/validator/impl/validate-query.cpp
@@ -460,7 +460,7 @@ void ValidateQuery::load_prev_states() {
  * @returns True if the block candidate was successfully unpacked, false otherwise.
  */
 bool ValidateQuery::unpack_block_candidate() {
-  vm::BagOfCells boc1, boc2;
+  vm::BagOfCells boc1;
   // 1. deserialize block itself
   FileHash fhash = block::compute_file_hash(block_candidate.data);
   if (fhash != id_.file_hash) {
@@ -497,15 +497,11 @@ bool ValidateQuery::unpack_block_candidate() {
   }
   // ...
   // 8. deserialize collated data
-  auto res2 = boc2.deserialize(block_candidate.collated_data);
+  auto res2 = vm::std_boc_deserialize_multi(block_candidate.collated_data);
   if (res2.is_error()) {
     return reject_query("cannot deserialize collated data", res2.move_as_error());
   }
-  int n = boc2.get_root_count();
-  REJECT_UNLESS(n >= 0);
-  for (int i = 0; i < n; i++) {
-    collated_roots_.emplace_back(boc2.get_root_cell(i));
-  }
+  collated_roots_ = res2.move_as_ok();
   // 9. extract/classify collated data
   return extract_collated_data();
 }


### PR DESCRIPTION
- Fixed behavior mismatch between compression and decompression of empty collated data. 
- Improved external interface of boc.deserialize() method. Now it returns an error status instead of a negative size in case of header parsing error. It simplifies result processing in caller sites and avoids confusion.