### PR TITLE
fix wrong getoriginalfwdfee formula in docs

### DIFF
--- a/doc/GlobalVersions.md
+++ b/doc/GlobalVersions.md
@@ -82,7 +82,7 @@ __Enabled in mainnet on 2024-03-16__
 * `GETSTORAGEFEE` (`cells bits seconds is_mc - price`) - calculates storage fees (only current StoragePrices entry is used).
 * `GETFORWARDFEE` (`cells bits is_mc - price`) - calculates forward fee.
 * `GETPRECOMPILEDGAS` (`- x`) - returns gas usage for the current contract if it is precompiled, `null` otherwise.
-* `GETORIGINALFWDFEE` (`fwd_fee is_mc - orig_fwd_fee`) - calculate `fwd_fee * 2^16 / first_frac`. Can be used to get the original `fwd_fee` of the message.
+* `GETORIGINALFWDFEE` (`fwd_fee is_mc - orig_fwd_fee`) - calculate `fwd_fee * 2^16 / (2^16 - first_frac)`. Can be used to get the original `fwd_fee` of the message.
 * `GETGASFEESIMPLE` (`gas_used is_mc - price`) - same as `GETGASFEE`, but without flat price (just `(gas_used * price) / 2^16`).
 * `GETFORWARDFEESIMPLE` (`cells bits is_mc - price`) - same as `GETFORWARDFEE`, but without lump price (just `(bits*bit_price + cells*cell_price) / 2^16`).
 


### PR DESCRIPTION
## summary
- fix incorrect GETORIGINALFWDFEE formula in doc/GlobalVersions.md
- doc said fwd_fee * 2^16 / first_frac but implementation uses fwd_fee * 2^16 / (2^16 - first_frac)

## test plan
- verified against actual implementation in crypto/vm/tonops.cpp

fixes #1878