### PR TITLE
prevent CellDb preload from inflating RocksDB cache

### DIFF
--- a/tddb/td/db/KeyValue.h
+++ b/tddb/td/db/KeyValue.h
@@ -60,11 +60,20 @@ class KeyValueReader {
  public:
   virtual ~KeyValueReader() = default;
   enum class GetStatus : int32 { Ok, NotFound };
+  struct ForEachOptions {
+    bool fill_cache = true;
+  };
 
   virtual Result<GetStatus> get(Slice key, std::string& value) = 0;
   virtual Result<std::vector<GetStatus>> get_multi(td::Span<Slice> keys, std::vector<std::string>* values) = 0;
   virtual Result<size_t> count(Slice prefix) = 0;
   virtual Status for_each(std::function<Status(Slice, Slice)> f) {
+    return for_each(f, {});
+  }
+  virtual Status for_each(std::function<Status(Slice, Slice)> f, ForEachOptions options) {
+    if (!options.fill_cache) {
+      return Status::Error("for_each with options is not supported");
+    }
     return Status::Error("for_each is not supported");
   }
   virtual Status for_each_in_range(Slice begin, Slice end, std::function<Status(Slice, Slice)> f) {

--- a/tddb/td/db/MemoryKeyValue.cpp
+++ b/tddb/td/db/MemoryKeyValue.cpp
@@ -53,6 +53,10 @@ Result<std::vector<MemoryKeyValue::GetStatus>> MemoryKeyValue::get_multi(td::Spa
 }
 
 Status MemoryKeyValue::for_each(std::function<Status(Slice, Slice)> f) {
+  return for_each(std::move(f), {});
+}
+
+Status MemoryKeyValue::for_each(std::function<Status(Slice, Slice)> f, ForEachOptions) {
   for (auto &unlocked_bucket : buckets_) {
     auto bucket = lock(unlocked_bucket);
     for (auto &it : bucket->map) {

--- a/tddb/td/db/MemoryKeyValue.h
+++ b/tddb/td/db/MemoryKeyValue.h
@@ -36,6 +36,7 @@ class MemoryKeyValue : public KeyValue {
   Result<GetStatus> get(Slice key, std::string& value) override;
   Result<std::vector<GetStatus>> get_multi(td::Span<Slice> keys, std::vector<std::string>* values) override;
   Status for_each(std::function<Status(Slice, Slice)> f) override;
+  Status for_each(std::function<Status(Slice, Slice)> f, ForEachOptions options) override;
   Status for_each_in_range(Slice begin, Slice end, std::function<Status(Slice, Slice)> f) override;
   Status set(Slice key, Slice value) override;
   Status merge(Slice key, Slice value) override;

--- a/tddb/td/db/RocksDb.cpp
+++ b/tddb/td/db/RocksDb.cpp
@@ -289,12 +289,17 @@ Result<size_t> RocksDb::count(Slice prefix) {
 }
 
 Status RocksDb::for_each(std::function<Status(Slice, Slice)> f) {
+  return for_each(std::move(f), {});
+}
+
+Status RocksDb::for_each(std::function<Status(Slice, Slice)> f, ForEachOptions for_each_options) {
   if (options_.no_reads) {
     return td::Status::Error("trying to read from write-only database");
   }
   rocksdb::ReadOptions options;
   options.auto_prefix_mode = true;
   options.snapshot = snapshot_.get();
+  options.fill_cache = for_each_options.fill_cache;
   std::unique_ptr<rocksdb::Iterator> iterator;
   if (snapshot_ || !transaction_) {
     iterator.reset(db_->NewIterator(options));

--- a/tddb/td/db/RocksDb.h
+++ b/tddb/td/db/RocksDb.h
@@ -91,6 +91,7 @@ class RocksDb : public KeyValue {
   Status run_gc() override;
   Result<size_t> count(Slice prefix) override;
   Status for_each(std::function<Status(Slice, Slice)> f) override;
+  Status for_each(std::function<Status(Slice, Slice)> f, ForEachOptions options) override;
   Status for_each_in_range(Slice begin, Slice end, std::function<Status(Slice, Slice)> f) override;
 
   Status begin_write_batch() override;

--- a/validator/db/celldb.cpp
+++ b/validator/db/celldb.cpp
@@ -304,19 +304,22 @@ void CellDbIn::start_up() {
   }
 
   if (opts_->get_celldb_preload_all()) {
-    // Iterate whole DB in a separate thread
+    // Iterate whole DB in a separate thread without filling RocksDb block cache.
+    // This avoids turning preload into an aggressive RAM-filling operation when CellDb cache is large.
     delay_action(
         [snapshot = cell_db_->snapshot()]() {
-          LOG(WARNING) << "CellDb: pre-loading all keys";
+          LOG(WARNING) << "CellDb: pre-loading all keys without filling RocksDb block cache";
           td::uint64 total = 0;
           td::Timer timer;
-          auto S = snapshot->for_each([&](td::Slice, td::Slice) {
-            ++total;
-            if (total % 1000000 == 0) {
-              LOG(INFO) << "CellDb: iterated " << total << " keys";
-            }
-            return td::Status::OK();
-          });
+          auto S = snapshot->for_each(
+              [&](td::Slice, td::Slice) {
+                ++total;
+                if (total % 1000000 == 0) {
+                  LOG(INFO) << "CellDb: iterated " << total << " keys";
+                }
+                return td::Status::OK();
+              },
+              {.fill_cache = false});
           if (S.is_error()) {
             LOG(ERROR) << "CellDb: pre-load failed: " << S.move_as_error();
           } else {


### PR DESCRIPTION
@DanShaders would love your thoughts on this 
Add iteration options to the key-value reader path and use RocksDB `ReadOptions.fill_cache = false` for CellDb preload.
Mitigates #2351 
### What changed

- Added `KeyValueReader::ForEachOptions`
- Added `for_each(..., options)` support in:
  - `RocksDb`
  - `MemoryKeyValue`
- Updated CellDb preload to call `for_each(..., {.fill_cache = false})`

### Effect

- `--celldb-preload-all` still scans the whole DB
- preload no longer aggressively fills RocksDB block cache
- should reduce startup / steady-state RAM inflation in large-cache validator setups