### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -6340,7 +6340,7 @@ td::Status TonlibClient::do_request(const tonlib_api::blocks_getTransactionsExt&
         auto raw_transactions =
             ToRawTransactions(td::optional<td::Ed25519::PrivateKey>()).to_raw_transactions(info.move_as_ok());
         if (raw_transactions.is_error()) {
-          return raw_transactions.move_as_error_prefix("Error occured while creating tonlib_api::raw_transaction: ");
+          return raw_transactions.move_as_error_prefix("Error occurred while creating tonlib_api::raw_transaction: ");
         }
 
         tonlib_api::blocks_transactionsExt r;

--- a/validator/consensus/simplex/pool.cpp
+++ b/validator/consensus/simplex/pool.cpp
@@ -658,7 +658,7 @@ class PoolImpl : public td::actor::SpawnsWith<Bus>, public td::actor::ConnectsTo
 
       if (auto misbehavior = add_result.misbehavior) {
         LOG_CHECK(validator != owning_bus()->local_id || tolerate_conflicts)
-            << "We produced conflicting votes! Conflict occured for " << vote.vote;
+            << "We produced conflicting votes! Conflict occurred for " << vote.vote;
         // The following line cannot be simply
         // `owning_bus().publish<MisbehaviorReport>(validator.idx, *misbehavior);` as this would
         // _sometimes_ result in link errors (at least with clang-21 and libstdc++-15) because of a

--- a/validator/impl/collator.cpp
+++ b/validator/impl/collator.cpp
@@ -3648,7 +3648,7 @@ bool Collator::is_our_address(const ton::StdSmcAddress& addr) const {
  *          0 - message was enqueued.
  *          1 - message was processed.
  *          3 - message was processed, all future messages must be enqueued.
- *          -1 - error occured.
+ *          -1 - error occurred.
  */
 int Collator::process_one_new_message(block::NewOutMsg msg, bool enqueue_only, Ref<vm::Cell>* is_special) {
   bool from_dispatch_queue = msg.msg_env_from_dispatch_queue.not_null();

--- a/validator/impl/validate-query.cpp
+++ b/validator/impl/validate-query.cpp
@@ -5488,7 +5488,7 @@ std::unique_ptr<block::Account> ValidateQuery::CheckAccountTxs::make_account_fro
  * @param addr The 256-bit address of the account.
  *
  * @returns Pointer to the account if found or created successfully.
- *          Returns nullptr if an error occured.
+ *          Returns nullptr if an error occurred.
  */
 std::unique_ptr<block::Account> ValidateQuery::CheckAccountTxs::unpack_account(td::ConstBitPtr addr) {
   auto dict_entry = vq_.ps_.account_dict_->lookup_extra(addr, 256);


### PR DESCRIPTION
## Problem

Four occurrences of the misspelling `occured` (correct: `occurred`):

- `validator/impl/validate-query.cpp:5491` — doc comment for `unpack_account`
- `validator/impl/collator.cpp:3651` — doc comment for `process_one_new_message`
- `validator/consensus/simplex/pool.cpp:661` — `LOG_CHECK` message ("We produced conflicting votes! Conflict occured for ...")
- `tonlib/tonlib/TonlibClient.cpp:6343` — `move_as_error_prefix` payload ("Error occured while creating tonlib_api::raw_transaction: ")

The last two are user-visible (log output / API error string).

## Fix

Spell-correct to `occurred` in all four locations.

## Scope

- 4 files, +4 / −4 lines.
- No behavioral change.
- No public API or schema impact. The error message text on `TonlibClient.cpp:6343` is part of a runtime error string; callers should not be matching on this text, and the corrected spelling is the only difference.