### PR TITLE
Update QUIC flood control for shared validator IPs

### DIFF
--- a/adnl/adnl-sender-ex.h
+++ b/adnl/adnl-sender-ex.h
@@ -27,6 +27,10 @@ class AdnlSenderEx : public AdnlSenderInterface {
   }
 
   virtual void add_id(AdnlNodeIdShort local_id) = 0;
+  virtual void add_protected_peers(AdnlNodeIdShort local_id, std::vector<AdnlNodeIdShort> peer_ids) {
+  }
+  virtual void remove_protected_peers(AdnlNodeIdShort local_id, std::vector<AdnlNodeIdShort> peer_ids) {
+  }
 
   // MTU for incoming messages in peer pair (local_id, peer_id) is max of:
   // - default mtu

--- a/quic/quic-pimpl.h
+++ b/quic/quic-pimpl.h
@@ -13,6 +13,7 @@
 #include "ngtcp2/ngtcp2_crypto.h"
 #include "ngtcp2/ngtcp2_crypto_ossl.h"
 #include "td/utils/Time.h"
+#include "td/utils/format.h"
 #include "td/utils/port/UdpSocketFd.h"
 
 #include "openssl-utils.h"
@@ -79,13 +80,18 @@ struct VersionCid {
       return td::Status::Error("empty datagram");
     }
 
-    ngtcp2_pkt_hd hd;
+    ngtcp2_pkt_hd hd{};
     int rv = ngtcp2_accept(&hd, reinterpret_cast<const uint8_t*>(datagram.data()), datagram.size());
     if (rv != 0) {
-      return td::Status::Error("packet is not acceptable as an initial packet");
+      return build_not_acceptable_as_initial_error(datagram, rv);
     }
     if (hd.type != NGTCP2_PKT_INITIAL) {
-      return td::Status::Error("first packet is not an initial packet");
+      return td::Status::Error(
+          PSTRING() << "unknown CID packet rejected as new connection: reason=long_header_non_initial "
+                    << packet_diagnostic_prefix(datagram) << " pkt_type=" << packet_type_name(hd.type)
+                    << " version=" << td::format::as_hex(hd.version) << " dcid=" << cid_to_string(hd.dcid)
+                    << " dcid_len=" << hd.dcid.datalen << " scid=" << cid_to_string(hd.scid)
+                    << " scid_len=" << hd.scid.datalen << " token_len=" << hd.tokenlen);
     }
 
     td::Slice token;
@@ -96,6 +102,84 @@ struct VersionCid {
   }
 
  private:
