### PR TITLE
Fix use-after-move in LastBlockStorage::get_state migration path

### DIFF
--- a/tonlib/tonlib/LastBlockStorage.cpp
+++ b/tonlib/tonlib/LastBlockStorage.cpp
@@ -59,9 +59,9 @@ td::Result<LastBlockState> LastBlockStorage::get_state(td::Slice name) {
     auto key_depr = get_file_name_depr(name);
     auto data_depr = kv_->get(key_depr);
     if (data_depr.is_ok()) {
-      kv_->set(get_file_name(name), data_depr.move_as_ok());
-      kv_->erase(key_depr);
       data_r = std::move(data_depr);
+      kv_->set(get_file_name(name), data_r.ok());
+      kv_->erase(key_depr);
     } else {
       return td::Status::Error("not found");
     }


### PR DESCRIPTION
## Problem

`LastBlockStorage::get_state` has a use-after-move that breaks every read on the deprecated-key migration path.

```cpp
auto data_depr = kv_->get(key_depr);            // td::Result<td::SecureString>
if (data_depr.is_ok()) {
  kv_->set(get_file_name(name), data_depr.move_as_ok());  // (1) inner SecureString moved out
  kv_->erase(key_depr);
  data_r = std::move(data_depr);                          // (2) move the now-empty Result into data_r
} else {
  return td::Status::Error("not found");
}

auto data = data_r.move_as_ok();                // (3) returns the moved-from (empty) SecureString
if (data.size() < 8) {
  return td::Status::Error("too short");        // <-- this is what callers see
}
```

`td::Result<T>::move_as_ok()` (`tdutils/td/utils/Status.h:636`) is defined as:

```cpp
T move_as_ok() {
  LOG_CHECK(status_.is_ok()) << status_;
  return std::move(value_);
}
```

It moves out `value_` but leaves `status_` unchanged at `is_ok()`. So after step (1), `data_depr.value_` is empty but `data_depr.is_ok()` still holds. Step (2) therefore copies the empty value into `data_r` together with the lingering OK status.

`data_r.move_as_ok()` on the way out then yields an empty `SecureString`, the `data.size() < 8` check fires, and the migration call returns `td::Status::Error("too short")`.

The on-disk migration itself completes (the new key is written and the deprecated key is erased), so a *second* call to `get_state` succeeds. But every caller on the first read after migration sees a spurious `"too short"` error.

## Fix

Move the `Result` wrapper *before* consuming its inner value, then pass the now-owned `data_r.ok()` to `kv_->set`. `KeyValue::set` takes a `td::Slice` and `td::SecureString` provides an implicit conversion to `td::Slice` via `operator Slice() const` (`tdutils/td/utils/SharedSlice.h:199`).

```cpp
if (data_depr.is_ok()) {
  data_r = std::move(data_depr);
  kv_->set(get_file_name(name), data_r.ok());
  kv_->erase(key_depr);
} else {
  return td::Status::Error("not found");
}
```

After the fix, `data_r` holds the migrated value with both `status_=ok` and `value_` populated, and the downstream `data_r.move_as_ok()` correctly returns the migrated bytes.

## Scope

- Single file (`tonlib/tonlib/LastBlockStorage.cpp`), single function, +2 / −2.
- Behavioral fix: the first read on the migration path now returns the migrated value instead of erroring with `"too short"`. Subsequent reads were already working; they continue to work.
- The on-disk migration logic is unchanged: the new key is still written and the deprecated key is still erased before the value is consumed.
- No public API or schema change.