### PR TITLE
Add checks for validators weight overflow

### DIFF
--- a/crypto/block/signature-set.cpp
+++ b/crypto/block/signature-set.cpp
@@ -86,7 +86,7 @@ class BlockSignatureSetBase : public BlockSignatureSet {
 
   virtual td::Result<td::BufferSlice> to_sign(ton::BlockIdExt block_id) const = 0;
   virtual bool check_threshold(ton::ValidatorWeight sig_weight, ton::ValidatorWeight total_weight) const {
-    return sig_weight * 3 > total_weight * 2;
+    return ton::validator_weight_is_supermajority(sig_weight, total_weight);
   }
 
   size_t get_size() const override {
@@ -106,7 +106,9 @@ class BlockSignatureSetBase : public BlockSignatureSet {
       if (!validator) {
         return td::Status::Error(ton::ErrorCode::protoviolation, "unknown node");
       }
-      weight += validator->weight;
+      if (!ton::validator_weight_add(weight, validator->weight)) {
+        return td::Status::Error(ton::ErrorCode::protoviolation, "signature weight overflow");
+      }
     }
     return weight;
   }
@@ -149,7 +151,9 @@ class BlockSignatureSetBase : public BlockSignatureSet {
 
       auto E = ton::PublicKey{ton::pubkeys::Ed25519{validator->key}}.create_encryptor().move_as_ok();
       TRY_STATUS(E->check_signature(data, sig.signature.as_slice()));
-      weight += validator->weight;
+      if (!ton::validator_weight_add(weight, validator->weight)) {
+        return td::Status::Error(ton::ErrorCode::protoviolation, "signature weight overflow");
+      }
     }
 
     if (!check_threshold(weight, vset->get_total_weight())) {

--- a/crypto/block/validator-set.cpp
+++ b/crypto/block/validator-set.cpp
@@ -42,7 +42,7 @@ ValidatorSet::ValidatorSet(ton::CatchainSeqno cc_seqno, ton::ShardIdFull from, s
   ids_map_.reserve(ids_.size());
 
   for (std::size_t i = 0; i < ids_.size(); i++) {
-    total_weight_ += ids_[i].weight;
+    CHECK(ton::validator_weight_add(total_weight_, ids_[i].weight));
     ids_map_.emplace_back(ton::PublicKey{ton::pubkeys::Ed25519{ids_[i].key}}.compute_short_id().bits256_value(), i);
   }
 

--- a/ton/ton-types.h
+++ b/ton/ton-types.h
@@ -29,6 +29,7 @@
 #include "td/utils/buffer.h"
 #include "td/utils/misc.h"
 #include "td/utils/optional.h"
+#include "td/utils/uint128.h"
 
 namespace ton {
 
@@ -49,6 +50,28 @@ using ValidatorWeight = td::uint64;  // was td::uint32 before
 using CatchainSeqno = td::uint32;
 
 using ValidatorSessionId = td::Bits256;
+
+inline bool validator_weight_add(ValidatorWeight& total_weight, ValidatorWeight weight) {
+  if (weight > ~total_weight) {
+    return false;
+  }
+  total_weight += weight;
+  return true;
+}
+
+inline bool validator_weight_is_supermajority(ValidatorWeight signed_weight, ValidatorWeight total_weight) {
+  auto lhs = td::uint128::from_unsigned(signed_weight).mult(3);
+  auto rhs = td::uint128::from_unsigned(total_weight).mult(2);
+  return lhs.hi() > rhs.hi() || (lhs.hi() == rhs.hi() && lhs.lo() > rhs.lo());
+}
+
+inline ValidatorWeight validator_weight_supermajority_threshold(ValidatorWeight total_weight) {
+  return td::uint128::from_unsigned(total_weight)
+      .mult(2)
+      .div(td::uint128::from_unsigned(3))
+      .add(td::uint128::from_unsigned(1))
+      .lo();
+}
 
 constexpr WorkchainId masterchainId = -1, basechainId = 0, workchainInvalid = 0x80000000;
 constexpr ShardId shardIdAll = (1ULL << 63);

--- a/validator/consensus/bridge.cpp
+++ b/validator/consensus/bridge.cpp
@@ -226,10 +226,10 @@ class BridgeImpl final : public IValidatorGroup {
     bus->manager = manager_facade_.get();
     bus->keyring = params_.keyring;
     bus->validator_opts = params_.validator_opts;
+    bus->total_weight = params_.validator_set->get_total_weight();
 
     bool found = false;
     size_t idx = 0;
-    ValidatorWeight total_weight = 0;
     for (const auto& el : params_.validator_set->export_vector()) {
       PublicKey key{pubkeys::Ed25519{el.key}};
       PublicKeyHash short_id = key.compute_short_id();
@@ -246,11 +246,8 @@ class BridgeImpl final : public IValidatorGroup {
         found = true;
         bus->local_id = bus->validator_set.back();
       }
-
-      total_weight += el.weight;
       ++idx;
     }
-    bus->total_weight = total_weight;
     bus->cc_seqno = params_.validator_set->get_catchain_seqno();
     bus->validator_set_hash = params_.validator_set->get_validator_set_hash();
     CHECK(found);

--- a/validator/consensus/simplex/certificate.cpp
+++ b/validator/consensus/simplex/certificate.cpp
@@ -31,10 +31,12 @@ td::Result<td::Ref<Certificate<T>>> Certificate<T>::from_tl(tl::voteSignatureSet
 
     auto validator = PeerValidatorId{who}.get_using(bus);
     signatures.emplace_back(VoteSignature{validator.idx, std::move(signature->signature_)});
-    voted_weight += validator.weight;
+    if (!ton::validator_weight_add(voted_weight, validator.weight)) {
+      return td::Status::Error("certificate weight overflow");
+    }
   }
 
-  if (voted_weight < (bus.total_weight * 2) / 3 + 1) {
+  if (voted_weight < ton::validator_weight_supermajority_threshold(bus.total_weight)) {
     return td::Status::Error("Not enough signatures in certificate");
   }
 

--- a/validator/consensus/simplex/pool.cpp
+++ b/validator/consensus/simplex/pool.cpp
@@ -320,7 +320,7 @@ class PoolImpl : public td::actor::SpawnsWith<Bus>, public td::actor::ConnectsTo
     slots_per_leader_window_ = bus.config.slots_per_leader_window;
     params_ = bus.config.noncritical_params;
 
-    weight_threshold_ = (bus.total_weight * 2) / 3 + 1;
+    weight_threshold_ = ton::validator_weight_supermajority_threshold(bus.total_weight);
 
     state_.emplace(State(bus));
     state_->slot_at(0)->state->available_base = ParentId{};
@@ -678,21 +678,24 @@ class PoolImpl : public td::actor::SpawnsWith<Bus>, public td::actor::ConnectsTo
   }
 
   void handle_typed_vote(const PeerValidator &validator, Signed<NotarizeVote> vote, State::SlotRef &slot) {
-    auto new_weight = (slot.state->notarize_weight[vote.vote.id] += validator.weight);
+    auto &new_weight = slot.state->notarize_weight[vote.vote.id];
+    CHECK(ton::validator_weight_add(new_weight, validator.weight));
     if (!slot.state->will_be_notarized() && new_weight >= weight_threshold_) {
       handle_certificate(slot.state->create_cert(vote.vote));
     }
   }
 
   void handle_typed_vote(const PeerValidator &validator, Signed<SkipVote> vote, State::SlotRef &slot) {
-    auto new_weight = (slot.state->skip_weight += validator.weight);
+    auto &new_weight = slot.state->skip_weight;
+    CHECK(ton::validator_weight_add(new_weight, validator.weight));
     if (!slot.state->will_be_skipped() && new_weight >= weight_threshold_) {
       handle_certificate(slot.state->create_cert(vote.vote));
     }
   }
 
   void handle_typed_vote(const PeerValidator &validator, Signed<FinalizeVote> vote, State::SlotRef &slot) {
-    auto new_weight = (slot.state->finalize_weight[vote.vote.id] += validator.weight);
+    auto &new_weight = slot.state->finalize_weight[vote.vote.id];
+    CHECK(ton::validator_weight_add(new_weight, validator.weight));
     if (!slot.state->will_be_finalized() && new_weight >= weight_threshold_) {
       handle_certificate(slot.state->create_cert(vote.vote));
     }


### PR DESCRIPTION
Although these checks are not important in practice because validator weight is limited in `elector-code.fc`, the possibility of weight overflow has been reported to the bug bounty program dozens of times. To avoid wasting security researchers’ time, we decided to add these checks explicitly.
