### PR TITLE
Ed25519 `EVP_DigestVerify` return-code hardening

### DIFF
--- a/crypto/Ed25519.cpp
+++ b/crypto/Ed25519.cpp
@@ -287,7 +287,7 @@ Status Ed25519::PublicKey::verify_signature(Slice data, Slice signature) const {
     return Status::Error("Can't init DigestVerify");
   }
 
-  if (EVP_DigestVerify(md_ctx, signature.ubegin(), signature.size(), data.ubegin(), data.size())) {
+  if (EVP_DigestVerify(md_ctx, signature.ubegin(), signature.size(), data.ubegin(), data.size()) == 1) {
     return Status::OK();
   }
   return Status::Error("Wrong signature");


### PR DESCRIPTION
Accept Ed25519 signatures only when `EVP_DigestVerify()` returns exactly `1`, matching OpenSSL's documented success contract and the existing P-256 verification pattern.

This does not appear to pose a practical risk in current TON builds: in the bundled OpenSSL Ed25519 provider and legacy ECX paths, normal external-actor-controlled malformed-input cases return 0, not a negative value. Signature length mismatch returns 0; invalid public key encoding returns 0; invalid signature scalar or signature mismatch returns 0; Ed25519 provider allocation/hash failures also return 0; and the s390x accelerated Ed25519 verify path maps the low-level return to 1 or 0. Negative EVP_DigestVerify() returns are possible for generic EVP misuse/state failures or custom provider behavior, but there is no way where remote Ed25519 input can trigger them after successful import/init checks.
This is fixed for code cleanliness and to reduce false-positive bug bounty reports.
