### PR TITLE
test/consensus: fix stop_instance loop using wrong node index

### DIFF
--- a/test/validator/consensus/test-consensus.cpp
+++ b/test/validator/consensus/test-consensus.cpp
@@ -824,7 +824,7 @@ class TestConsensus : public td::actor::Actor {
     LOG(WARNING) << "TEST FINISHED";
     std::vector<td::actor::Task<>> tasks;
     for (size_t idx = 0; idx < N_NODES; ++idx) {
-      for (size_t i = 0; i < nodes_[i].instances.size(); ++i) {
+      for (size_t i = 0; i < nodes_[idx].instances.size(); ++i) {
         tasks.push_back(stop_instance(idx, i));
       }
     }


### PR DESCRIPTION
## What

Fix a copy-paste typo in the inner loop of `TestConsensus::finalize()` in `test/validator/consensus/test-consensus.cpp`.

```diff
   for (size_t idx = 0; idx < N_NODES; ++idx) {
-    for (size_t i = 0; i < nodes_[i].instances.size(); ++i) {
+    for (size_t i = 0; i < nodes_[idx].instances.size(); ++i) {
       tasks.push_back(stop_instance(idx, i));
     }
   }
```

The inner loop checked `nodes_[i].instances.size()` (using the inner counter `i` as the node index) instead of `nodes_[idx].instances.size()`. The parallel loop just below at lines 832-836 already uses the correct `nodes_[idx]` form.

## Why it matters

When instance counts are heterogeneous (e.g. `--n-double-nodes N > 0`), the inner `i` can advance past `nodes_[idx].instances.size()`. The subsequent `stop_instance(idx, i)` call then does:

```cpp
Instance &inst = node.instances[instance_idx];   // out-of-range
...
inst.bus.publish<StopRequested>();               // UB / SIGSEGV
```

## Reproducer (before this PR)

```bash
./test-consensus --duration 30 --n-nodes 5 --n-double-nodes 2                  --gremlin-period 5 --gremlin-kills-leader
```

Crashes with `Signal: 11` and a backtrace ending in `TestConsensus::stop_instance` / `BusHandle::publish<StopRequested>` during teardown. The crash is timing-sensitive (it needs at least two double-nodes plus a leader-killing gremlin to manifest reliably) because the bad iteration only triggers UB when scheduling lines up with concurrent stops.

## Verification

After the fix, the same command runs to completion and `TEST RESULTS` are printed for every node with no signal.