+  static td::Status build_not_acceptable_as_initial_error(td::Slice datagram, int accept_rv) {
+    if (!has_long_header(datagram)) {
+      return td::Status::Error(
+          PSTRING() << "unknown CID packet rejected as new connection: reason=short_header_unknown_cid "
+                    << packet_diagnostic_prefix(datagram) << version_cid_diagnostic(datagram)
+                    << " accept_rv=" << accept_rv);
+    }
+
+    ngtcp2_pkt_hd hd{};
+    auto long_rv = ngtcp2_pkt_decode_hd_long(&hd, reinterpret_cast<const uint8_t*>(datagram.data()), datagram.size());
+    if (long_rv < 0) {
+      return td::Status::Error(
+          PSTRING() << "unknown CID packet rejected as new connection: reason=malformed_long_header "
+                    << packet_diagnostic_prefix(datagram) << version_cid_diagnostic(datagram)
+                    << " accept_rv=" << accept_rv << " long_decode_rv=" << long_rv);
+    }
+
+    const char* reason = hd.type == NGTCP2_PKT_INITIAL ? "initial_rejected_by_ngtcp2" : "long_header_non_initial";
+    return td::Status::Error(PSTRING() << "unknown CID packet rejected as new connection: reason=" << reason << ' '
+                                       << packet_diagnostic_prefix(datagram) << " pkt_type="
+                                       << packet_type_name(hd.type) << " version=" << td::format::as_hex(hd.version)
+                                       << " dcid=" << cid_to_string(hd.dcid) << " dcid_len=" << hd.dcid.datalen
+                                       << " scid=" << cid_to_string(hd.scid) << " scid_len=" << hd.scid.datalen
+                                       << " token_len=" << hd.tokenlen << " accept_rv=" << accept_rv);
+  }
+
+  static bool has_long_header(td::Slice datagram) {
+    CHECK(!datagram.empty());
+    return (static_cast<td::uint8>(datagram[0]) & 0x80u) != 0;
+  }
+
+  static std::string packet_diagnostic_prefix(td::Slice datagram) {
+    CHECK(!datagram.empty());
+    const auto first_byte = static_cast<td::uint8>(datagram[0]);
+    return PSTRING() << "size=" << datagram.size() << " first_byte=" << td::format::as_hex(first_byte)
+                     << " long_header=" << (has_long_header(datagram) ? "yes" : "no")
+                     << " fixed_bit=" << (((first_byte & 0x40u) != 0) ? "set" : "clear");
+  }
+
+  static std::string version_cid_diagnostic(td::Slice datagram) {
+    auto vc = from_datagram(datagram);
+    if (vc.is_error()) {
+      return PSTRING() << " version_cid_decode=" << vc.error();
+    }
+    return PSTRING() << " version=" << td::format::as_hex(vc.ok().version) << " dcid=" << vc.ok().dcid
+                     << " dcid_len=" << vc.ok().dcid.as_slice().size() << " scid=" << vc.ok().scid
+                     << " scid_len=" << vc.ok().scid.as_slice().size();
+  }
+
+  static std::string cid_to_string(const ngtcp2_cid& cid) {
+    auto parsed = QuicConnectionId::from_raw(cid.data, cid.datalen);
+    if (parsed.is_ok()) {
+      return PSTRING() << parsed.ok();
+    }
+    return PSTRING() << "<invalid:" << parsed.error() << '>';
+  }
+
+  static const char* packet_type_name(td::uint8 type) {
+    switch (type) {
+      case NGTCP2_PKT_VERSION_NEGOTIATION:
+        return "version_negotiation";
+      case NGTCP2_PKT_STATELESS_RESET:
+        return "stateless_reset";
+      case NGTCP2_PKT_INITIAL:
+        return "initial";
+      case NGTCP2_PKT_0RTT:
+        return "0rtt";
+      case NGTCP2_PKT_HANDSHAKE:
+        return "handshake";
+      case NGTCP2_PKT_RETRY:
+        return "retry";
+      case NGTCP2_PKT_1RTT:
+        return "1rtt";
+      default:
+        return "unknown";
+    }
+  }
+
   static td::Result<VersionCid> from_parts(td::uint32 version, const uint8_t* dcid_data, size_t dcid_size,
                                            const uint8_t* scid_data, size_t scid_size, td::Slice token = {}) {
     TRY_RESULT(scid, QuicConnectionId::from_raw(scid_data, scid_size));

--- a/quic/quic-sender.cpp
+++ b/quic/quic-sender.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <sstream>
 #include <utility>
 
 #include "auto/tl/ton_api.hpp"
@@ -282,6 +284,43 @@ void QuicSender::add_id(adnl::AdnlNodeIdShort local_id) {
   add_local_id_coro(local_id).start().detach("add local id");
 }
 
+void QuicSender::add_protected_peers(adnl::AdnlNodeIdShort local_id, std::vector<adnl::AdnlNodeIdShort> peer_ids) {
+  for (const auto &peer_id : peer_ids) {
+    auto &entry = protected_peers_[local_id][peer_id];
+    entry.refs++;
+    if (entry.endpoint.has_value()) {
+      add_protected_endpoint_ref(local_id, *entry.endpoint);
+    } else {
+      schedule_protected_peer_endpoint_resolve(local_id, peer_id);
+    }
+  }
+  schedule_protected_endpoints_log();
+}
+
+void QuicSender::remove_protected_peers(adnl::AdnlNodeIdShort local_id, std::vector<adnl::AdnlNodeIdShort> peer_ids) {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return;
+  }
+  for (const auto &peer_id : peer_ids) {
+    auto peer_it = local_it->second.find(peer_id);
+    if (peer_it == local_it->second.end()) {
+      continue;
+    }
+    auto &entry = peer_it->second;
+    if (entry.endpoint.has_value()) {
+      remove_protected_endpoint_ref(local_id, *entry.endpoint);
+    }
+    if (--entry.refs == 0) {
+      local_it->second.erase(peer_it);
+    }
+  }
+  if (local_it->second.empty()) {
+    protected_peers_.erase(local_it);
+  }
+  schedule_protected_endpoints_log();
+}
+
 void QuicSender::log_stats(std::string reason) {
   for (auto &it : servers_) {
     td::actor::send_closure(it.second.get(), &QuicServer::log_stats, reason);
@@ -363,7 +402,12 @@ QuicSender::Connection::~Connection() {
 
 void QuicSender::start_up() {
   AdnlSenderInterface::start_up();
-  alarm_timestamp() = td::Timestamp::now();
+  alarm_timestamp() = td::Timestamp::never();
+}
+
+void QuicSender::alarm() {
+  maybe_log_protected_endpoints("periodic", true);
+  alarm_timestamp() = next_protected_endpoints_log_at_;
 }
 
 td::actor::Task<td::Unit> QuicSender::send_message_coro(adnl::AdnlNodeIdShort src, adnl::AdnlNodeIdShort dst,
@@ -435,7 +479,64 @@ td::actor::Task<> QuicSender::add_local_id_coro(adnl::AdnlNodeIdShort local_id) 
                                   std::make_unique<ServerCallback>(local_id, actor_id(this)),
                                   get_local_id_mtu(local_id), "ton", "0.0.0.0", server_options_, std::move(peers_mtu));
   servers_[local_id] = std::move(server);
+  if (auto it = protected_endpoint_refs_.find(local_id); it != protected_endpoint_refs_.end()) {
+    for (const auto &[endpoint, refs] : it->second) {
+      td::actor::send_closure(servers_[local_id].get(), &QuicServer::add_protected_flood_endpoint, endpoint, refs);
+    }
+  }
+  schedule_protected_endpoints_log();
 
+  co_return td::Unit{};
+}
+
+td::actor::Task<> QuicSender::resolve_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id,
+                                                              adnl::AdnlNodeIdShort peer_id, td::uint64 generation) {
+  double retry_delay = 1.0;
+  td::Result<td::IPAddress> last_error = td::Status::Error("not attempted");
+  size_t attempt = 0;
+
+  while (is_protected_peer_registered(local_id, peer_id, generation)) {
+    attempt++;
+
+    auto node_result = co_await td::actor::ask(adnl_, &adnl::Adnl::get_peer_node, local_id, peer_id).wrap();
+    if (node_result.is_ok()) {
+      auto endpoint_result = get_ip_address(node_result.move_as_ok());
+      if (endpoint_result.is_ok()) {
+        auto endpoint = endpoint_result.move_as_ok();
+        if (is_protected_peer_registered(local_id, peer_id, generation)) {
+          auto &entry = protected_peers_[local_id][peer_id];
+          entry.resolve_failures = 0;
+          update_protected_peer_endpoint(local_id, peer_id, endpoint);
+          if (attempt > 1) {
+            LOG(INFO) << "Resolved protected QUIC flood endpoint " << local_id << " -> " << peer_id
+                      << " endpoint=" << endpoint.get_ip_str() << ":" << endpoint.get_port() << " attempts=" << attempt;
+          }
+          schedule_protected_endpoints_log();
+        }
+        finish_protected_peer_endpoint_resolve(local_id, peer_id, generation);
+        co_return td::Unit{};
+      }
+      last_error = endpoint_result.move_as_error();
+    } else {
+      last_error = node_result.move_as_error();
+    }
+
+    if (!is_protected_peer_registered(local_id, peer_id, generation)) {
+      break;
+    }
+
+    auto &entry = protected_peers_[local_id][peer_id];
+    entry.resolve_failures++;
+    if (attempt == 1 || attempt % 8 == 0) {
+      LOG(INFO) << "Retrying protected QUIC flood endpoint resolve " << local_id << " -> " << peer_id
+                << " attempt=" << attempt << " retry_in=" << retry_delay << "s error=" << last_error.error();
+    }
+
+    co_await td::actor::coro_sleep(td::Timestamp::in(retry_delay));
+    retry_delay = std::min(retry_delay * 2.0, PROTECTED_PEER_RESOLVE_RETRY_MAX_DELAY);
+  }
+
+  finish_protected_peer_endpoint_resolve(local_id, peer_id, generation);
   co_return td::Unit{};
 }
 
@@ -482,6 +583,7 @@ td::actor::Task<td::Unit> QuicSender::init_connection_inner(AdnlPath path, std::
   auto node = co_await ask(adnl_, &adnl::Adnl::get_peer_node, path.first, path.second).trace("get_peer_node");
 
   auto peer_addr = co_await get_ip_address(node);
+  update_protected_peer_endpoint(path.first, path.second, peer_addr);
   auto peer_host = peer_addr.get_ip_host();
   auto peer_port = peer_addr.get_port();
 
@@ -687,6 +789,195 @@ void QuicSender::on_answer(Connection &connection, QuicStreamID stream_id, ton_a
   }
   it->second.set_result(std::move(answer.data_));
   connection.responses.erase(it);
+}
+
+void QuicSender::update_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                                std::optional<td::IPAddress> endpoint) {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return;
+  }
+  auto peer_it = local_it->second.find(peer_id);
+  if (peer_it == local_it->second.end()) {
+    return;
+  }
+
+  auto &entry = peer_it->second;
+  if (entry.endpoint == endpoint) {
+    return;
+  }
+  if (entry.endpoint.has_value()) {
+    remove_protected_endpoint_ref(local_id, *entry.endpoint, entry.refs);
+  }
+  entry.endpoint = std::move(endpoint);
+  if (entry.endpoint.has_value()) {
+    add_protected_endpoint_ref(local_id, *entry.endpoint, entry.refs);
+  }
+  schedule_protected_endpoints_log();
+}
+
+void QuicSender::schedule_protected_peer_endpoint_resolve(adnl::AdnlNodeIdShort local_id,
+                                                          adnl::AdnlNodeIdShort peer_id) {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return;
+  }
+  auto peer_it = local_it->second.find(peer_id);
+  if (peer_it == local_it->second.end()) {
+    return;
+  }
+  auto &entry = peer_it->second;
+  if (entry.refs == 0 || entry.endpoint.has_value() || entry.resolve_in_flight) {
+    return;
+  }
+  entry.resolve_in_flight = true;
+  entry.resolve_generation = next_protected_peer_resolve_generation_++;
+  resolve_protected_peer_endpoint(local_id, peer_id, entry.resolve_generation)
+      .start()
+      .detach("resolve protected peer endpoint");
+}
+
+void QuicSender::finish_protected_peer_endpoint_resolve(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                                        td::uint64 generation) {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return;
+  }
+  auto peer_it = local_it->second.find(peer_id);
+  if (peer_it == local_it->second.end()) {
+    return;
+  }
+  auto &entry = peer_it->second;
+  if (entry.resolve_generation != generation) {
+    return;
+  }
+  entry.resolve_in_flight = false;
+}
+
+bool QuicSender::is_protected_peer_registered(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                              td::uint64 generation) const {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return false;
+  }
+  auto peer_it = local_it->second.find(peer_id);
+  if (peer_it == local_it->second.end()) {
+    return false;
+  }
+  const auto &entry = peer_it->second;
+  return entry.refs > 0 && entry.resolve_in_flight && entry.resolve_generation == generation;
+}
+
+void QuicSender::schedule_protected_endpoints_log(double delay) {
+  auto next = td::Timestamp::in(delay);
+  if (next_protected_endpoints_log_at_ && next_protected_endpoints_log_at_.at() <= next.at()) {
+    return;
+  }
+  next_protected_endpoints_log_at_ = next;
+  alarm_timestamp().relax(next_protected_endpoints_log_at_);
+}
+
+void QuicSender::maybe_log_protected_endpoints(std::string reason, bool force) {
+  if (!force && (!next_protected_endpoints_log_at_ || !next_protected_endpoints_log_at_.is_in_past())) {
+    return;
+  }
+
+  size_t resolved_count = 0;
+  size_t resolved_refs = 0;
+  size_t unresolved_count = 0;
+  std::ostringstream endpoints;
+  std::ostringstream unresolved;
+  size_t logged_endpoints = 0;
+  size_t logged_unresolved = 0;
+
+  for (const auto &[local_id, endpoint_map] : protected_endpoint_refs_) {
+    for (const auto &[endpoint, refs] : endpoint_map) {
+      resolved_count++;
+      resolved_refs += refs;
+      if (logged_endpoints++ < PROTECTED_ENDPOINTS_LOG_LIMIT) {
+        if (logged_endpoints > 1) {
+          endpoints << ", ";
+        }
+        endpoints << (PSTRING() << local_id << "=>" << endpoint.get_ip_str() << ":" << endpoint.get_port()
+                                << "(refs=" << refs << ")");
+      }
+    }
+  }
+
+  for (const auto &[local_id, peer_map] : protected_peers_) {
+    for (const auto &[peer_id, entry] : peer_map) {
+      if (entry.refs == 0 || entry.endpoint.has_value()) {
+        continue;
+      }
+      unresolved_count++;
+      if (logged_unresolved++ < PROTECTED_UNRESOLVED_LOG_LIMIT) {
+        if (logged_unresolved > 1) {
+          unresolved << ", ";
+        }
+        unresolved << (PSTRING() << local_id << "->" << peer_id << "(refs=" << entry.refs << ", failures="
+                                 << entry.resolve_failures << ", resolving=" << entry.resolve_in_flight << ")");
+      }
+    }
+  }
+
+  if (resolved_count == 0 && unresolved_count == 0) {
+    next_protected_endpoints_log_at_ = td::Timestamp::never();
+    return;
+  }
+
+  if (resolved_count > PROTECTED_ENDPOINTS_LOG_LIMIT) {
+    endpoints << ", ...";
+  }
+  if (unresolved_count > PROTECTED_UNRESOLVED_LOG_LIMIT) {
+    unresolved << ", ...";
+  }
+
+  LOG(INFO) << "QUIC protected flood endpoints reason=" << reason << " local_ids=" << protected_peers_.size()
+            << " resolved=" << resolved_count << " resolved_refs=" << resolved_refs
+            << " unresolved=" << unresolved_count << " endpoints=[" << endpoints.str() << "] unresolved_peers=["
+            << unresolved.str() << "]";
+  next_protected_endpoints_log_at_ = td::Timestamp::in(PROTECTED_ENDPOINTS_LOG_PERIOD);
+}
+
+void QuicSender::add_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress &endpoint,
+                                            size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  protected_endpoint_refs_[local_id][endpoint] += refs;
+  if (auto it = servers_.find(local_id); it != servers_.end()) {
+    td::actor::send_closure(it->second.get(), &QuicServer::add_protected_flood_endpoint, endpoint, refs);
+  }
+  schedule_protected_endpoints_log();
+}
+
+void QuicSender::remove_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress &endpoint,
+                                               size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  auto local_it = protected_endpoint_refs_.find(local_id);
+  if (local_it == protected_endpoint_refs_.end()) {
+    return;
+  }
+  auto endpoint_it = local_it->second.find(endpoint);
+  if (endpoint_it == local_it->second.end()) {
+    return;
+  }
+
+  const size_t removed_refs = std::min(endpoint_it->second, refs);
+  if (endpoint_it->second == removed_refs) {
+    local_it->second.erase(endpoint_it);
+  } else {
+    endpoint_it->second -= removed_refs;
+  }
+  if (local_it->second.empty()) {
+    protected_endpoint_refs_.erase(local_it);
+  }
+  if (auto it = servers_.find(local_id); it != servers_.end()) {
+    td::actor::send_closure(it->second.get(), &QuicServer::remove_protected_flood_endpoint, endpoint, removed_refs);
+  }
+  schedule_protected_endpoints_log();
 }
 
 }  // namespace ton::quic

--- a/quic/quic-sender.cpp
+++ b/quic/quic-sender.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <utility>
 
 #include "auto/tl/ton_api.hpp"
@@ -282,6 +283,43 @@ void QuicSender::add_id(adnl::AdnlNodeIdShort local_id) {
   add_local_id_coro(local_id).start().detach("add local id");
 }
 
