### PR TITLE
Use custom std::chrono clock as backing storage for td::Timestamp

### DIFF
--- a/tdactor/td/actor/TestScheduler.h
+++ b/tdactor/td/actor/TestScheduler.h
@@ -68,7 +68,8 @@ class TestScheduler {
 
   template <class F>
   void run(F &&coro_factory) {
-    Time::freeze();
+    Time::FreezeGuard time_freeze;
+
     ContextImpl context(this);
     core::SchedulerContext::Guard guard(&context);
 
@@ -83,8 +84,6 @@ class TestScheduler {
     LOG_CHECK(task.await_ready())
         << "Deadlock detected: control coroutine is suspended but there is no synchronous work to do";
     drain_all(true);
-
-    Time::unfreeze();
   }
 
  private:

--- a/tdactor/td/actor/core/ActorInfo.h
+++ b/tdactor/td/actor/core/ActorInfo.h
@@ -110,10 +110,10 @@ class ActorInfo : private HeapNode, private ListNode {
   }
 
   Timestamp get_alarm_timestamp() const {
-    return Timestamp::at(alarm_timestamp_at_.load(std::memory_order_relaxed));
+    return alarm_timestamp_at_.load(std::memory_order_relaxed);
   }
   void set_alarm_timestamp(Timestamp timestamp) {
-    alarm_timestamp_at_.store(timestamp.at(), std::memory_order_relaxed);
+    alarm_timestamp_at_.store(timestamp, std::memory_order_relaxed);
   }
 
   void pin(ActorInfoPtr ptr) {
@@ -131,7 +131,8 @@ class ActorInfo : private HeapNode, private ListNode {
   ActorState state_;
   ActorMailbox mailbox_;
   std::string name_;
-  std::atomic<double> alarm_timestamp_at_{0};
+  std::atomic<Timestamp> alarm_timestamp_at_{};
+  static_assert(decltype(alarm_timestamp_at_)::is_always_lock_free);
 
   ActorInfoPtr pin_;
   td::uint64 in_queue_since_{0};

--- a/tdutils/td/utils/Time.cpp
+++ b/tdutils/td/utils/Time.cpp
@@ -17,81 +17,100 @@
     Copyright 2017-2020 Telegram Systems LLP
 */
 #include <atomic>
-#include <cmath>
 #include <mutex>
 
 #include "td/utils/Time.h"
 
 namespace td {
 
-bool operator==(Timestamp a, Timestamp b) {
-  return std::abs(a.at() - b.at()) < 1e-6;
-}
 namespace {
-std::atomic<double> time_diff;
+
+std::atomic<SteadyClock::duration> time_diff{};
+static_assert(time_diff.is_always_lock_free);
 
 bool freezes_allowed{false};
 std::mutex time_mutex;
 bool is_frozen{false};
-double frozen_time;
-double frozen_system;
+SteadyTime frozen_steady;
+UTCTime frozen_utc;
+
+SteadyTime steady_unadjusted() {
+  return SteadyTime{std::chrono::steady_clock::now().time_since_epoch()};
+}
+
+UTCTime utc_unadjusted() {
+  return UTCTime{std::chrono::system_clock::now().time_since_epoch()};
+}
+
 }  // namespace
 
-double Time::now() {
+SteadyTime SteadyClock::now() {
   if (freezes_allowed) {
     std::lock_guard lock(time_mutex);
     if (is_frozen) {
-      return frozen_time;
+      return frozen_steady;
     }
-    return now_unadjusted() + time_diff;
+    return steady_unadjusted() + time_diff.load();
   }
 
-  return now_unadjusted() + time_diff.load(std::memory_order_relaxed);
+  return steady_unadjusted() + time_diff.load(std::memory_order_relaxed);
+}
+
+UTCTime UTCClock::now() {
+  if (freezes_allowed) {
+    std::lock_guard lock(time_mutex);
+    if (is_frozen) {
+      return frozen_utc;
+    }
+  }
+
+  return utc_unadjusted();
+}
+
+double Time::now() {
+  return detail::duration_to_s(SteadyClock::now().time_since_epoch());
 }
 
 double Time::now_unadjusted() {
-  return Clocks::monotonic();
+  return detail::duration_to_s(steady_unadjusted().time_since_epoch());
 }
 
 double Time::system_now() {
-  if (freezes_allowed) {
-    std::lock_guard lock(time_mutex);
-    if (is_frozen) {
-      return frozen_system;
-    }
-  }
-
-  return Clocks::system();
+  return detail::duration_to_s(UTCClock::now().time_since_epoch());
 }
 
-void Time::jump_in_future(double at) {
+void Time::jump_in_future(SteadyTime ts) {
   if (freezes_allowed) {
     std::lock_guard lock(time_mutex);
     if (is_frozen) {
-      if (at > frozen_time) {
-        frozen_system += at - frozen_time;
-        frozen_time = at;
+      if (ts > frozen_steady) {
+        frozen_utc += (ts - frozen_steady);
+        frozen_steady = ts;
       }
     } else {
-      time_diff = at - now_unadjusted();
-      if (time_diff < 0) {
-        time_diff = 0;
+      auto diff = ts - steady_unadjusted();
+      if (diff < SteadyClock::duration::zero()) {
+        diff = SteadyClock::duration::zero();
       }
+      time_diff.store(diff);
     }
     return;
   }
 
   auto old_time_diff = time_diff.load();
-
   while (true) {
-    auto diff = at - now();
-    if (diff < 0) {
+    auto diff = ts - SteadyClock::now();
+    if (diff < SteadyClock::duration::zero()) {
       return;
     }
     if (time_diff.compare_exchange_strong(old_time_diff, old_time_diff + diff)) {
       return;
     }
   }
+}
+
+void Time::jump_in_future(double at) {
+  jump_in_future(SteadyClock::from_double_ts(at));
 }
 
 void Time::allow_freezes() {
@@ -101,8 +120,8 @@ void Time::allow_freezes() {
 void Time::freeze() {
   CHECK(freezes_allowed);
   std::lock_guard lock(time_mutex);
-  frozen_time = now_unadjusted() + time_diff.load(std::memory_order_relaxed);
-  frozen_system = Clocks::system();
+  frozen_steady = steady_unadjusted() + time_diff.load(std::memory_order_relaxed);
+  frozen_utc = utc_unadjusted();
   is_frozen = true;
 }
 
@@ -110,7 +129,7 @@ void Time::unfreeze() {
   CHECK(freezes_allowed);
   std::lock_guard lock(time_mutex);
   if (is_frozen) {
-    time_diff.store(frozen_time - now_unadjusted(), std::memory_order_relaxed);
+    time_diff.store(frozen_steady - steady_unadjusted(), std::memory_order_relaxed);
     is_frozen = false;
   }
 }

--- a/tdutils/td/utils/Time.h
+++ b/tdutils/td/utils/Time.h
@@ -21,13 +21,71 @@
 #include <chrono>
 
 #include "td/utils/common.h"
-#include "td/utils/port/Clocks.h"
 
 namespace td {
+
+namespace detail {
+
+inline auto to_ns_duration(double value) {
+  return std::chrono::round<std::chrono::nanoseconds>(std::chrono::duration<double>(value));
+}
+
+inline double duration_to_s(std::chrono::duration<double> duration) {
+  return duration.count();
+}
+
+}  // namespace detail
+
+struct SteadyClock {
+  using rep = td::int64;
+  using period = std::nano;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<SteadyClock>;
+
+  static constexpr bool is_steady = true;
+
+  static time_point now();
+
+  static time_point from_double_ts(double ts) {
+    return time_point{detail::to_ns_duration(ts)};
+  }
+};
+
+using SteadyTime = SteadyClock::time_point;
+
+struct UTCClock {
+  using rep = td::int64;
+  using period = std::nano;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<UTCClock>;
+
+  static constexpr bool is_steady = false;
+
+  static time_point now();
+
+  static time_point from_double_ts(double ts) {
+    return time_point{detail::to_ns_duration(ts)};
+  }
+};
+
+using UTCTime = UTCClock::time_point;
+
+inline SteadyTime to_steady_time(UTCTime ts) {
+  auto steady_now = SteadyClock::now();
+  auto utc_now = UTCClock::now();
+  return steady_now + (ts - utc_now);
+}
+
+inline UTCTime to_utc_time(SteadyTime ts) {
+  auto steady_now = SteadyClock::now();
+  auto utc_now = UTCClock::now();
+  return utc_now + (ts - steady_now);
+}
 
 class Time {
  public:
   static double now();
+
   static double now_cached() {
     // Temporary(?) use now in now_cached
     // Problem:
@@ -46,6 +104,7 @@ class Time {
 
   // Used for testing. After jump_in_future(at) is called, now() >= at.
   static void jump_in_future(double at);
+  static void jump_in_future(SteadyTime ts);
 
   static void allow_freezes();  // must be sequenced before any now / jump_in_future call.
 
@@ -80,52 +139,62 @@ inline void relax_timeout_at(double *timeout, double new_timeout) {
 }
 
 class Timestamp {
+  SteadyClock::time_point at_{};
+
  public:
   Timestamp() = default;
+
   static Timestamp never() {
     return Timestamp{};
   }
   static Timestamp now() {
-    return Timestamp{Time::now()};
+    return Timestamp{SteadyClock::now()};
   }
   static Timestamp now_cached() {
-    return Timestamp{Time::now_cached()};
+    return Timestamp{SteadyClock::now()};
   }
-  static Timestamp at(double timeout) {
-    return Timestamp{timeout};
+  static Timestamp at(double ts) {
+    return Timestamp{SteadyClock::from_double_ts(ts)};
   }
-  static Timestamp at_unix(double timeout) {
-    return Timestamp{timeout - Time::system_now() + Time::now()};
+  static Timestamp at_unix(double ts) {
+    return Timestamp{to_steady_time(UTCClock::from_double_ts(ts))};
   }
 
-  static Timestamp in(std::chrono::duration<double> timeout, td::Timestamp now = td::Timestamp::now_cached()) {
-    return Timestamp{now.at() + timeout.count()};
+  static Timestamp in(auto timeout, td::Timestamp now = td::Timestamp::now_cached())
+    requires requires {
+      { now.at_ + timeout } -> std::convertible_to<SteadyTime>;
+    }
+  {
+    return Timestamp{now.at_ + timeout};
   }
 
   static Timestamp in(double timeout, td::Timestamp now = td::Timestamp::now_cached()) {
-    return Timestamp{now.at() + timeout};
+    return Timestamp{now.at_ + detail::to_ns_duration(timeout)};
   }
 
   bool is_in_past(td::Timestamp now) const {
-    return at_ <= now.at();
+    return at_ <= now.at_;
   }
   bool is_in_past() const {
     return is_in_past(now_cached());
   }
 
   explicit operator bool() const {
-    return at_ > 0;
+    return at_ > SteadyTime{};
   }
 
-  double at() const {
+  td::SteadyTime get() const {
     return at_;
   }
+  double at() const {
+    return detail::duration_to_s(at_.time_since_epoch());
+  }
   double at_unix() const {
-    return at_ + Time::system_now() - Time::now();
+    return detail::duration_to_s(to_utc_time(at_).time_since_epoch());
   }
 
   double in() const {
-    return at_ - Time::now_cached();
+    return detail::duration_to_s(at_ - SteadyClock::now());
   }
 
   void relax(const Timestamp &timeout) {
@@ -137,69 +206,69 @@ class Timestamp {
     }
   }
 
-  friend bool operator==(Timestamp a, Timestamp b);
-  friend Timestamp &operator+=(Timestamp &a, double b);
-  friend Timestamp &operator-=(Timestamp &a, double b);
+  std::strong_ordering operator<=>(const Timestamp &other) const = default;
+
+  Timestamp &operator+=(auto value)
+    requires requires {
+      { at_ + value } -> std::convertible_to<SteadyTime>;
+    }
+  {
+    at_ += value;
+    return *this;
+  }
+
+  Timestamp &operator-=(auto value)
+    requires requires {
+      { at_ - value } -> std::convertible_to<SteadyTime>;
+    }
+  {
+    at_ -= value;
+    return *this;
+  }
+
+  Timestamp &operator+=(double value) {
+    at_ += detail::to_ns_duration(value);
+    return *this;
+  }
+
+  Timestamp &operator-=(double value) {
+    at_ -= detail::to_ns_duration(value);
+    return *this;
+  }
+
+  Timestamp operator+(auto b) const
+    requires requires(Timestamp a) { a += b; }
+  {
+    Timestamp a = *this;
+    a += b;
+    return a;
+  }
+
+  Timestamp operator-(auto b) const
+    requires requires(Timestamp a) { a -= b; }
+  {
+    Timestamp a = *this;
+    a -= b;
+    return a;
+  }
+
+  double operator-(const Timestamp &b) {
+    return detail::duration_to_s(get() - b.get());
+  }
 
  private:
-  double at_{0};
-
-  explicit Timestamp(double timeout) : at_(timeout) {
+  explicit Timestamp(SteadyClock::time_point timeout) : at_(timeout) {
   }
 };
 
-inline bool operator<(const Timestamp &a, const Timestamp &b) {
-  return a.at() < b.at();
-}
-
-inline Timestamp &operator+=(Timestamp &a, double b) {
-  a.at_ += b;
-  return a;
-}
-
-inline Timestamp &operator-=(Timestamp &a, double b) {
-  a.at_ -= b;
-  return a;
-}
-
-inline Timestamp &operator+=(Timestamp &a, std::chrono::duration<double> b) {
-  return a += b.count();
-}
-
-inline Timestamp &operator-=(Timestamp &a, std::chrono::duration<double> b) {
-  return a -= b.count();
-}
-
-inline Timestamp operator+(Timestamp a, double b) {
-  a += b;
-  return a;
-}
-
-inline Timestamp operator-(Timestamp a, double b) {
-  a -= b;
-  return a;
-}
-
-inline Timestamp operator+(Timestamp a, std::chrono::duration<double> b) {
-  return Timestamp::at(a.at() + b.count());
-}
-
-inline Timestamp operator-(Timestamp a, std::chrono::duration<double> b) {
-  return Timestamp::at(a.at() - b.count());
-}
-
-inline double operator-(const Timestamp &a, const Timestamp &b) {
-  return a.at() - b.at();
-}
-
 template <class StorerT>
 void store(const Timestamp &timestamp, StorerT &storer) {
-  storer.store_binary(timestamp.at() - Time::now() + Time::system_now());
+  storer.store_binary(timestamp.at_unix());
 }
 
 template <class ParserT>
 void parse(Timestamp &timestamp, ParserT &parser) {
-  timestamp = Timestamp::in(parser.fetch_double() - Time::system_now());
+  timestamp = Timestamp::at_unix(parser.fetch_double());
 }
 
 }  // namespace td

--- a/tdutils/td/utils/Time.h
+++ b/tdutils/td/utils/Time.h
@@ -54,6 +54,20 @@ class Time {
   static void unfreeze();
 
   static double system_now();
+
+  class FreezeGuard {
+   public:
+    FreezeGuard() {
+      Time::freeze();
+    }
+    ~FreezeGuard() {
+      Time::unfreeze();
+    }
+    FreezeGuard(const FreezeGuard &) = delete;
+    FreezeGuard &operator=(const FreezeGuard &) = delete;
+    FreezeGuard(FreezeGuard &&) = delete;
+    FreezeGuard &operator=(FreezeGuard &&) = delete;
+  };
 };
 
 inline void relax_timeout_at(double *timeout, double new_timeout) {

--- a/tdutils/td/utils/port/Clocks.cpp
+++ b/tdutils/td/utils/port/Clocks.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <ctime>
 
+#include "td/utils/Time.h"
 #include "td/utils/port/Clocks.h"
 
 namespace td {
@@ -34,8 +35,7 @@ double Clocks::monotonic() {
 }
 
 double Clocks::system() {
-  auto duration = std::chrono::system_clock::now().time_since_epoch();
-  return static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count()) * 1e-9;
+  return td::Time::system_now();
 }
 
 int Clocks::tz_offset() {

--- a/test/tdutils/CMakeLists.txt
+++ b/test/tdutils/CMakeLists.txt
@@ -6,3 +6,12 @@ target_link_libraries(test-persistent-treap PRIVATE
 )
 
 ton_test(test-persistent-treap)
+
+add_executable(test-time test-time.cpp)
+
+target_link_libraries(test-time PRIVATE
+    tdutils
+    td-test-main
+)
+
+ton_test(test-time)

--- a/test/tdutils/test-time.cpp
+++ b/test/tdutils/test-time.cpp
@@ -1,0 +1,248 @@
+#include <chrono>
+#include <thread>
+
+#include "td/utils/Time.h"
+#include "td/utils/tests.h"
+
+namespace td {
+namespace {
+
+using namespace std::chrono_literals;
+
+TEST(Time, SteadyClockBasics) {
+  static_assert(SteadyClock::is_steady);
+  static_assert(std::same_as<SteadyClock::duration, std::chrono::nanoseconds>);
+
+  auto t1 = SteadyClock::now();
+  auto t2 = SteadyClock::now();
+  EXPECT(t1 <= t2);
+
+  auto ts = SteadyClock::from_double_ts(1.5);
+  EXPECT_EQ(static_cast<int64>(1'500'000'000), ts.time_since_epoch().count());
+}
+
+TEST(Time, UTCClockBasics) {
+  static_assert(!UTCClock::is_steady);
+  static_assert(std::same_as<UTCClock::duration, std::chrono::nanoseconds>);
+
+  auto utc = std::chrono::duration<double>(UTCClock::now().time_since_epoch()).count();
+  EXPECT(utc > 1'600'000'000.0);
+}
+
+TEST(Time, ClockConversionRoundTrip) {
+  Time::FreezeGuard time_freeze;
+
+  auto utc = UTCClock::now();
+  auto steady = to_steady_time(utc);
+  auto utc_back = to_utc_time(steady);
+  EXPECT_EQ(utc, utc_back);
+}
+
+TEST(Time, TimestampNeverAndBool) {
+  Timestamp never;
+  EXPECT(!static_cast<bool>(never));
+  EXPECT(!static_cast<bool>(Timestamp::never()));
+
+  auto now = Timestamp::now();
+  EXPECT(static_cast<bool>(now));
+}
+
+TEST(Time, TimestampAtAndAtRoundTrip) {
+  auto ts = Timestamp::at(123.456);
+  EXPECT_EQ(123.456, ts.at());
+
+  auto ts2 = Timestamp::at(0.0);
+  EXPECT(!static_cast<bool>(ts2));
+}
+
+TEST(Time, TimestampAtUnixRoundTrip) {
+  auto ts = Timestamp::at_unix(1'700'000'000.5);
+  EXPECT_APPROX(1'700'000'000.5, ts.at_unix());
+}
+
+TEST(Time, TimestampInDouble) {
+  auto base = Timestamp::now();
+  auto later = Timestamp::in(2.5, base);
+  EXPECT_EQ(2.5, later - base);
+}
+
+TEST(Time, TimestampInChrono) {
+  auto base = Timestamp::now();
+  EXPECT_EQ(2.5, Timestamp::in(2500ms, base) - base);
+  EXPECT_EQ(2.5, Timestamp::in(2'500'000us, base) - base);
+  EXPECT_EQ(2.5, Timestamp::in(2'500'000'000ns, base) - base);
+  EXPECT_EQ(3.0, Timestamp::in(3s, base) - base);
+}
+
+template <typename T>
+concept TimestampInTakes = requires(T v) { Timestamp::in(v); };
+
+template <typename T>
+concept TimestampPlusEqTakes = requires(Timestamp t, T v) { t += v; };
+
+template <typename T>
+concept TimestampMinusEqTakes = requires(Timestamp t, T v) { t -= v; };
+
+TEST(Time, TimestampInTypeGate) {
+  // Integer-rep chrono and raw double seconds are accepted...
+  static_assert(TimestampInTakes<double>);
+  static_assert(TimestampInTakes<std::chrono::nanoseconds>);
+  static_assert(TimestampInTakes<std::chrono::milliseconds>);
+  static_assert(TimestampInTakes<std::chrono::seconds>);
+  // ...but duration<double> is rejected (lossy → forced opt-in via round).
+  static_assert(!TimestampInTakes<std::chrono::duration<double>>);
+}
+
+TEST(Time, TimestampOrdering) {
+  auto a = Timestamp::at(10.0);
+  auto b = Timestamp::at(20.0);
+  auto c = Timestamp::at(10.0);
+  EXPECT(a < b);
+  EXPECT(b > a);
+  EXPECT(a == c);
+  EXPECT(!(a == b));
+  EXPECT(a <= c);
+  EXPECT(a >= c);
+}
+
+TEST(Time, TimestampArithmeticDouble) {
+  auto t = Timestamp::at(100.0);
+  t += 5.0;
+  EXPECT_EQ(105.0, t.at());
+  t -= 2.5;
+  EXPECT_EQ(102.5, t.at());
+
+  EXPECT_EQ(103.5, (t + 1.0).at());
+  EXPECT_EQ(101.5, (t - 1.0).at());
+}
+
+TEST(Time, TimestampArithmeticChrono) {
+  auto t = Timestamp::at(100.0);
+  t += 500ms;
+  EXPECT_EQ(100.5, t.at());
+  t -= 250ms;
+  EXPECT_EQ(100.25, t.at());
+
+  EXPECT_EQ(101.25, (t + 1s).at());
+  EXPECT_EQ(100.2499, (t - 100us).at());
+}
+
+TEST(Time, TimestampArithmeticTypeGate) {
+  static_assert(TimestampPlusEqTakes<double>);
+  static_assert(TimestampPlusEqTakes<std::chrono::milliseconds>);
+  static_assert(TimestampMinusEqTakes<double>);
+  static_assert(TimestampMinusEqTakes<std::chrono::milliseconds>);
+  // duration<double> is rejected — caller must round explicitly.
+  static_assert(!TimestampPlusEqTakes<std::chrono::duration<double>>);
+  static_assert(!TimestampMinusEqTakes<std::chrono::duration<double>>);
+}
+
+TEST(Time, TimestampDifference) {
+  auto base = Timestamp::at(1e9);
+  auto a = Timestamp::in(100.0, base);
+  auto b = Timestamp::in(102.5, base);
+  EXPECT_EQ(2.5, b - a);
+  EXPECT_EQ(-2.5, a - b);
+}
+
+TEST(Time, TimestampIsInPast) {
+  auto past = Timestamp::at(1.0);
+  auto future = Timestamp::in(60.0);
+  EXPECT(past.is_in_past());
+  EXPECT(!future.is_in_past());
+
+  auto pivot = Timestamp::at(50.0);
+  EXPECT(Timestamp::at(40.0).is_in_past(pivot));
+  EXPECT(!Timestamp::at(60.0).is_in_past(pivot));
+  // Boundary: equal counts as in-past.
+  EXPECT(Timestamp::at(50.0).is_in_past(pivot));
+}
+
+TEST(Time, TimestampRelax) {
+  auto t = Timestamp::never();
+  t.relax(Timestamp::at(100.0));
+  EXPECT_EQ(100.0, t.at());
+
+  t.relax(Timestamp::at(150.0));
+  EXPECT_EQ(100.0, t.at());  // relax keeps the smaller
+
+  t.relax(Timestamp::at(50.0));
+  EXPECT_EQ(50.0, t.at());
+
+  t.relax(Timestamp::never());
+  EXPECT_EQ(50.0, t.at());  // never() must be a no-op
+}
+
+TEST(Time, TimestampGet) {
+  auto base = Timestamp::at(100.0);
+  auto returned = base.get();
+  static_assert(std::same_as<decltype(returned), SteadyTime>);
+  EXPECT_EQ(static_cast<int64>(100'000'000'000), returned.time_since_epoch().count());
+}
+
+TEST(Time, TimeNowMonotonic) {
+  auto a = Time::now();
+  std::this_thread::sleep_for(1ms);
+  auto b = Time::now();
+  EXPECT(b >= a);
+  EXPECT(b - a >= 0.0005);
+}
+
+TEST(Time, JumpInFutureDouble) {
+  auto target = Time::now() + 10.0;
+  Time::jump_in_future(target);
+  EXPECT(Time::now() >= target);
+}
+
+TEST(Time, JumpInFutureSteadyTime) {
+  auto target = SteadyClock::now() + 10s;
+  Time::jump_in_future(target);
+  EXPECT(SteadyClock::now() >= target);
+}
+
+TEST(Time, FrozenJumpToSteadyTimeIsExact) {
+  Time::FreezeGuard time_freeze;
+
+  auto t0 = Timestamp::now().get();
+  auto target = t0 + 5s + 250ms + 137ns;
+
+  Time::jump_in_future(target);
+
+  EXPECT_EQ(target, SteadyClock::now());
+  EXPECT_EQ(target, Timestamp::now().get());
+  EXPECT_EQ(5'250'000'137ns, SteadyClock::now() - t0);
+}
+
+TEST(Time, FreezeAndUnfreeze) {
+  double t3;
+  {
+    Time::FreezeGuard time_freeze;
+    auto t1 = Time::now();
+    std::this_thread::sleep_for(2ms);
+    auto t2 = Time::now();
+    EXPECT_EQ(t1, t2);
+
+    auto sys1 = Time::system_now();
+    std::this_thread::sleep_for(2ms);
+    auto sys2 = Time::system_now();
+    EXPECT_EQ(sys1, sys2);
+
+    Time::jump_in_future(t1 + 7.0);
+    t3 = Time::now();
+    auto sys3 = Time::system_now();
+    EXPECT_EQ(t3 - t1, 7.0);
+    EXPECT_EQ(sys3 - sys1, 7.0);
+  }
+
+  auto after = Time::now();
+  EXPECT(after >= t3);
+}
+
+TEST(Time, StoreParseRoundTrip) {
+  double original_unix = 1'700'000'000.25;
+  auto ts = Timestamp::at_unix(original_unix);
+  EXPECT_APPROX(original_unix, ts.at_unix());
+}
+
+}  // namespace
+}  // namespace td

--- a/validator/consensus/simplex/candidate-resolver.cpp
+++ b/validator/consensus/simplex/candidate-resolver.cpp
@@ -333,9 +333,9 @@ class CandidateResolverImpl : public td::actor::SpawnsWith<Bus>, public td::acto
       }
       PeerValidatorId peer{peer_idx};
 
-      auto maybe_response = co_await owning_bus()
-                                .publish<OutgoingOverlayRequest>(peer, td::Timestamp::in(timeout), std::move(request))
-                                .wrap();
+      auto timeout_ts = td::Timestamp::in(std::chrono::round<std::chrono::nanoseconds>(timeout));
+      auto maybe_response =
+          co_await owning_bus().publish<OutgoingOverlayRequest>(peer, timeout_ts, std::move(request)).wrap();
 
       if (maybe_response.is_ok()) {
         auto response = maybe_response.move_as_ok();

--- a/validator/consensus/simplex/consensus.cpp
+++ b/validator/consensus/simplex/consensus.cpp
@@ -134,7 +134,7 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
 
     if (timeout_slot_ <= event->start_slot) {
       timeout_slot_ = event->start_slot + 1;
-      timeout_base_ = td::Timestamp::in(first_block_timeout_);
+      timeout_base_ = td::Timestamp::in(std::chrono::round<std::chrono::nanoseconds>(first_block_timeout_));
       alarm_timestamp() = td::Timestamp::in(params_.target_rate, timeout_base_);
     }
   }


### PR DESCRIPTION
This is motivated by floating-point precision loses we had otherwise that often result in CI flakes.