### PR TITLE
Fix persistent state split part formatting

### DIFF
--- a/validator/interfaces/persistent-state.h
+++ b/validator/interfaces/persistent-state.h
@@ -71,23 +71,21 @@ inline ShardId persistent_state_to_effective_shard(const ShardIdFull &shard, con
 
 inline std::string persistent_state_type_to_string(const ShardIdFull &shard, const PersistentStateType &state) {
   std::string result;
-  state.visit(td::overloaded([&](UnsplitStateType) { result = "unsplit"; },
-                             [&](SplitAccountStateType type) {
-                               auto real_pfx_len = shard_prefix_length(shard.shard);
-                               auto effective_pfx_len = shard_prefix_length(type.effective_shard_id);
-                               if (shard.shard == 0 || type.effective_shard_id == 0 ||
-                                   effective_pfx_len <= real_pfx_len ||
-                                   !shard_is_proper_ancestor(shard.shard, type.effective_shard_id)) {
-                                 result = "invalid split part";
-                                 return;
-                               }
-                               td::uint64 parts_count = td::uint64{1} << (effective_pfx_len - real_pfx_len);
-                               td::uint64 part_idx =
-                                   type.effective_shard_id >> (64 - effective_pfx_len) & (parts_count - 1);
-                               result =
-                                   "part " + std::to_string(part_idx + 1) + " out of " + std::to_string(parts_count);
-                             },
-                             [&](SplitPersistentStateType) { result = "split header"; }));
+  state.visit(
+      td::overloaded([&](UnsplitStateType) { result = "unsplit"; },
+                     [&](SplitAccountStateType type) {
+                       auto real_pfx_len = shard_prefix_length(shard.shard);
+                       auto effective_pfx_len = shard_prefix_length(type.effective_shard_id);
+                       if (shard.shard == 0 || type.effective_shard_id == 0 || effective_pfx_len <= real_pfx_len ||
+                           !shard_is_proper_ancestor(shard.shard, type.effective_shard_id)) {
+                         result = "invalid split part";
+                         return;
+                       }
+                       td::uint64 parts_count = td::uint64{1} << (effective_pfx_len - real_pfx_len);
+                       td::uint64 part_idx = type.effective_shard_id >> (64 - effective_pfx_len) & (parts_count - 1);
+                       result = "part " + std::to_string(part_idx + 1) + " out of " + std::to_string(parts_count);
+                     },
+                     [&](SplitPersistentStateType) { result = "split header"; }));
   return result;
 }
 

--- a/validator/interfaces/persistent-state.h
+++ b/validator/interfaces/persistent-state.h
@@ -73,9 +73,15 @@ inline std::string persistent_state_type_to_string(const ShardIdFull &shard, con
   std::string result;
   state.visit(td::overloaded([&](UnsplitStateType) { result = "unsplit"; },
                              [&](SplitAccountStateType type) {
-                               int real_pfx_len = shard_prefix_length(shard.shard);
-                               int effective_pfx_len = shard_prefix_length(type.effective_shard_id);
-                               td::uint64 parts_count = 1 << (effective_pfx_len - real_pfx_len);
+                               auto real_pfx_len = shard_prefix_length(shard.shard);
+                               auto effective_pfx_len = shard_prefix_length(type.effective_shard_id);
+                               if (shard.shard == 0 || type.effective_shard_id == 0 ||
+                                   effective_pfx_len <= real_pfx_len ||
+                                   !shard_is_proper_ancestor(shard.shard, type.effective_shard_id)) {
+                                 result = "invalid split part";
+                                 return;
+                               }
+                               td::uint64 parts_count = td::uint64{1} << (effective_pfx_len - real_pfx_len);
                                td::uint64 part_idx =
                                    type.effective_shard_id >> (64 - effective_pfx_len) & (parts_count - 1);
                                result =


### PR DESCRIPTION
Prevent signed-shift UB in `persistent_state_type_to_string()` by validating split-account state shape before formatting and using a `td::uint64` shift operand. Invalid split parts are rendered as `invalid split part` instead of evaluating unsafe arithmetic.

This does not pose a real risk; fixed for code cleanliness and to reduce false-positive bug bounty reports.