+void QuicSender::add_protected_peers(adnl::AdnlNodeIdShort local_id,
+                                     std::vector<adnl::AdnlNodeIdShort> peer_ids) {
+  for (const auto &peer_id : peer_ids) {
+    auto &entry = protected_peers_[local_id][peer_id];
+    entry.refs++;
+    if (entry.endpoint.has_value()) {
+      add_protected_endpoint_ref(local_id, *entry.endpoint);
+    } else {
+      resolve_protected_peer_endpoint(local_id, peer_id).start().detach("resolve protected peer endpoint");
+    }
+  }
+}
+
+void QuicSender::remove_protected_peers(adnl::AdnlNodeIdShort local_id,
+                                        std::vector<adnl::AdnlNodeIdShort> peer_ids) {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return;
+  }
+  for (const auto &peer_id : peer_ids) {
+    auto peer_it = local_it->second.find(peer_id);
+    if (peer_it == local_it->second.end()) {
+      continue;
+    }
+    auto &entry = peer_it->second;
+    if (entry.endpoint.has_value()) {
+      remove_protected_endpoint_ref(local_id, *entry.endpoint);
+    }
+    if (--entry.refs == 0) {
+      local_it->second.erase(peer_it);
+    }
+  }
+  if (local_it->second.empty()) {
+    protected_peers_.erase(local_it);
+  }
+}
+
 void QuicSender::log_stats(std::string reason) {
   for (auto &it : servers_) {
     td::actor::send_closure(it.second.get(), &QuicServer::log_stats, reason);
@@ -435,7 +473,32 @@ td::actor::Task<> QuicSender::add_local_id_coro(adnl::AdnlNodeIdShort local_id) 
                                   std::make_unique<ServerCallback>(local_id, actor_id(this)),
                                   get_local_id_mtu(local_id), "ton", "0.0.0.0", server_options_, std::move(peers_mtu));
   servers_[local_id] = std::move(server);
+  if (auto it = protected_endpoint_refs_.find(local_id); it != protected_endpoint_refs_.end()) {
+    for (const auto &[endpoint, refs] : it->second) {
+      td::actor::send_closure(servers_[local_id].get(), &QuicServer::add_protected_flood_endpoint, endpoint, refs);
+    }
+  }
 
+  co_return td::Unit{};
+}
+
+td::actor::Task<> QuicSender::resolve_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id,
+                                                              adnl::AdnlNodeIdShort peer_id) {
+  auto node_result = co_await td::actor::ask(adnl_, &adnl::Adnl::get_peer_node, local_id, peer_id).wrap();
+  if (node_result.is_error()) {
+    LOG(DEBUG) << "Failed to resolve protected peer " << local_id << " -> " << peer_id << ": "
+               << node_result.error();
+    co_return td::Unit{};
+  }
+
+  auto endpoint_result = get_ip_address(node_result.move_as_ok());
+  if (endpoint_result.is_error()) {
+    LOG(DEBUG) << "Failed to resolve protected peer endpoint " << local_id << " -> " << peer_id << ": "
+               << endpoint_result.error();
+    co_return td::Unit{};
+  }
+
+  update_protected_peer_endpoint(local_id, peer_id, endpoint_result.move_as_ok());
   co_return td::Unit{};
 }
 
@@ -482,6 +545,7 @@ td::actor::Task<td::Unit> QuicSender::init_connection_inner(AdnlPath path, std::
   auto node = co_await ask(adnl_, &adnl::Adnl::get_peer_node, path.first, path.second).trace("get_peer_node");
 
   auto peer_addr = co_await get_ip_address(node);
+  update_protected_peer_endpoint(path.first, path.second, peer_addr);
   auto peer_host = peer_addr.get_ip_host();
   auto peer_port = peer_addr.get_port();
 
@@ -687,6 +751,69 @@ void QuicSender::on_answer(Connection &connection, QuicStreamID stream_id, ton_a
   }
   it->second.set_result(std::move(answer.data_));
   connection.responses.erase(it);
+}
+
+void QuicSender::update_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                                std::optional<td::IPAddress> endpoint) {
+  auto local_it = protected_peers_.find(local_id);
+  if (local_it == protected_peers_.end()) {
+    return;
+  }
+  auto peer_it = local_it->second.find(peer_id);
+  if (peer_it == local_it->second.end()) {
+    return;
+  }
+
+  auto &entry = peer_it->second;
+  if (entry.endpoint == endpoint) {
+    return;
+  }
+  if (entry.endpoint.has_value()) {
+    remove_protected_endpoint_ref(local_id, *entry.endpoint, entry.refs);
+  }
+  entry.endpoint = std::move(endpoint);
+  if (entry.endpoint.has_value()) {
+    add_protected_endpoint_ref(local_id, *entry.endpoint, entry.refs);
+  }
+}
+
+void QuicSender::add_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress &endpoint,
+                                            size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  protected_endpoint_refs_[local_id][endpoint] += refs;
+  if (auto it = servers_.find(local_id); it != servers_.end()) {
+    td::actor::send_closure(it->second.get(), &QuicServer::add_protected_flood_endpoint, endpoint, refs);
+  }
+}
+
+void QuicSender::remove_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress &endpoint,
+                                               size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  auto local_it = protected_endpoint_refs_.find(local_id);
+  if (local_it == protected_endpoint_refs_.end()) {
+    return;
+  }
+  auto endpoint_it = local_it->second.find(endpoint);
+  if (endpoint_it == local_it->second.end()) {
+    return;
+  }
+
+  const size_t removed_refs = std::min(endpoint_it->second, refs);
+  if (endpoint_it->second == removed_refs) {
+    local_it->second.erase(endpoint_it);
+  } else {
+    endpoint_it->second -= removed_refs;
+  }
+  if (local_it->second.empty()) {
+    protected_endpoint_refs_.erase(local_it);
+  }
+  if (auto it = servers_.find(local_id); it != servers_.end()) {
+    td::actor::send_closure(it->second.get(), &QuicServer::remove_protected_flood_endpoint, endpoint, removed_refs);
+  }
 }
 
 }  // namespace ton::quic

--- a/quic/quic-sender.h
+++ b/quic/quic-sender.h
@@ -31,6 +31,8 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
 
   void set_quic_options(QuicServer::Options options);
   void add_id(adnl::AdnlNodeIdShort local_id) override;
+  void add_protected_peers(adnl::AdnlNodeIdShort local_id, std::vector<adnl::AdnlNodeIdShort> peer_ids) override;
+  void remove_protected_peers(adnl::AdnlNodeIdShort local_id, std::vector<adnl::AdnlNodeIdShort> peer_ids) override;
   void log_stats(std::string reason = "stats");
 
   struct Stats {
@@ -81,11 +83,29 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
   std::map<AdnlPath, std::shared_ptr<Connection>> outbound_;
   std::map<AdnlPath, std::shared_ptr<Connection>> inbound_;
   std::map<QuicConnectionId, std::shared_ptr<Connection>> by_cid_;
+  struct ProtectedPeerState {
+    size_t refs = 0;
+    std::optional<td::IPAddress> endpoint;
+    bool resolve_in_flight = false;
+    size_t resolve_failures = 0;
+    td::uint64 resolve_generation = 0;
+  };
+  std::map<adnl::AdnlNodeIdShort, std::map<adnl::AdnlNodeIdShort, ProtectedPeerState>> protected_peers_;
+  std::map<adnl::AdnlNodeIdShort, std::map<td::IPAddress, size_t>> protected_endpoint_refs_;
+  td::Timestamp next_protected_endpoints_log_at_ = td::Timestamp::never();
+  td::uint64 next_protected_peer_resolve_generation_ = 1;
 
   std::map<adnl::AdnlNodeIdShort, td::actor::ActorOwn<QuicServer>> servers_;
   std::map<adnl::AdnlNodeIdShort, td::Ed25519::PrivateKey> local_keys_;
 
   void start_up() override;
+  void alarm() override;
+
+  static constexpr double PROTECTED_ENDPOINTS_LOG_PERIOD = 300.0;
+  static constexpr double PROTECTED_ENDPOINTS_INITIAL_LOG_DELAY = 30.0;
+  static constexpr double PROTECTED_PEER_RESOLVE_RETRY_MAX_DELAY = 60.0;
+  static constexpr size_t PROTECTED_ENDPOINTS_LOG_LIMIT = 32;
+  static constexpr size_t PROTECTED_UNRESOLVED_LOG_LIMIT = 16;
 
   td::actor::Task<td::Unit> send_message_coro(adnl::AdnlNodeIdShort src, adnl::AdnlNodeIdShort dst,
                                               td::BufferSlice data);
@@ -96,6 +116,8 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
                                                    std::optional<td::uint64> limit);
   td::actor::Task<std::string> get_conn_ip_str_coro(adnl::AdnlNodeIdShort l_id, adnl::AdnlNodeIdShort p_id);
   td::actor::Task<> add_local_id_coro(adnl::AdnlNodeIdShort local_id);
+  td::actor::Task<> resolve_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                                    td::uint64 generation);
 
   td::actor::Task<std::shared_ptr<Connection>> find_or_create_connection(AdnlPath path);
   td::actor::Task<td::Unit> init_connection(AdnlPath path, std::shared_ptr<Connection> connection);
@@ -117,6 +139,17 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
   td::actor::Task<> on_inbound_query(std::shared_ptr<Connection> connection, QuicStreamID stream_id,
                                      td::BufferSlice query);
   void on_answer(Connection& connection, QuicStreamID stream_id, ton_api::quic_answer& answer);
+  void update_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                      std::optional<td::IPAddress> endpoint);
+  void schedule_protected_peer_endpoint_resolve(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id);
+  void finish_protected_peer_endpoint_resolve(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                              td::uint64 generation);
+  bool is_protected_peer_registered(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                    td::uint64 generation) const;
+  void schedule_protected_endpoints_log(double delay = PROTECTED_ENDPOINTS_INITIAL_LOG_DELAY);
+  void maybe_log_protected_endpoints(std::string reason, bool force = false);
+  void add_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress& endpoint, size_t refs = 1);
+  void remove_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress& endpoint, size_t refs = 1);
 
   static td::Result<td::IPAddress> get_ip_address(const adnl::AdnlNode& node);
 };

--- a/quic/quic-sender.h
+++ b/quic/quic-sender.h
@@ -31,6 +31,8 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
 
   void set_quic_options(QuicServer::Options options);
   void add_id(adnl::AdnlNodeIdShort local_id) override;
