### PR TITLE
Fix double semicolon typo in GenericsSubstitutions::as_human_readable

### DIFF
--- a/tolk/generics-helpers.cpp
+++ b/tolk/generics-helpers.cpp
@@ -68,7 +68,7 @@ std::string GenericsSubstitutions::as_human_readable(bool show_nullptr) const {
   std::string result;
   for (int i = 0; i < size(); ++i) {
     if (valuesTs[i] == nullptr && !show_nullptr) {
-      continue;;
+      continue;
     }
     if (!result.empty()) {
       result += ", ";


### PR DESCRIPTION
## Problem

In `tolk/generics-helpers.cpp::GenericsSubstitutions::as_human_readable()`, the `continue` statement at line 71 has a trailing extra semicolon:

```cpp
for (int i = 0; i < size(); ++i) {
  if (valuesTs[i] == nullptr && !show_nullptr) {
    continue;;
  }
  ...
}
```

The second semicolon is parsed as a null statement, harmless but clearly unintended.

## Fix

Remove the stray semicolon.

```cpp
continue;
```

## Scope

- Single file, single line, +1 / −1.
- No behavioral change.
- No public API impact.