### PR TITLE
Adjust time threshold for last masterchain block check

### DIFF
--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -2112,7 +2112,7 @@ bool ValidatorManagerImpl::out_of_sync() {
   if (shard_client_handle_->id().seqno() + 16 < last_masterchain_seqno_) {
     return true;
   }
-  if (last_masterchain_block_handle_->unix_time() + 600 > td::Clocks::system()) {
+  if (last_masterchain_block_handle_->unix_time() + 80 > td::Clocks::system()) {
     return false;
   }
 


### PR DESCRIPTION
Change the time threshold from 600 seconds to 80 seconds for the last masterchain block check.