+  void add_protected_peers(adnl::AdnlNodeIdShort local_id, std::vector<adnl::AdnlNodeIdShort> peer_ids) override;
+  void remove_protected_peers(adnl::AdnlNodeIdShort local_id, std::vector<adnl::AdnlNodeIdShort> peer_ids) override;
   void log_stats(std::string reason = "stats");
 
   struct Stats {
@@ -81,6 +83,12 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
   std::map<AdnlPath, std::shared_ptr<Connection>> outbound_;
   std::map<AdnlPath, std::shared_ptr<Connection>> inbound_;
   std::map<QuicConnectionId, std::shared_ptr<Connection>> by_cid_;
+  struct ProtectedPeerState {
+    size_t refs = 0;
+    std::optional<td::IPAddress> endpoint;
+  };
+  std::map<adnl::AdnlNodeIdShort, std::map<adnl::AdnlNodeIdShort, ProtectedPeerState>> protected_peers_;
+  std::map<adnl::AdnlNodeIdShort, std::map<td::IPAddress, size_t>> protected_endpoint_refs_;
 
   std::map<adnl::AdnlNodeIdShort, td::actor::ActorOwn<QuicServer>> servers_;
   std::map<adnl::AdnlNodeIdShort, td::Ed25519::PrivateKey> local_keys_;
@@ -96,6 +104,7 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
                                                    std::optional<td::uint64> limit);
   td::actor::Task<std::string> get_conn_ip_str_coro(adnl::AdnlNodeIdShort l_id, adnl::AdnlNodeIdShort p_id);
   td::actor::Task<> add_local_id_coro(adnl::AdnlNodeIdShort local_id);
+  td::actor::Task<> resolve_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id);
 
   td::actor::Task<std::shared_ptr<Connection>> find_or_create_connection(AdnlPath path);
   td::actor::Task<td::Unit> init_connection(AdnlPath path, std::shared_ptr<Connection> connection);
@@ -117,6 +126,10 @@ class QuicSender : public adnl::AdnlSenderEx, public virtual metrics::AsyncColle
   td::actor::Task<> on_inbound_query(std::shared_ptr<Connection> connection, QuicStreamID stream_id,
                                      td::BufferSlice query);
   void on_answer(Connection& connection, QuicStreamID stream_id, ton_api::quic_answer& answer);
+  void update_protected_peer_endpoint(adnl::AdnlNodeIdShort local_id, adnl::AdnlNodeIdShort peer_id,
+                                      std::optional<td::IPAddress> endpoint);
+  void add_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress &endpoint, size_t refs = 1);
+  void remove_protected_endpoint_ref(adnl::AdnlNodeIdShort local_id, const td::IPAddress &endpoint, size_t refs = 1);
 
   static td::Result<td::IPAddress> get_ip_address(const adnl::AdnlNode& node);
 };

