### PR TITLE
Simplify TestScheduler code, remove some edge cases, add tests

### DIFF
--- a/tdactor/td/actor/TestScheduler.h
+++ b/tdactor/td/actor/TestScheduler.h
@@ -35,8 +35,8 @@ class TestScheduler {
       return false;
     }
     void await_suspend(std::coroutine_handle<> h) noexcept {
+      CHECK(!sched->control_continuation_);
       sched->control_continuation_ = h;
-      sched->control_waiting_ = true;
     }
     void await_resume() const noexcept {
     }
@@ -72,23 +72,18 @@ class TestScheduler {
     ContextImpl context(this);
     core::SchedulerContext::Guard guard(&context);
 
-    auto task = coro_factory();
-    auto started = std::move(task).start_immediate();
-
-    while (!started.await_ready() && !stop_requested_) {
-      drain_all();
-      if (control_waiting_) {
-        control_waiting_ = false;
-        control_continuation_.resume();
-      } else {
-        LOG_CHECK(started.await_ready() || stop_requested_)
-            << "Deadlock detected: control coroutine is suspended but there is no synchronous work to do";
+    auto task = coro_factory().start_immediate();
+    while (true) {
+      drain_all(false);
+      if (!control_continuation_) {
         break;
       }
+      std::exchange(control_continuation_, nullptr).resume();
     }
+    LOG_CHECK(task.await_ready())
+        << "Deadlock detected: control coroutine is suspended but there is no synchronous work to do";
+    drain_all(true);
 
-    started.detach_silent();
-    cleanup();
     Time::unfreeze();
   }
 
@@ -100,10 +95,7 @@ class TestScheduler {
   Poll poll_;
   core::Debug debug_;
   core::ActorInfoCreator creator_{true};
-  bool stop_requested_{false};
-
   std::coroutine_handle<> control_continuation_;
-  bool control_waiting_{false};
 
   class ContextImpl : public core::SchedulerContext {
    public:
@@ -149,10 +141,9 @@ class TestScheduler {
     }
 
     bool is_stop_requested() override {
-      return sched_->stop_requested_;
+      return false;
     }
     void stop() override {
-      sched_->stop_requested_ = true;
     }
 
     core::Debug &get_debug() override {
@@ -186,49 +177,7 @@ class TestScheduler {
     TestScheduler *sched_;
   };
 
-  bool process_alarms() {
-    bool did_work = false;
-    auto &dispatcher = core::SchedulerContext::get();
-    auto now = Time::now();
-    while (!heap_.empty() && heap_.top_key() <= now) {
-      auto *heap_node = heap_.pop();
-      auto *actor_info = core::ActorInfo::from_heap_node(heap_node);
-      actor_info->unpin();
-      auto lock = debug_.start(actor_info->get_name());
-      core::ActorExecutor executor(*actor_info, dispatcher, core::ActorExecutor::Options().with_has_poll(true));
-      if (executor.can_send_immediate()) {
-        executor.send_immediate(core::ActorSignals::one(core::ActorSignals::Alarm));
-      } else {
-        executor.send(core::ActorSignals::one(core::ActorSignals::Alarm));
-      }
-      did_work = true;
-    }
-    return did_work;
-  }
-
-  bool process_io_queue() {
-    bool did_work = false;
-    auto &dispatcher = core::SchedulerContext::get();
-    while (!io_queue_.empty()) {
-      auto actor_info_ptr = std::move(io_queue_.front());
-      io_queue_.pop_front();
-      if (!actor_info_ptr) {
-        continue;
-      }
-      if (actor_info_ptr->state().get_flags_unsafe().is_shared()) {
-        dispatcher.set_alarm_timestamp(actor_info_ptr);
-      } else {
-        auto lock = debug_.start(actor_info_ptr->get_name());
-        core::ActorExecutor executor(*actor_info_ptr, dispatcher,
-                                     core::ActorExecutor::Options().with_from_queue().with_has_poll(true));
-      }
-      did_work = true;
-    }
-    return did_work;
-  }
-
-  bool process_cpu_queue() {
-    bool did_work = false;
+  void process_cpu_queue() {
     auto &dispatcher = core::SchedulerContext::get();
     while (!cpu_queue_.empty()) {
       auto token = cpu_queue_.front();
@@ -247,45 +196,58 @@ class TestScheduler {
         auto lock = debug_.start("coro");
         h.resume();
       }
-      did_work = true;
-    }
-    return did_work;
-  }
-
-  void drain_all() {
-    while (true) {
-      bool did_work = false;
-      did_work |= process_alarms();
-      did_work |= process_io_queue();
-      did_work |= process_cpu_queue();
-      if (!did_work) {
-        break;
-      }
     }
   }
 
-  void cleanup() {
-    while (!heap_.empty()) {
-      Time::jump_in_future(heap_.top_key());
-      drain_all();
-    }
-
-    for (auto &token : cpu_queue_) {
-      if (!token) {
+  void process_io_queue() {
+    auto &dispatcher = core::SchedulerContext::get();
+    while (!io_queue_.empty()) {
+      auto actor_info_ptr = std::move(io_queue_.front());
+      io_queue_.pop_front();
+      if (!actor_info_ptr) {
         continue;
       }
-      auto encoded = reinterpret_cast<uintptr_t>(token);
-      if ((encoded & 1u) == 0u) {
-        auto *raw = reinterpret_cast<core::SchedulerMessage::Raw *>(token);
-        core::SchedulerMessage(core::SchedulerMessage::acquire_t{}, raw);
+      if (actor_info_ptr->state().get_flags_unsafe().is_shared()) {
+        dispatcher.set_alarm_timestamp(actor_info_ptr);
       } else {
-        auto h = std::coroutine_handle<>::from_address(reinterpret_cast<void *>(encoded & ~uintptr_t(1)));
-        h.destroy();
+        auto lock = debug_.start(actor_info_ptr->get_name());
+        core::ActorExecutor executor(*actor_info_ptr, dispatcher,
+                                     core::ActorExecutor::Options().with_from_queue().with_has_poll(true));
       }
     }
-    cpu_queue_.clear();
-    io_queue_.clear();
-    creator_.clear();
+  }
+
+  void process_single_alarm() {
+    auto &dispatcher = core::SchedulerContext::get();
+    auto *heap_node = heap_.pop();
+    auto *actor_info = core::ActorInfo::from_heap_node(heap_node);
+    actor_info->unpin();
+    auto lock = debug_.start(actor_info->get_name());
+    core::ActorExecutor executor(*actor_info, dispatcher, core::ActorExecutor::Options().with_has_poll(true));
+    if (executor.can_send_immediate()) {
+      executor.send_immediate(core::ActorSignals::one(core::ActorSignals::Alarm));
+    } else {
+      executor.send(core::ActorSignals::one(core::ActorSignals::Alarm));
+    }
+  }
+
+  void drain_all(bool advance_time) {
+    while (true) {
+      while (!cpu_queue_.empty() || !io_queue_.empty()) {
+        process_cpu_queue();
+        process_io_queue();
+      }
+      if (heap_.empty()) {
+        break;
+      }
+      if (heap_.top_key() > Time::now()) {
+        if (!advance_time) {
+          break;
+        }
+        Time::jump_in_future(heap_.top_key());
+      }
+      process_single_alarm();
+    }
   }
 };
 

--- a/test/tdactor/test-test-scheduler.cpp
+++ b/test/tdactor/test-test-scheduler.cpp
@@ -359,5 +359,59 @@ TEST(TestScheduler, CleanupDrainsPendingAlarmsWithActor) {
   });
 }
 
+TEST(TestScheduler, CleanupDrainsCpuQueue) {
+  static bool started;
+  started = false;
+
+  struct MyActor : Actor {
+    void start_up() override {
+      started = true;
+    }
+  };
+
+  TestScheduler ts;
+  ts.run([]() -> Task<> {
+    create_actor<MyActor>("dummy").release();
+    co_return {};
+  });
+  EXPECT(started);
+}
+
+TEST(TestScheduler, CpuBeforeAlarms) {
+  static std::vector<int> events;
+  events.clear();
+
+  struct MyActor : Actor {
+    double timeout;
+    int event;
+
+    MyActor(double t, int e) : timeout(t), event(e) {
+    }
+
+    void start_up() override {
+      alarm_timestamp() = td::Timestamp::in(timeout);
+    }
+
+    void alarm() override {
+      events.push_back(event);
+      yield();
+    }
+
+    void wake_up() override {
+      events.push_back(event + 1);
+    }
+  };
+
+  TestScheduler ts;
+  ts.run([&]() -> Task<> {
+    create_actor<MyActor>("dummy1", 1, 0).release();
+    create_actor<MyActor>("dummy1", 2, 2).release();
+    co_await ts.wait_sync_work();
+    ts.advance_time(3);
+    co_return {};
+  });
+  EXPECT_EQ(events, (std::vector<int>{0, 1, 2, 3}));
+}
+
 }  // namespace
 }  // namespace td::actor


### PR DESCRIPTION
This makes scheduling more predictable when `advance_time` is used: CPU and IO queues are always drained before alarms. Also, CPU queues are drained in all cases, which wasn't the case previously. `stop_requested` flag is removed because it didn't really do anything: all events were processed regardless of whether `stop()` was called or not.