--- a/quic/quic-server.cpp
+++ b/quic/quic-server.cpp
@@ -13,6 +13,14 @@ namespace {
 
 constexpr ngtcp2_duration RETRY_TOKEN_TIMEOUT = 10 * NGTCP2_SECONDS;
 
+std::string flood_ip_bucket_key(td::Slice ip_host) {
+  return PSTRING() << "ip:" << ip_host;
+}
+
+std::string flood_endpoint_bucket_key(const td::IPAddress &remote_address) {
+  return PSTRING() << "endpoint:" << remote_address.get_ip_host() << ":" << remote_address.get_port();
+}
+
 ngtcp2_tstamp retry_token_now() {
   return static_cast<ngtcp2_tstamp>(
       std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
@@ -20,6 +28,15 @@ ngtcp2_tstamp retry_token_now() {
 }
 
 }  // namespace
+
+bool is_private_rfc1918_ipv4(const td::IPAddress &address) {
+  if (!address.is_valid() || !address.is_ipv4()) {
+    return false;
+  }
+
+  const td::uint32 ip = address.get_ipv4();
+  return (ip & 0xFF000000u) == 0x0A000000u || (ip & 0xFFF00000u) == 0xAC100000u || (ip & 0xFFFF0000u) == 0xC0A80000u;
+}
 
 td::Result<td::actor::ActorOwn<QuicServer>> QuicServer::create(int port, td::Ed25519::PrivateKey server_key,
                                                                std::unique_ptr<Callback> callback,
@@ -173,7 +190,7 @@ void QuicServer::unbind_all_cids(ConnectionState &state) {
 
 td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::install_connection(
     std::unique_ptr<QuicConnectionPImpl> p_impl, const td::IPAddress &remote_address, bool is_outbound,
-    std::optional<QuicConnectionId> bootstrap_routed_cid) {
+    std::optional<QuicConnectionId> bootstrap_routed_cid, std::optional<std::string> flood_bucket_key) {
   TRY_RESULT(initial_cid_state, p_impl->take_initial_cid_state());
 
   auto state = std::make_shared<ConnectionState>(ConnectionState{
@@ -182,6 +199,7 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::install_con
       .cid = initial_cid_state.primary_scid,
       .bootstrap_routed_cid = {},
       .routed_cids = {},
+      .flood_bucket_key = std::move(flood_bucket_key),
       .is_outbound = is_outbound,
   });
   LOG(INFO) << "creating " << *state;
@@ -210,32 +228,45 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::install_con
   return state;
 }
 
-td::Status QuicServer::ensure_flood_allowed(const std::string &flood_addr) {
+std::optional<std::string> QuicServer::classify_flood_bucket(const td::IPAddress &remote_address) const {
+  if (options_.exempt_private_rfc1918_from_per_ip_flood && is_private_rfc1918_ipv4(remote_address)) {
+    return std::nullopt;
+  }
+  if (options_.protect_validator_endpoints_from_shared_ip_flood &&
+      protected_flood_endpoints_.find(remote_address) != protected_flood_endpoints_.end()) {
+    return flood_endpoint_bucket_key(remote_address);
+  }
+  return flood_ip_bucket_key(remote_address.get_ip_host());
+}
+
+td::Status QuicServer::ensure_flood_allowed(const std::optional<std::string> &flood_bucket_key) {
   if (!options_.flood_control.has_value()) {
     return td::Status::OK();
   }
-  if (auto it = flood_map_.find(flood_addr); it != flood_map_.end() && it->second >= *options_.flood_control) {
-    return td::Status::Error("flood control overflow");
+  if (flood_bucket_key.has_value()) {
+    if (auto it = flood_map_.find(*flood_bucket_key); it != flood_map_.end() && it->second >= *options_.flood_control) {
+      return td::Status::Error("flood control overflow");
+    }
+    TRY_STATUS(conn_rate_limiters_.take_new_connection(*flood_bucket_key));
   }
-  TRY_STATUS(conn_rate_limiters_.take_new_connection(flood_addr));
   if (!global_conn_rate_limiter_.take()) {
     return td::Status::Error("global new connection rate limit exceeded");
   }
   return td::Status::OK();
 }
 
-void QuicServer::flood_on_inbound_connection_created(const std::string &flood_addr) {
-  if (!options_.flood_control.has_value()) {
+void QuicServer::flood_on_inbound_connection_created(const std::optional<std::string> &flood_bucket_key) {
+  if (!options_.flood_control.has_value() || !flood_bucket_key.has_value()) {
     return;
   }
-  flood_map_[flood_addr]++;
+  flood_map_[*flood_bucket_key]++;
 }
 
-void QuicServer::flood_on_inbound_connection_closed(const std::string &flood_addr) {
-  if (!options_.flood_control.has_value()) {
+void QuicServer::flood_on_inbound_connection_closed(const std::optional<std::string> &flood_bucket_key) {
+  if (!options_.flood_control.has_value() || !flood_bucket_key.has_value()) {
     return;
   }
-  auto it = flood_map_.find(flood_addr);
+  auto it = flood_map_.find(*flood_bucket_key);
   if (it == flood_map_.end()) {
     return;
   }
@@ -259,6 +290,28 @@ void QuicServer::on_local_cid_issued(const QuicConnectionId &primary_cid, const 
 
 void QuicServer::on_local_cid_retired(const QuicConnectionId &primary_cid, const QuicConnectionId &cid) {
   unbind_cid(primary_cid, cid);
+}
+
+void QuicServer::add_protected_flood_endpoint(td::IPAddress endpoint, size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  protected_flood_endpoints_[endpoint] += refs;
+}
+
+void QuicServer::remove_protected_flood_endpoint(td::IPAddress endpoint, size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  auto it = protected_flood_endpoints_.find(endpoint);
+  if (it == protected_flood_endpoints_.end()) {
+    return;
+  }
+  if (it->second <= refs) {
+    protected_flood_endpoints_.erase(it);
+  } else {
+    it->second -= refs;
+  }
 }
 
 td::Result<std::optional<ServerInitialInfo>> QuicServer::prepare_server_initial_info(
@@ -448,7 +501,7 @@ void QuicServer::on_connection_closed(QuicConnectionId cid) {
     timeout_heap_.erase(state.get());
   }
   if (!state->is_outbound) {
-    flood_on_inbound_connection_closed(state->remote_address.get_ip_host());
+    flood_on_inbound_connection_closed(state->flood_bucket_key);
   }
   connections_.erase(it);
   callback_->on_closed(cid);
@@ -596,8 +649,8 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::get_or_crea
 
   TRY_RESULT(initial_packet, VersionCid::from_initial_datagram(td::Slice(msg_in.storage)));
 
-  auto flood_addr = msg_in.address.get_ip_host();
-  TRY_STATUS(ensure_flood_allowed(flood_addr));
+  auto flood_bucket_key = classify_flood_bucket(msg_in.address);
+  TRY_STATUS(ensure_flood_allowed(flood_bucket_key));
 
   TRY_RESULT(initial_info, prepare_server_initial_info(initial_packet, msg_in.address));
   if (!initial_info.has_value()) {
@@ -611,9 +664,10 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::get_or_crea
   auto pimpl_callback = std::make_unique<PImplCallback>(*this, false);
   TRY_RESULT(p_impl, QuicConnectionPImpl::create_server(local_address, msg_in.address, server_key_, alpn_.as_slice(),
                                                         *initial_info, std::move(pimpl_callback), conn_options));
-  TRY_RESULT(state, install_connection(std::move(p_impl), msg_in.address, false, initial_packet.dcid));
+  TRY_RESULT(state, install_connection(std::move(p_impl), msg_in.address, false, initial_packet.dcid,
+                                       std::move(flood_bucket_key)));
 
-  flood_on_inbound_connection_created(flood_addr);
+  flood_on_inbound_connection_created(state->flood_bucket_key);
 
   return state;
 }

--- a/quic/quic-server.cpp
+++ b/quic/quic-server.cpp
@@ -13,6 +13,14 @@ namespace {
 
 constexpr ngtcp2_duration RETRY_TOKEN_TIMEOUT = 10 * NGTCP2_SECONDS;
 
+std::string flood_ip_bucket_key(td::Slice ip_host) {
+  return PSTRING() << "ip:" << ip_host;
+}
+
+std::string flood_endpoint_bucket_key(const td::IPAddress &remote_address) {
+  return PSTRING() << "endpoint:" << remote_address.get_ip_host() << ":" << remote_address.get_port();
+}
+
 ngtcp2_tstamp retry_token_now() {
   return static_cast<ngtcp2_tstamp>(
       std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
@@ -20,6 +28,16 @@ ngtcp2_tstamp retry_token_now() {
 }
 
 }  // namespace
+
+bool is_private_rfc1918_ipv4(const td::IPAddress &address) {
+  if (!address.is_valid() || !address.is_ipv4()) {
+    return false;
+  }
+
+  const td::uint32 ip = address.get_ipv4();
+  return (ip & 0xFF000000u) == 0x0A000000u || (ip & 0xFFF00000u) == 0xAC100000u ||
+         (ip & 0xFFFF0000u) == 0xC0A80000u;
+}
 
 td::Result<td::actor::ActorOwn<QuicServer>> QuicServer::create(int port, td::Ed25519::PrivateKey server_key,
                                                                std::unique_ptr<Callback> callback,
@@ -173,7 +191,7 @@ void QuicServer::unbind_all_cids(ConnectionState &state) {
 
 td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::install_connection(
     std::unique_ptr<QuicConnectionPImpl> p_impl, const td::IPAddress &remote_address, bool is_outbound,
-    std::optional<QuicConnectionId> bootstrap_routed_cid) {
+    std::optional<QuicConnectionId> bootstrap_routed_cid, std::optional<std::string> flood_bucket_key) {
   TRY_RESULT(initial_cid_state, p_impl->take_initial_cid_state());
 
   auto state = std::make_shared<ConnectionState>(ConnectionState{
@@ -182,6 +200,7 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::install_con
       .cid = initial_cid_state.primary_scid,
       .bootstrap_routed_cid = {},
       .routed_cids = {},
+      .flood_bucket_key = std::move(flood_bucket_key),
       .is_outbound = is_outbound,
   });
   LOG(INFO) << "creating " << *state;
@@ -210,32 +229,45 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::install_con
   return state;
 }
 
-td::Status QuicServer::ensure_flood_allowed(const std::string &flood_addr) {
+std::optional<std::string> QuicServer::classify_flood_bucket(const td::IPAddress &remote_address) const {
+  if (options_.exempt_private_rfc1918_from_per_ip_flood && is_private_rfc1918_ipv4(remote_address)) {
+    return std::nullopt;
+  }
+  if (options_.protect_validator_endpoints_from_shared_ip_flood &&
+      protected_flood_endpoints_.find(remote_address) != protected_flood_endpoints_.end()) {
+    return flood_endpoint_bucket_key(remote_address);
+  }
+  return flood_ip_bucket_key(remote_address.get_ip_host());
+}
+
+td::Status QuicServer::ensure_flood_allowed(const std::optional<std::string> &flood_bucket_key) {
   if (!options_.flood_control.has_value()) {
     return td::Status::OK();
   }
-  if (auto it = flood_map_.find(flood_addr); it != flood_map_.end() && it->second >= *options_.flood_control) {
-    return td::Status::Error("flood control overflow");
+  if (flood_bucket_key.has_value()) {
+    if (auto it = flood_map_.find(*flood_bucket_key); it != flood_map_.end() && it->second >= *options_.flood_control) {
+      return td::Status::Error("flood control overflow");
+    }
+    TRY_STATUS(conn_rate_limiters_.take_new_connection(*flood_bucket_key));
   }
-  TRY_STATUS(conn_rate_limiters_.take_new_connection(flood_addr));
   if (!global_conn_rate_limiter_.take()) {
     return td::Status::Error("global new connection rate limit exceeded");
   }
   return td::Status::OK();
 }
 
-void QuicServer::flood_on_inbound_connection_created(const std::string &flood_addr) {
-  if (!options_.flood_control.has_value()) {
+void QuicServer::flood_on_inbound_connection_created(const std::optional<std::string> &flood_bucket_key) {
+  if (!options_.flood_control.has_value() || !flood_bucket_key.has_value()) {
     return;
   }
-  flood_map_[flood_addr]++;
+  flood_map_[*flood_bucket_key]++;
 }
 
-void QuicServer::flood_on_inbound_connection_closed(const std::string &flood_addr) {
-  if (!options_.flood_control.has_value()) {
+void QuicServer::flood_on_inbound_connection_closed(const std::optional<std::string> &flood_bucket_key) {
+  if (!options_.flood_control.has_value() || !flood_bucket_key.has_value()) {
     return;
   }
-  auto it = flood_map_.find(flood_addr);
+  auto it = flood_map_.find(*flood_bucket_key);
   if (it == flood_map_.end()) {
     return;
   }
@@ -259,6 +291,28 @@ void QuicServer::on_local_cid_issued(const QuicConnectionId &primary_cid, const 
 
 void QuicServer::on_local_cid_retired(const QuicConnectionId &primary_cid, const QuicConnectionId &cid) {
   unbind_cid(primary_cid, cid);
+}
+
+void QuicServer::add_protected_flood_endpoint(td::IPAddress endpoint, size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  protected_flood_endpoints_[endpoint] += refs;
+}
+
+void QuicServer::remove_protected_flood_endpoint(td::IPAddress endpoint, size_t refs) {
+  if (refs == 0) {
+    return;
+  }
+  auto it = protected_flood_endpoints_.find(endpoint);
+  if (it == protected_flood_endpoints_.end()) {
+    return;
+  }
+  if (it->second <= refs) {
+    protected_flood_endpoints_.erase(it);
+  } else {
+    it->second -= refs;
+  }
 }
 
 td::Result<std::optional<ServerInitialInfo>> QuicServer::prepare_server_initial_info(
@@ -448,7 +502,7 @@ void QuicServer::on_connection_closed(QuicConnectionId cid) {
     timeout_heap_.erase(state.get());
   }
   if (!state->is_outbound) {
-    flood_on_inbound_connection_closed(state->remote_address.get_ip_host());
+    flood_on_inbound_connection_closed(state->flood_bucket_key);
   }
   connections_.erase(it);
   callback_->on_closed(cid);
@@ -596,8 +650,8 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::get_or_crea
 
   TRY_RESULT(initial_packet, VersionCid::from_initial_datagram(td::Slice(msg_in.storage)));
 
-  auto flood_addr = msg_in.address.get_ip_host();
-  TRY_STATUS(ensure_flood_allowed(flood_addr));
+  auto flood_bucket_key = classify_flood_bucket(msg_in.address);
+  TRY_STATUS(ensure_flood_allowed(flood_bucket_key));
 
   TRY_RESULT(initial_info, prepare_server_initial_info(initial_packet, msg_in.address));
   if (!initial_info.has_value()) {
@@ -611,9 +665,10 @@ td::Result<std::shared_ptr<QuicServer::ConnectionState>> QuicServer::get_or_crea
   auto pimpl_callback = std::make_unique<PImplCallback>(*this, false);
   TRY_RESULT(p_impl, QuicConnectionPImpl::create_server(local_address, msg_in.address, server_key_, alpn_.as_slice(),
                                                         *initial_info, std::move(pimpl_callback), conn_options));
-  TRY_RESULT(state, install_connection(std::move(p_impl), msg_in.address, false, initial_packet.dcid));
+  TRY_RESULT(state, install_connection(std::move(p_impl), msg_in.address, false, initial_packet.dcid,
+                                       std::move(flood_bucket_key)));
 
-  flood_on_inbound_connection_created(flood_addr);
+  flood_on_inbound_connection_created(state->flood_bucket_key);
 
   return state;
 }

--- a/quic/quic-server.h
+++ b/quic/quic-server.h
@@ -30,6 +30,8 @@ struct VersionCid;
 
 struct QuicConnectionPImpl;
 
+bool is_private_rfc1918_ipv4(const td::IPAddress &address);
+
 struct StreamOptions {
   std::optional<td::uint64> max_size;
   td::Timestamp timeout = td::Timestamp::never();
@@ -60,6 +62,8 @@ class QuicServer : public td::actor::Actor, public td::ObserverBase {
     td::uint32 global_new_connection_rate_limit_capacity = 100000;
     double global_new_connection_rate_limit_period = 0.00001;
     bool stateless_retry = true;
+    bool exempt_private_rfc1918_from_per_ip_flood = true;
+    bool protect_validator_endpoints_from_shared_ip_flood = true;
   };
   class Callback {
    public:
@@ -93,6 +97,8 @@ class QuicServer : public td::actor::Actor, public td::ObserverBase {
 
   void set_default_mtu(td::uint64 mtu);
   void set_peer_mtu(adnl::AdnlNodeIdShort peer_id, td::uint64 mtu);
+  void add_protected_flood_endpoint(td::IPAddress endpoint, size_t refs = 1);
+  void remove_protected_flood_endpoint(td::IPAddress endpoint, size_t refs = 1);
 
   constexpr static size_t DEFAULT_FLOOD_CONTROL = 10;
 
@@ -165,6 +171,7 @@ class QuicServer : public td::actor::Actor, public td::ObserverBase {
     QuicConnectionId cid;
     std::optional<QuicConnectionId> bootstrap_routed_cid;
     std::set<QuicConnectionId> routed_cids;
+    std::optional<std::string> flood_bucket_key;
     bool is_outbound;
     bool in_active_queue = false;
     friend td::StringBuilder &operator<<(td::StringBuilder &sb, const ConnectionState &state) {
@@ -187,7 +194,8 @@ class QuicServer : public td::actor::Actor, public td::ObserverBase {
   void unbind_all_cids(ConnectionState &state);
   td::Result<std::shared_ptr<ConnectionState>> install_connection(std::unique_ptr<QuicConnectionPImpl> p_impl,
                                                                   const td::IPAddress &remote_address, bool is_outbound,
-                                                                  std::optional<QuicConnectionId> bootstrap_routed_cid);
+                                                                  std::optional<QuicConnectionId> bootstrap_routed_cid,
+                                                                  std::optional<std::string> flood_bucket_key = {});
   void on_local_cid_issued(const QuicConnectionId &primary_cid, const QuicConnectionId &cid);
   void on_local_cid_retired(const QuicConnectionId &primary_cid, const QuicConnectionId &cid);
   td::Result<std::optional<ServerInitialInfo>> prepare_server_initial_info(const VersionCid &initial_packet,
@@ -205,9 +213,10 @@ class QuicServer : public td::actor::Actor, public td::ObserverBase {
 
   std::shared_ptr<ConnectionState> find_connection(const QuicConnectionId &cid);
   td::Result<std::shared_ptr<ConnectionState>> get_or_create_connection(const UdpMessageBuffer &msg_in);
-  td::Status ensure_flood_allowed(const std::string &flood_addr);
-  void flood_on_inbound_connection_created(const std::string &flood_addr);
-  void flood_on_inbound_connection_closed(const std::string &flood_addr);
+  std::optional<std::string> classify_flood_bucket(const td::IPAddress &remote_address) const;
+  td::Status ensure_flood_allowed(const std::optional<std::string> &flood_bucket_key);
+  void flood_on_inbound_connection_created(const std::optional<std::string> &flood_bucket_key);
+  void flood_on_inbound_connection_closed(const std::optional<std::string> &flood_bucket_key);
   QuicConnectionOptions build_connection_options() const;
   bool handle_expiry(ConnectionState &state);
   void log_conn_stats(ConnectionState &state, const char *reason);
@@ -222,6 +231,7 @@ class QuicServer : public td::actor::Actor, public td::ObserverBase {
   bool gso_enabled_{true};
   bool gro_enabled_{false};
   std::unordered_map<std::string, size_t> flood_map_;
+  std::map<td::IPAddress, size_t> protected_flood_endpoints_;
 
   std::unique_ptr<Callback> callback_;
   td::actor::ActorId<QuicServer> self_id_;

--- a/test/net/test-quic-sender.cpp
+++ b/test/net/test-quic-sender.cpp
@@ -81,6 +81,18 @@ ton::quic::QuicServer::Options quic_test_options() {
   return options;
 }
 
+ton::quic::QuicServer::Options flood_test_options(size_t flood_limit) {
+  auto options = quic_test_options();
+  options.flood_control = flood_limit;
+  return options;
+}
+
+td::IPAddress make_ip_address(td::Slice host, int port) {
+  td::IPAddress ip;
+  ip.init_host_port(PSTRING() << host << ":" << port).ensure();
+  return ip;
+}
+
 class EchoCallback : public ton::adnl::Adnl::Callback {
  public:
   std::shared_ptr<std::vector<td::BufferSlice>> received_messages;
@@ -414,6 +426,12 @@ ton::quic::QuicServer::Options small_stream_limit_options(size_t max_streams_bid
 }
 
 struct RawQuicEndpointState {
+  void clear_connection_tracking() {
+    std::lock_guard guard(mutex);
+    outbound_cid.reset();
+    inbound_cid.reset();
+  }
+
   void remember_connection(ton::quic::QuicConnectionId cid, bool is_outbound) {
     std::lock_guard guard(mutex);
     if (is_outbound) {
@@ -1778,6 +1796,100 @@ TEST(QuicRateLimiter, CapacityOneDoesNotAllowExtraBurst) {
   jump_time_by(1.0);
   expect_take(true);
   expect_take(false);
+}
+
+TEST(QuicFloodControl, Rfc1918Matcher) {
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("10.1.2.3", 31000)));
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.16.0.1", 31001)));
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.31.255.254", 31002)));
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("192.168.10.20", 31003)));
+
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("9.255.255.255", 31010)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.15.255.255", 31011)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.32.0.1", 31012)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("192.167.255.255", 31013)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("192.169.0.1", 31014)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("127.0.0.1", 31015)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("100.64.0.1", 31016)));
+}
+
+TEST(QuicFloodControl, ProtectedEndpointsBypassSharedIpFlood) {
+  run_raw_quic_test([](RawQuicTestRunner& t) -> td::actor::Task<td::Unit> {
+    auto server = co_await t.create_endpoint(flood_test_options(1));
+    auto client1 = co_await t.create_endpoint(quic_test_options());
+    auto client2 = co_await t.create_endpoint(quic_test_options());
+
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint,
+                            make_ip_address("127.0.0.1", client1.port), size_t{1});
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint,
+                            make_ip_address("127.0.0.1", client2.port), size_t{1});
+
+    co_await t.connect(client1, server);
+    co_await t.connect(client2, server);
+
+    auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+    ASSERT_EQ(stats.per_conn.size(), 2u);
+    co_return td::Unit{};
+  });
+}
+
+TEST(QuicFloodControl, SharedIpWithoutProtectionUsesSingleBucket) {
+  run_raw_quic_test([](RawQuicTestRunner& t) -> td::actor::Task<td::Unit> {
+    auto server = co_await t.create_endpoint(flood_test_options(1));
+    auto client1 = co_await t.create_endpoint(quic_test_options());
+    auto client2 = co_await t.create_endpoint(quic_test_options());
+
+    co_await t.connect(client1, server);
+
+    auto second_connect_result =
+        co_await td::actor::ask(client2.server, &ton::quic::QuicServer::connect, td::Slice("127.0.0.1"), server.port,
+                                clone_quic_key(client2.key), td::Slice("ton"))
+            .wrap();
+    ASSERT_TRUE(second_connect_result.is_ok());
+    co_await td::actor::coro_sleep(td::Timestamp::in(0.2));
+
+    auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+    ASSERT_EQ(stats.per_conn.size(), 1u);
+    ASSERT_TRUE(!client2.state->get_outbound_cid().has_value());
+    co_return td::Unit{};
+  });
+}
+
+TEST(QuicFloodControl, CloseUsesStoredAcceptedBucket) {
+  run_raw_quic_test([](RawQuicTestRunner& t) -> td::actor::Task<td::Unit> {
+    auto server = co_await t.create_endpoint(flood_test_options(1));
+    auto client = co_await t.create_endpoint(quic_test_options());
+
+    auto client_endpoint = make_ip_address("127.0.0.1", client.port);
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint, client_endpoint,
+                            size_t{1});
+
+    auto [outbound_cid, inbound_cid] = co_await t.connect(client, server);
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::remove_protected_flood_endpoint, client_endpoint,
+                            size_t{1});
+    td::actor::send_closure(client.server, &ton::quic::QuicServer::on_connection_closed, outbound_cid);
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::on_connection_closed, inbound_cid);
+
+    auto deadline = td::Timestamp::in(2.0);
+    while (true) {
+      auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+      if (stats.per_conn.empty()) {
+        break;
+      }
+      ASSERT_TRUE(!deadline.is_in_past());
+      co_await td::actor::yield_on_current();
+    }
+
+    client.state->clear_connection_tracking();
+    server.state->clear_connection_tracking();
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint, client_endpoint,
+                            size_t{1});
+
+    co_await t.connect(client, server);
+    auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+    ASSERT_EQ(stats.per_conn.size(), 1u);
+    co_return td::Unit{};
+  });
 }
 
 int main(int argc, char* argv[]) {

--- a/test/net/test-quic-sender.cpp
+++ b/test/net/test-quic-sender.cpp
@@ -81,6 +81,18 @@ ton::quic::QuicServer::Options quic_test_options() {
   return options;
 }
 
+ton::quic::QuicServer::Options flood_test_options(size_t flood_limit) {
+  auto options = quic_test_options();
+  options.flood_control = flood_limit;
+  return options;
+}
+
+td::IPAddress make_ip_address(td::Slice host, int port) {
+  td::IPAddress ip;
+  ip.init_host_port(PSTRING() << host << ":" << port).ensure();
+  return ip;
+}
+
 class EchoCallback : public ton::adnl::Adnl::Callback {
  public:
   std::shared_ptr<std::vector<td::BufferSlice>> received_messages;
@@ -414,6 +426,12 @@ ton::quic::QuicServer::Options small_stream_limit_options(size_t max_streams_bid
 }
 
 struct RawQuicEndpointState {
+  void clear_connection_tracking() {
+    std::lock_guard guard(mutex);
+    outbound_cid.reset();
+    inbound_cid.reset();
+  }
+
   void remember_connection(ton::quic::QuicConnectionId cid, bool is_outbound) {
     std::lock_guard guard(mutex);
     if (is_outbound) {
@@ -1778,6 +1796,100 @@ TEST(QuicRateLimiter, CapacityOneDoesNotAllowExtraBurst) {
   jump_time_by(1.0);
   expect_take(true);
   expect_take(false);
+}
+
+TEST(QuicFloodControl, Rfc1918Matcher) {
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("10.1.2.3", 31000)));
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.16.0.1", 31001)));
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.31.255.254", 31002)));
+  ASSERT_TRUE(ton::quic::is_private_rfc1918_ipv4(make_ip_address("192.168.10.20", 31003)));
+
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("9.255.255.255", 31010)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.15.255.255", 31011)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("172.32.0.1", 31012)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("192.167.255.255", 31013)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("192.169.0.1", 31014)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("127.0.0.1", 31015)));
+  ASSERT_TRUE(!ton::quic::is_private_rfc1918_ipv4(make_ip_address("100.64.0.1", 31016)));
+}
+
+TEST(QuicFloodControl, ProtectedEndpointsBypassSharedIpFlood) {
+  run_raw_quic_test([](RawQuicTestRunner& t) -> td::actor::Task<td::Unit> {
+    auto server = co_await t.create_endpoint(flood_test_options(1));
+    auto client1 = co_await t.create_endpoint(quic_test_options());
+    auto client2 = co_await t.create_endpoint(quic_test_options());
+
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint,
+                            make_ip_address("127.0.0.1", client1.port), size_t{1});
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint,
+                            make_ip_address("127.0.0.1", client2.port), size_t{1});
+
+    co_await t.connect(client1, server);
+    co_await t.connect(client2, server);
+
+    auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+    ASSERT_EQ(stats.per_conn.size(), 2u);
+    co_return td::Unit{};
+  });
+}
+
+TEST(QuicFloodControl, SharedIpWithoutProtectionUsesSingleBucket) {
+  run_raw_quic_test([](RawQuicTestRunner& t) -> td::actor::Task<td::Unit> {
+    auto server = co_await t.create_endpoint(flood_test_options(1));
+    auto client1 = co_await t.create_endpoint(quic_test_options());
+    auto client2 = co_await t.create_endpoint(quic_test_options());
+
+    co_await t.connect(client1, server);
+
+    auto second_connect_result =
+        co_await td::actor::ask(client2.server, &ton::quic::QuicServer::connect, td::Slice("127.0.0.1"), server.port,
+                                clone_quic_key(client2.key), td::Slice("ton"))
+                     .wrap();
+    ASSERT_TRUE(second_connect_result.is_ok());
+    co_await td::actor::coro_sleep(td::Timestamp::in(0.2));
+
+    auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+    ASSERT_EQ(stats.per_conn.size(), 1u);
+    ASSERT_TRUE(!client2.state->get_outbound_cid().has_value());
+    co_return td::Unit{};
+  });
+}
+
+TEST(QuicFloodControl, CloseUsesStoredAcceptedBucket) {
+  run_raw_quic_test([](RawQuicTestRunner& t) -> td::actor::Task<td::Unit> {
+    auto server = co_await t.create_endpoint(flood_test_options(1));
+    auto client = co_await t.create_endpoint(quic_test_options());
+
+    auto client_endpoint = make_ip_address("127.0.0.1", client.port);
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint, client_endpoint,
+                            size_t{1});
+
+    auto [outbound_cid, inbound_cid] = co_await t.connect(client, server);
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::remove_protected_flood_endpoint, client_endpoint,
+                            size_t{1});
+    td::actor::send_closure(client.server, &ton::quic::QuicServer::on_connection_closed, outbound_cid);
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::on_connection_closed, inbound_cid);
+
+    auto deadline = td::Timestamp::in(2.0);
+    while (true) {
+      auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+      if (stats.per_conn.empty()) {
+        break;
+      }
+      ASSERT_TRUE(!deadline.is_in_past());
+      co_await td::actor::yield_on_current();
+    }
+
+    client.state->clear_connection_tracking();
+    server.state->clear_connection_tracking();
+    td::actor::send_closure(server.server, &ton::quic::QuicServer::add_protected_flood_endpoint, client_endpoint,
+                            size_t{1});
+
+    co_await t.connect(client, server);
+    auto stats = co_await td::actor::ask(server.server, &ton::quic::QuicServer::collect_stats);
+    ASSERT_EQ(stats.per_conn.size(), 1u);
+    co_return td::Unit{};
+  });
 }
 
 int main(int argc, char* argv[]) {

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -5898,11 +5898,35 @@ int main(int argc, char *argv[]) {
       '\0', "quic-flood-control", "per-IP limit for QUIC connections (-1 to disable)", [&](td::Slice arg) {
         TRY_RESULT(l, td::to_integer_safe<int64_t>(arg));
         acts.push_back([&, l = l >= 0 ? std::optional<size_t>{l} : std::optional<size_t>{std::nullopt}] {
-          td::actor::send_closure(x, &ValidatorEngine::set_quic_options,
-                                  ton::quic::QuicServer::Options{.flood_control = l});
+          td::actor::send_closure(x, &ValidatorEngine::set_quic_flood_control, l);
         });
         return td::Status::OK();
       });
+  p.add_checked_option(
+      '\0', "quic-exempt-private-rfc1918-from-per-ip-flood",
+      "whether RFC1918 10/8, 172.16/12, 192.168/16 bypass per-IP QUIC flood limits (0 or 1)", [&](td::Slice arg) {
+        TRY_RESULT(enabled_i, td::to_integer_safe<int>(arg));
+        if (enabled_i != 0 && enabled_i != 1) {
+          return td::Status::Error("expected 0 or 1");
+        }
+        acts.push_back([&, enabled = static_cast<bool>(enabled_i)] {
+          td::actor::send_closure(x, &ValidatorEngine::set_quic_exempt_private_rfc1918_from_per_ip_flood, enabled);
+        });
+        return td::Status::OK();
+      });
+  p.add_checked_option('\0', "quic-protect-validator-endpoints-from-shared-ip-flood",
+                       "whether protected validator endpoints use separate ip:port QUIC flood buckets (0 or 1)",
+                       [&](td::Slice arg) {
+                         TRY_RESULT(enabled_i, td::to_integer_safe<int>(arg));
+                         if (enabled_i != 0 && enabled_i != 1) {
+                           return td::Status::Error("expected 0 or 1");
+                         }
+                         acts.push_back([&, enabled = static_cast<bool>(enabled_i)] {
+                           td::actor::send_closure(
+                               x, &ValidatorEngine::set_quic_protect_validator_endpoints_from_shared_ip_flood, enabled);
+                         });
+                         return td::Status::OK();
+                       });
   auto S = p.run(argc, argv);
   if (S.is_error()) {
     LOG(ERROR) << "failed to parse options: " << S.move_as_error();

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -5898,11 +5898,37 @@ int main(int argc, char *argv[]) {
       '\0', "quic-flood-control", "per-IP limit for QUIC connections (-1 to disable)", [&](td::Slice arg) {
         TRY_RESULT(l, td::to_integer_safe<int64_t>(arg));
         acts.push_back([&, l = l >= 0 ? std::optional<size_t>{l} : std::optional<size_t>{std::nullopt}] {
-          td::actor::send_closure(x, &ValidatorEngine::set_quic_options,
-                                  ton::quic::QuicServer::Options{.flood_control = l});
+          td::actor::send_closure(x, &ValidatorEngine::set_quic_flood_control, l);
         });
         return td::Status::OK();
       });
+  p.add_checked_option('\0', "quic-exempt-private-rfc1918-from-per-ip-flood",
+                       "whether RFC1918 10/8, 172.16/12, 192.168/16 bypass per-IP QUIC flood limits (0 or 1)",
+                       [&](td::Slice arg) {
+                         TRY_RESULT(enabled_i, td::to_integer_safe<int>(arg));
+                         if (enabled_i != 0 && enabled_i != 1) {
+                           return td::Status::Error("expected 0 or 1");
+                         }
+                         acts.push_back([&, enabled = static_cast<bool>(enabled_i)] {
+                           td::actor::send_closure(x, &ValidatorEngine::set_quic_exempt_private_rfc1918_from_per_ip_flood,
+                                                   enabled);
+                         });
+                         return td::Status::OK();
+                       });
+  p.add_checked_option('\0', "quic-protect-validator-endpoints-from-shared-ip-flood",
+                       "whether protected validator endpoints use separate ip:port QUIC flood buckets (0 or 1)",
+                       [&](td::Slice arg) {
+                         TRY_RESULT(enabled_i, td::to_integer_safe<int>(arg));
+                         if (enabled_i != 0 && enabled_i != 1) {
+                           return td::Status::Error("expected 0 or 1");
+                         }
+                         acts.push_back([&, enabled = static_cast<bool>(enabled_i)] {
+                           td::actor::send_closure(
+                               x, &ValidatorEngine::set_quic_protect_validator_endpoints_from_shared_ip_flood,
+                               enabled);
+                         });
+                         return td::Status::OK();
+                       });
   auto S = p.run(argc, argv);
   if (S.is_error()) {
     LOG(ERROR) << "failed to parse options: " << S.move_as_error();

--- a/validator-engine/validator-engine.hpp
+++ b/validator-engine/validator-engine.hpp
@@ -428,6 +428,15 @@ class ValidatorEngine : public td::actor::Actor {
   void set_quic_options(ton::quic::QuicServer::Options options) {
     quic_options_ = std::move(options);
   }
+  void set_quic_flood_control(std::optional<size_t> value) {
+    quic_options_.flood_control = std::move(value);
+  }
+  void set_quic_exempt_private_rfc1918_from_per_ip_flood(bool value) {
+    quic_options_.exempt_private_rfc1918_from_per_ip_flood = value;
+  }
+  void set_quic_protect_validator_endpoints_from_shared_ip_flood(bool value) {
+    quic_options_.protect_validator_endpoints_from_shared_ip_flood = value;
+  }
 
   void start_up() override;
   ValidatorEngine() {

--- a/validator/consensus/private-overlay.cpp
+++ b/validator/consensus/private-overlay.cpp
@@ -48,9 +48,16 @@ class PrivateOverlayImpl : public td::actor::SpawnsWith<Bus>, public td::actor::
       overlay_nodes.push_back(peer.adnl_id);
       overlay_nodes_tl.push_back(peer.short_id.bits256_value());
       authorized_keys.emplace(peer.short_id, max_broadcast_size);
+      if (peer.adnl_id != local_id_.adnl_id) {
+        protected_peer_ids_.push_back(peer.adnl_id);
+      }
     }
 
     td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_id, local_id_.adnl_id);
+    if (!protected_peer_ids_.empty()) {
+      td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_protected_peers, local_id_.adnl_id,
+                              protected_peer_ids_);
+    }
 
     auto overlay_seed = create_tl_object<tl::overlayId>(bus.session_id, std::move(overlay_nodes_tl));
     auto overlay_full_id = overlay::OverlayIdFull{serialize_tl_object(overlay_seed, true)};
@@ -74,6 +81,10 @@ class PrivateOverlayImpl : public td::actor::SpawnsWith<Bus>, public td::actor::
 
   template <>
   void handle(BusHandle, std::shared_ptr<const StopRequested>) {
+    if (!protected_peer_ids_.empty()) {
+      td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::remove_protected_peers, local_id_.adnl_id,
+                              std::move(protected_peer_ids_));
+    }
     td::actor::send_closure(overlays_, &overlay::Overlays::delete_overlay, local_id_.adnl_id, overlay_id_);
     stop();
   }
@@ -228,6 +239,7 @@ class PrivateOverlayImpl : public td::actor::SpawnsWith<Bus>, public td::actor::
   td::actor::ActorId<adnl::AdnlSenderEx> adnl_sender_;
   overlay::OverlayIdShort overlay_id_;
   PeerValidator local_id_;
+  std::vector<adnl::AdnlNodeIdShort> protected_peer_ids_;
   std::map<adnl::AdnlNodeIdShort, PeerValidator> adnl_id_to_peer_;
   std::map<PublicKeyHash, PeerValidator> short_id_to_peer_;
 };

--- a/validator/full-node-fast-sync-overlays.cpp
+++ b/validator/full-node-fast-sync-overlays.cpp
@@ -334,8 +334,14 @@ void FullNodeFastSyncOverlay::start_up() {
   b.as_slice().copy_from(as_slice(X));
   overlay_id_full_ = overlay::OverlayIdFull{std::move(b)};
   overlay_id_ = overlay_id_full_.compute_short_id();
+  alarm_timestamp() = td::Timestamp::never();
 
   try_init();
+}
+
+void FullNodeFastSyncOverlay::alarm() {
+  maybe_log_protected_peers("periodic", true);
+  alarm_timestamp() = next_protected_peers_log_at_;
 }
 
 void FullNodeFastSyncOverlay::try_init() {
@@ -379,6 +385,7 @@ void FullNodeFastSyncOverlay::init() {
   td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_id, local_id_);
   // Enable quic server even if use_quic is not set
   td::actor::send_closure(quic_, &quic::QuicSender::add_id, local_id_);
+  sync_protected_peers();
 
   std::map<PublicKeyHash, td::uint32> authorized_keys;
   // FIXME: allow broadcasts from non-validators when needed
@@ -421,6 +428,7 @@ void FullNodeFastSyncOverlay::init() {
 }
 
 void FullNodeFastSyncOverlay::tear_down() {
+  unregister_protected_peers();
   if (inited_) {
     td::actor::send_closure(overlays_, &overlay::Overlays::delete_overlay, local_id_, overlay_id_);
   }
@@ -430,6 +438,7 @@ void FullNodeFastSyncOverlay::set_validators(std::vector<PublicKeyHash> root_pub
                                              std::vector<adnl::AdnlNodeIdShort> current_validators_adnl) {
   root_public_keys_ = std::move(root_public_keys);
   current_validators_adnl_ = std::move(current_validators_adnl);
+  sync_protected_peers();
   if (inited_) {
     td::actor::send_closure(overlays_, &overlay::Overlays::delete_overlay, local_id_, overlay_id_);
     init();
@@ -453,10 +462,92 @@ void FullNodeFastSyncOverlay::set_params(bool receive_broadcasts, bool send_twos
   receive_broadcasts_ = receive_broadcasts;
   send_twostep_broadcasts_ = send_twostep_broadcasts;
   adnl_sender_ = adnl_sender;
+  sync_protected_peers();
   if (inited_) {
     td::actor::send_closure(overlays_, &overlay::Overlays::delete_overlay, local_id_, overlay_id_);
     init();
   }
+}
+
+bool FullNodeFastSyncOverlay::uses_quic_sender() const {
+  return adnl_sender_ == td::actor::ActorId<adnl::AdnlSenderEx>{quic_};
+}
+
+std::vector<adnl::AdnlNodeIdShort> FullNodeFastSyncOverlay::get_desired_protected_peer_ids() const {
+  std::vector<adnl::AdnlNodeIdShort> result;
+  result.reserve(current_validators_adnl_.size());
+  for (const auto &peer_id : current_validators_adnl_) {
+    if (peer_id != local_id_) {
+      result.push_back(peer_id);
+    }
+  }
+  return result;
+}
+
+void FullNodeFastSyncOverlay::unregister_protected_peers() {
+  if (!protected_peers_sender_.empty() && !protected_peer_ids_.empty()) {
+    td::actor::send_closure(protected_peers_sender_, &adnl::AdnlSenderEx::remove_protected_peers, local_id_,
+                            std::move(protected_peer_ids_));
+  }
+  protected_peer_ids_.clear();
+  protected_peers_sender_ = {};
+  next_protected_peers_log_at_ = td::Timestamp::never();
+}
+
+void FullNodeFastSyncOverlay::sync_protected_peers() {
+  auto desired_peer_ids = get_desired_protected_peer_ids();
+  bool should_use_protection = uses_quic_sender() && !desired_peer_ids.empty();
+  bool changed = false;
+
+  if (!protected_peers_sender_.empty() &&
+      (!should_use_protection || protected_peers_sender_ != adnl_sender_ || protected_peer_ids_ != desired_peer_ids)) {
+    unregister_protected_peers();
+    changed = true;
+  }
+
+  if (should_use_protection && protected_peers_sender_.empty()) {
+    td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_protected_peers, local_id_, desired_peer_ids);
+    protected_peer_ids_ = std::move(desired_peer_ids);
+    protected_peers_sender_ = adnl_sender_;
+    changed = true;
+  }
+
+  if (changed) {
+    maybe_log_protected_peers("updated", true);
+  } else if (!protected_peer_ids_.empty()) {
+    next_protected_peers_log_at_ = td::Timestamp::in(PROTECTED_PEERS_LOG_PERIOD);
+    alarm_timestamp().relax(next_protected_peers_log_at_);
+  }
+}
+
+void FullNodeFastSyncOverlay::maybe_log_protected_peers(std::string reason, bool force) {
+  if (!force && (!next_protected_peers_log_at_ || !next_protected_peers_log_at_.is_in_past())) {
+    return;
+  }
+
+  if (protected_peer_ids_.empty()) {
+    next_protected_peers_log_at_ = td::Timestamp::never();
+    return;
+  }
+
+  td::StringBuilder sb;
+  size_t logged = 0;
+  for (const auto &peer_id : protected_peer_ids_) {
+    if (logged >= PROTECTED_PEERS_LOG_LIMIT) {
+      sb << ", ...";
+      break;
+    }
+    if (logged > 0) {
+      sb << ", ";
+    }
+    sb << peer_id;
+    logged++;
+  }
+
+  LOG(INFO) << "Fast sync QUIC flood protection reason=" << reason << " shard=" << shard_.to_str()
+            << " local_id=" << local_id_ << " protected_peers=" << protected_peer_ids_.size() << " peers=["
+            << sb.as_cslice() << "]";
+  next_protected_peers_log_at_ = td::Timestamp::in(PROTECTED_PEERS_LOG_PERIOD);
 }
 
 void FullNodeFastSyncOverlay::get_stats_extra(td::Promise<std::string> promise) {

--- a/validator/full-node-fast-sync-overlays.hpp
+++ b/validator/full-node-fast-sync-overlays.hpp
@@ -61,6 +61,7 @@ class FullNodeFastSyncOverlay : public td::actor::Actor {
 
   void start_up() override;
   void tear_down() override;
+  void alarm() override;
 
   void set_validators(std::vector<PublicKeyHash> root_public_keys,
                       std::vector<adnl::AdnlNodeIdShort> current_validators_adnl);
@@ -119,10 +120,21 @@ class FullNodeFastSyncOverlay : public td::actor::Actor {
   overlay::OverlayIdFull overlay_id_full_;
   overlay::OverlayIdShort overlay_id_;
   UnixTime created_at_ = (UnixTime)td::Clocks::system();
+  std::vector<adnl::AdnlNodeIdShort> protected_peer_ids_;
+  td::actor::ActorId<adnl::AdnlSenderEx> protected_peers_sender_;
+  td::Timestamp next_protected_peers_log_at_ = td::Timestamp::never();
 
   void try_init();
   void init();
   void get_stats_extra(td::Promise<std::string> promise);
+  bool uses_quic_sender() const;
+  std::vector<adnl::AdnlNodeIdShort> get_desired_protected_peer_ids() const;
+  void sync_protected_peers();
+  void unregister_protected_peers();
+  void maybe_log_protected_peers(std::string reason, bool force = false);
+
+  static constexpr double PROTECTED_PEERS_LOG_PERIOD = 1800.0;
+  static constexpr size_t PROTECTED_PEERS_LOG_LIMIT = 32;
 
   td::actor::ActorOwn<ValidatorTelemetry> telemetry_sender_;
   bool collect_telemetry_ = false;

--- a/validator/validator-group.cpp
+++ b/validator/validator-group.cpp
@@ -141,6 +141,7 @@ class ValidatorGroup : public IValidatorGroup {
   td::actor::ActorId<CollationManager> collation_manager_;
   td::actor::ActorOwn<validatorsession::ValidatorSession> session_;
   adnl::AdnlNodeIdShort local_adnl_id_;
+  std::vector<adnl::AdnlNodeIdShort> protected_validator_peer_ids_;
 
   bool init_ = false;
   bool started_ = false;
@@ -588,6 +589,16 @@ void ValidatorGroup::create_session() {
   CHECK(found);
 
   td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_id, local_adnl_id_);
+  protected_validator_peer_ids_.clear();
+  for (const auto &peer_id : adnl_ids) {
+    if (peer_id != local_adnl_id_) {
+      protected_validator_peer_ids_.push_back(peer_id);
+    }
+  }
+  if (!protected_validator_peer_ids_.empty()) {
+    td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_protected_peers, local_adnl_id_,
+                            protected_validator_peer_ids_);
+  }
   config_.catchain_opts.broadcast_speed_multiplier = opts_->get_catchain_broadcast_speed_multiplier();
   if (!config_.new_catchain_ids) {
     session_ = validatorsession::ValidatorSession::create(
@@ -664,6 +675,10 @@ void ValidatorGroup::destroy() {
     return;
   }
   destroying_ = true;
+  if (!protected_validator_peer_ids_.empty()) {
+    td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::remove_protected_peers, local_adnl_id_,
+                            std::move(protected_validator_peer_ids_));
+  }
   if (!session_.empty()) {
     td::actor::send_closure(session_, &validatorsession::ValidatorSession::get_end_stats,
                             [manager = manager_](td::Result<validatorsession::EndValidatorGroupStats> R) {


### PR DESCRIPTION
This change fixes the case where multiple validators behind the same IP interfere with each other due to QUIC flood control.

It makes two changes:

1. RFC1918 private IPv4 ranges are no longer subject to per-IP QUIC flood control:
- `10.0.0.0/8`
- `172.16.0.0/12`
- `192.168.0.0/16`

2. Validator endpoints can use separate flood buckets by exact `ip:port`, so multiple validators on the same public IP no longer
consume the same per-IP flood quota.

The global new-connection limiter is unchanged.

## What changed

- `QuicServer` flood control is now bucket-based:
- RFC1918 source -> bypass per-IP flood bucket
- protected validator endpoint -> bucket by exact `ip:port`
- all other traffic -> bucket by `ip`
- The selected flood bucket is stored on accepted inbound connections and reused on close, so accounting stays correct even if
protection state changes later.
- Added protected-endpoint registration in QUIC.
- `QuicSender` now tracks protected validator peers per local ADNL ID, resolves their exact endpoints, and updates the QUIC server
with those endpoints.
- `ValidatorGroup` now registers current validator-set peers as protected on session start and unregisters them on destroy.
- Added CLI/config knobs in `validator-engine`:
- `--quic-exempt-private-rfc1918-from-per-ip-flood`
- `--quic-protect-validator-endpoints-from-shared-ip-flood`

Both are enabled by default.

## Notes

- This change does not increase the numeric flood limits.
- It changes how inbound QUIC connections are bucketed for flood-control purposes.
- The scope of protected peers in this patch is the current validator set.