### PR TITLE
[Tolk] v1.4.1: small fixes and minor updates

### DIFF
--- a/crypto/smartcont/tolk-stdlib/common.tolk
+++ b/crypto/smartcont/tolk-stdlib/common.tolk
@@ -1,7 +1,7 @@
 // Standard library for Tolk (LGPL licence).
 // It contains common functions that are available out of the box, the user doesn't have to import anything.
 // More specific functions are required to be imported explicitly, like "@stdlib/gas-payments".
-tolk 1.4
+tolk 1.4.1
 
 /**
     Built-in types.

--- a/crypto/smartcont/tolk-stdlib/exotic-cells.tolk
+++ b/crypto/smartcont/tolk-stdlib/exotic-cells.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 enum ExoticCellType: int8 {
     Ordinary = -1

--- a/crypto/smartcont/tolk-stdlib/gas-payments.tolk
+++ b/crypto/smartcont/tolk-stdlib/gas-payments.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 /**
   Gas and payment related primitives.

--- a/crypto/smartcont/tolk-stdlib/lisp-lists.tolk
+++ b/crypto/smartcont/tolk-stdlib/lisp-lists.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 /**
     A lisp-style list is a set of nested 2-element TVM tuples:

--- a/crypto/smartcont/tolk-stdlib/reflection.tolk
+++ b/crypto/smartcont/tolk-stdlib/reflection.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 /**
     Reflection API.

--- a/crypto/smartcont/tolk-stdlib/strings.tolk
+++ b/crypto/smartcont/tolk-stdlib/strings.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 /**
     A string is a language primitive — a cell containing snake-formatted text data.

--- a/crypto/smartcont/tolk-stdlib/tvm-dicts.tolk
+++ b/crypto/smartcont/tolk-stdlib/tvm-dicts.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 /**
     Low-level API working with TVM dictionaries.

--- a/crypto/smartcont/tolk-stdlib/tvm-lowlevel.tolk
+++ b/crypto/smartcont/tolk-stdlib/tvm-lowlevel.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4
+tolk 1.4.1
 
 /// Usually `c3` has a continuation initialized by the whole code of the contract. It is used for function calls.
 /// The primitive returns the current value of `c3`.

--- a/tolk-tester/tests/assignment-tests.tolk
+++ b/tolk-tester/tests/assignment-tests.tolk
@@ -186,7 +186,7 @@ global ab122: (int, int);
 @method_id(122)
 fun test122() {
     (i122, ab122) = (0, (0,0));
-    (i122, ab122.0).1 = 10;     // modifies ab122.0
+    ab122.0 = 10;
     return (i122, ab122);
 }
 
@@ -195,7 +195,7 @@ fun test123() {
     var a = 0;
     a = a = a = 10;
     a = a.increment();
-    (a, 0).0 = a.increment().increment();
+    a = a.increment().increment();
     return a;
 }
 
@@ -207,19 +207,6 @@ fun test124() {
     g124 = (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18);
     var (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18) = g124;
     return (a1, a18);
-}
-
-const C125: (int, int) = (1, 2);
-
-struct P125 {
-    x: int;
-}
-
-@method_id(125)
-fun test125() {
-    var x = 1;
-    (x, Point { x: C125.0, y: C125.1 }).0 = 5;
-    return x;
 }
 
 
@@ -244,7 +231,6 @@ fun main(value: int, ) {
 @testcase | 122 |        | 0 10 0
 @testcase | 123 |        | 13
 @testcase | 124 |        | 1 18
-@testcase | 125 |        | 5
 
 
 @fif_codegen

--- a/tolk-tester/tests/cells-slices.tolk
+++ b/tolk-tester/tests/cells-slices.tolk
@@ -147,10 +147,9 @@ fun test11() {
     var size5 = s.remainingBitsCount();
 
     var s32 = stringHexToSlice("00000000");
-    // this call modifes `s32`
-    (s32, 0).0.skipBits(8);
+    s32.skipBits(8);
     // but this will be denied as "can not mutate a temporary exression"
-    // (s32!, 0).0.skipBits(8);
+    // (s32, 0).0.skipBits(8);
     // (s32 as slice, 0).0.skipBits(8);
 
     return (n1, n2, size1, size2, size3, size4, size5, s32.remainingBitsCount());
@@ -678,6 +677,20 @@ fun test50(s: slice): int {
     }
 }
 
+fun dupStoreWithOpaqueStur(b: builder, x: int): (builder, builder)
+    asm "OVER SWAP 8 STUR"
+
+@method_id(151)
+fun test51(): int {
+    try {
+        val (original, stored) = dupStoreWithOpaqueStur(beginCell(), 10);
+        var s = stored.toSlice();
+        return original.bitsCount() * 100 + stored.bitsCount() * 10 + s.loadUint(8);
+    } catch (err) {
+        return err;
+    }
+}
+
 fun main(): int {
     return 0;
 }
@@ -733,6 +746,7 @@ fun main(): int {
 @testcase | 148 |     | 7 32
 @testcase | 149 |     | -1 -1 0 -1 0 -1 -1 -1
 @testcase | 150 | x{} | 9
+@testcase | 151 |     | 90
 
 We test that consequtive storeInt/storeUint with constants are joined into a single number
 

--- a/tolk-tester/tests/comments-tests.tolk
+++ b/tolk-tester/tests/comments-tests.tolk
@@ -48,6 +48,29 @@ fun call_some_calc() {
     return some_calc(-10);
 }
 
+fun escapedAsmComment1(): int asm "1 PUSHINT // \n 10 ADDCONST"
+
+fun escapedAsmComment2(): int asm """
+    2 PUSHINT // \t \n 10 ADDCONST
+"""
+
+@method_id(102)
+fun test102() {
+    return (escapedAsmComment1(), escapedAsmComment2());
+}
+
+fun keepSliceWithAsmComment(s: slice): slice
+    asm """
+        DUP
+        // 8 LDU
+    """
+    "DROP"
+
+@method_id(103)
+fun test103(s: slice): int {
+    return keepSliceWithAsmComment(s).remainingBitsCount();
+}
+
 fun main() {
     var cb = demo_fields_def;
     demo_call_def;
@@ -57,6 +80,8 @@ fun main() {
 /**
 @testcase | 0   |   | 1
 @testcase | 101 |   | 20
+@testcase | 102 |   | 1 2
+@testcase | 103 | x{0102} | 16
 
 @fif_codegen_enable_comments
 @fif_codegen

--- a/tolk-tester/tests/constants-tests.tolk
+++ b/tolk-tester/tests/constants-tests.tolk
@@ -147,6 +147,9 @@ struct WithNullableArrayDef {
 const objWithNullableArray: WithNullableArray = { x: [1] }
 const objWithNullableArrayDef: WithNullableArrayDef = {}
 
+const emptyMapNullable: map<int8, int32>? = []
+const emptyMapAsNullableConst = [] as map<int8, int32>?
+
 
 fun iget240(): MInt { return int240; }
 
@@ -318,6 +321,12 @@ fun test125() {
     return (manual.size(), manual.get(0), def.size(), def.get(0));
 }
 
+@method_id(126)
+fun test126() {
+    __expect_type(emptyMapAsNullableConst, "map<int8, int32>?");
+    return (emptyMapAsNullableConst == null, emptyMapAsNullableConst!.isEmpty());
+}
+
 fun main() {
     var i1: int = iget1();
     var i2: int = iget2();
@@ -367,6 +376,7 @@ fun main() {
 @testcase | 123 |   | [ 1 ] [ 1 (null) ] 777 (null) 0
 @testcase | 124 |   | 0 50000000
 @testcase | 125 |   | 1 1 1 2
+@testcase | 126 |   | 0 -1
 
-@code_hash 108440790824773606102294831194495672355462123034127652878583577204193565477401
+@code_hash 69450727578206805235623888457664461735127156131005024409888318254979905151137
 */

--- a/tolk-tester/tests/dicts-demo.tolk
+++ b/tolk-tester/tests/dicts-demo.tolk
@@ -30,9 +30,9 @@ fun test101(getK1: int, getK2: int, getK3: int) {
     var (cur3: slice?, found3) = dict.uDictGet(32, getK3);
     old1 = old1!; old2 = old2!; cur3 = cur3!;
     return (
-        found1 ? (old1, 0).0.loadUint(32) : -1,
-        found2 ? (old2, 0).0.loadUint(32) : -1,
-        found3 ? (cur3, 0).0.loadUint(32) : -1
+        found1 ? old1.loadUint(32) : -1,
+        found2 ? old2.loadUint(32) : -1,
+        found3 ? cur3.loadUint(32) : -1
     );
 }
 
@@ -49,7 +49,7 @@ fun test102() {
         var (kDel, kVal, wasDel) = dict.iDictDeleteLastAndGet(32);
         if (wasDel) {
             kVal = kVal!;
-            deleted.push([kDel, (kVal, 0).0.loadInt(32)]);
+            deleted.push([kDel, kVal.loadInt(32)]);
         } else {
             shouldBreak = true;
         }

--- a/tolk-tester/tests/enums-tests.tolk
+++ b/tolk-tester/tests/enums-tests.tolk
@@ -283,6 +283,11 @@ fun test16() {
     return (p1.exitCode is int32, p2.exitCode is int32, p2.exitCode is (int32 -> bool), x);
 }
 
+@method_id(117)
+fun test27() {
+    return [[Color.Red]].toCell().beginParse().remainingBitsAndRefsCount()
+}
+
 
 fun main(c: Color) {
     __expect_type(c, "Color");
@@ -319,6 +324,7 @@ fun main(c: Color) {
 @testcase | 114 | 2   | 2 1 0 1000000000 -1 
 @testcase | 115 |     | 0 2
 @testcase | 116 |     | -1 0 -1 258
+@testcase | 117 |     | 9 1
 
 @fif_codegen
 """

--- a/tolk-tester/tests/generics-2.tolk
+++ b/tolk-tester/tests/generics-2.tolk
@@ -278,7 +278,7 @@ fun test11() {
 fun test12(is1: bool) {
     var c1: Wrapper<int|builder> = { value: 10 };
     var c2: Wrapper<builder|int> = { value: 20 };
-    var c3: Wrapper<int|builder> | WrapperAlias<builder|int> = is1 ? c1 : c2;
+    var c3: Wrapper<int|builder> | Wrapper<int|builder> = is1 ? c1 : c2;
     __expect_type(c3, "Wrapper<int | builder>");
     var m3: Wrapper<int|builder> | Wrapper<builder|int|null> = is1 ? c1 : Wrapper<builder?|int> { value: null };
     __expect_type(m3, "Wrapper<int | builder> | Wrapper<builder | int | null>");
@@ -426,7 +426,7 @@ fun test22(w: int | WrapperAlias<int> | slice) {
     match (w) {
         MyInt => {}
         slice => {}
-        WrapperAlias => {}
+        WrapperAlias<int> => {}
     }
 };
 

--- a/tolk-tester/tests/generics-3.tolk
+++ b/tolk-tester/tests/generics-3.tolk
@@ -80,7 +80,7 @@ fun test4() {
 fun test5() {
     var o1: Ok<int> = { result: 1 };
     var o2: OkAlias<int> = { result: 2 };
-    return (o1 is Ok, o1 is OkAlias, o2 is Ok, o2 is OkAlias, o1 is Ok<slice>, o1 is OkAlias<slice>);
+    return (o1 is Ok, o1 is OkAlias<int>, o2 is Ok, o2 is OkAlias<int>, o1 is Ok<slice>, o1 is OkAlias<slice>);
 }
 
 type OkInt = Ok<int>;

--- a/tolk-tester/tests/if-else-tests.tolk
+++ b/tolk-tester/tests/if-else-tests.tolk
@@ -339,6 +339,20 @@ fun test22(x: int): int {
     return r;
 }
 
+fun chooseAsmIfElse(flag: int): int
+    asm """
+IF:<{
+  1 PUSHINT
+  }>ELSE<{
+  2 PUSHINT
+  }>
+"""
+
+@method_id(123)
+fun test23(x: int): int {
+    return chooseAsmIfElse(x);
+}
+
 
 fun main() {
 
@@ -386,6 +400,8 @@ fun main() {
 @testcase | 121 | null | [ 0 0 0 0 ]
 @testcase | 122 | 0   | 1
 @testcase | 122 | 7   | 14
+@testcase | 123 | 0   | 2
+@testcase | 123 | 4   | 1
 
 @fif_codegen
 """

--- a/tolk-tester/tests/indexed-access.tolk
+++ b/tolk-tester/tests/indexed-access.tolk
@@ -313,9 +313,11 @@ fun touch127(mutate x: int) {
 @method_id(127)
 fun test127() {
     g127 = (1, 2);
-    touch127(mutate (g127.0, getShape127().0).0);
+    getShape127();
+    touch127(mutate g127.0);
     var a = 3;
-    touch127(mutate (getShape127().0, a).1);
+    getShape127();
+    touch127(mutate a);
     return (g127, a);
 }
 

--- a/tolk-tester/tests/invalid-declaration/err-1579.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1579.tolk
@@ -1,0 +1,21 @@
+type P2 = (int, int)
+type P4 = (P2, P2)
+type P8 = (P4, P4)
+type P16 = (P8, P8)
+type P32 = (P16, P16)
+type P64 = (P32, P32)
+type P128 = (P64, P64)
+type P256 = (P128, P128)
+
+fun main(flag: bool, t: P256): int {
+    return t.1.1.1.1.1.1.1.1;
+}
+
+/**
+@compilation_should_fail
+@stderr generated TVM stack is too deep while compiling function `main`
+@stderr TVM can not store more than 255 elements on the stack
+@stderr hint: try splitting very wide tensors/structs, storing parts in cells/tuples
+@stderr in function `main`
+@stderr              ^^^^
+ */

--- a/tolk-tester/tests/invalid-declaration/err-1588.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1588.tolk
@@ -1,0 +1,18 @@
+struct A<T> {
+    b: B<T>
+}
+
+struct B<T> {
+    a: A<T>
+}
+
+type X = A<int>
+
+fun main(): int {
+    return 0;
+}
+
+/**
+@compilation_should_fail
+@stderr size is infinity due to recursive fields
+ */

--- a/tolk-tester/tests/invalid-declaration/err-1982.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1982.tolk
@@ -1,0 +1,14 @@
+contract C {
+    storage: Box
+}
+
+struct Box<T = Box> {}
+
+fun main(): int {
+    return 0;
+}
+
+/**
+@compilation_should_fail
+@stderr type `Box` circularly references itself
+ */

--- a/tolk-tester/tests/invalid-declaration/err-1983.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1983.tolk
@@ -1,0 +1,10 @@
+fun main(arg: Box): int {
+    return 0;
+}
+
+struct Box<T = Box> {}
+
+/**
+@compilation_should_fail
+@stderr type `Box` circularly references itself
+ */

--- a/tolk-tester/tests/invalid-semantics/err-4952.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-4952.tolk
@@ -1,0 +1,24 @@
+struct Box<T> {
+    value: T;
+}
+
+type Tagged<T> = Box<T>
+
+fun makeTagged(): Tagged<uint8> | uint8 {
+    val tagged: Tagged<uint8> = { value: 1 };
+    return tagged;
+}
+
+fun main() {
+    var x: Tagged<uint8> | uint8 = makeTagged();
+    match (x) {
+        Tagged => {}
+        uint8 => {}
+    }
+}
+
+/**
+@compilation_should_fail
+@stderr can not deduce type arguments for `Tagged<T>`, provide them manually
+@stderr Tagged => {}
+ */

--- a/tolk-tester/tests/invalid-semantics/err-borrow-checker.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-borrow-checker.tolk
@@ -151,7 +151,7 @@ fun errCantBorrowInVeryComplex() {
     xy5.0.add(([xy5.1] = [xy5.0]).0);                      // ok
 
     var eqVoid = eq<void>;
-    eqVoid(xy5.0.add(([xy5.1, (xy5.0.add(1), xy5.0).1] = [0, 0]).0));
+    eqVoid(xy5.0.add(([xy5.1, xy5.0] = [0, 0]).0));
 }
 
 
@@ -188,7 +188,7 @@ fun (int, int).increment(mutate self) {
     self.1 += 1;
 }
 
-// @stderr can not borrow `x33` for mutation once again, it is already being mutated by `(int, int).increment`
+// @stderr can not mutate a temporary expression
 fun errCantBorrowViaTensorIndex() {
     var x33 = 0;
     ((x33, x33).0, (x33, x33).1).increment();

--- a/tolk-tester/tests/invalid-semantics/err-invalid-lvalue.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-invalid-lvalue.tolk
@@ -16,6 +16,13 @@ fun errAsOperatorAsLvalue() {
     return (i, j);
 }
 
+// @stderr can not assign to a temporary expression
+fun errTensorLiteralIndexedAssign() {
+    var (a, b) = (0, 0);
+    (a, b).0 = 10;
+    return (a, b);
+}
+
 // @stderr `_` can't be used as a value; it's a placeholder for a left side of assignment
 // @stderr takeInt(_)
 fun errUnderscoreRValue() {

--- a/tolk-tester/tests/invalid-serialization/err-7315.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7315.tolk
@@ -1,0 +1,17 @@
+struct (0x11) A {
+    x: int8
+}
+
+fun main(s: slice): int {
+    val a = lazy A.fromSlice(s);
+    match (a) {
+        A => { }
+        else => { return 0 }
+    }
+    return a.x;
+}
+
+/**
+@compilation_should_fail
+@stderr `lazy` will not work here, because variable `a` is used both for lazy matching and in a non-lazy manner
+ */

--- a/tolk-tester/tests/invalid-serialization/err-7316.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7316.tolk
@@ -1,0 +1,17 @@
+struct (0x11) A {
+    x: int8
+}
+
+fun main(s: slice): cell {
+    val a = lazy A.fromSlice(s);
+    match (a) {
+        A => { }
+        else => { return beginCell().endCell() }
+    }
+    return a.toCell();
+}
+
+/**
+@compilation_should_fail
+@stderr `lazy` will not work here, because variable `a` is used both for lazy matching and in a non-lazy manner
+ */

--- a/tolk-tester/tests/invalid-serialization/err-7317.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7317.tolk
@@ -1,0 +1,23 @@
+struct (0x1) A {}
+struct B {}
+struct C {}
+
+type Msg = A | B | C
+
+fun loadMsg(): Msg {
+    return A.fromSlice(createEmptySlice());
+}
+
+fun main(): int {
+    val msg = lazy loadMsg();
+    return match (msg) {
+        A => 1,
+        B => 2,
+        C => 3,
+    };
+}
+
+/**
+@compilation_should_fail
+@stderr `lazy` operator can only be used with built-in functions like fromCell/fromSlice or simple wrappers over them
+ */

--- a/tolk-tester/tests/invalid-serialization/err-7735.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7735.tolk
@@ -1,0 +1,25 @@
+struct Left {}
+struct Right {}
+
+type A<T> = Left | Right
+type B<T> = A<T>
+
+fun A<T>.packToBuilder(self, mutate b: builder) {
+}
+
+fun A<T>.unpackFromSlice(mutate s: slice): A<T> {
+    return Left {}
+}
+
+fun main(s: slice) {
+    val u = lazy B<int>.fromSlice(s);
+    match (u) {
+        Left => {}
+        Right => {}
+    }
+}
+
+/**
+@compilation_should_fail
+@stderr `lazy` is not applicable to `B<int>`, because it overrides packToBuilder/unpackFromSlice
+ */

--- a/tolk-tester/tests/invalid-serialization/err-7931.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7931.tolk
@@ -1,0 +1,28 @@
+struct (0x01) A {
+    x: uint8
+}
+
+struct (0x02) B {
+    y: uint8
+}
+
+fun A.packToBuilder(self, mutate b: builder) {
+    b.storeUint(self.x, 8);
+}
+
+fun A.unpackFromSlice(mutate s: slice): A {
+    return A {x: s.loadUint(8)};
+}
+
+type U = A | B
+
+fun f(u: U) {
+    u.toCell();
+}
+
+/**
+@compilation_should_fail
+@stderr auto-serialization via toCell() is not available for type `U`
+@stderr because alias `U` expands to `A | B`
+@stderr because could not automatically generate serialization prefixes for a union
+ */

--- a/tolk-tester/tests/invalid-typing/err-6274.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6274.tolk
@@ -1,5 +1,5 @@
 type MInt = int;
-type MInt2 = MInt | int;
+type MInt2 = MInt | MInt;
 type MSlice = slice;
 type MCell = cell;
 type MBuilder = builder;

--- a/tolk-tester/tests/invalid-typing/err-6520.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6520.tolk
@@ -1,0 +1,9 @@
+type UserId = int
+type OwnerId = int
+
+fun main(x: UserId | OwnerId) {}
+
+/**
+@compilation_should_fail
+@stderr union variants `UserId` and `OwnerId` have the same runtime representation
+ */

--- a/tolk-tester/tests/invalid-typing/err-6521.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6521.tolk
@@ -1,0 +1,12 @@
+type AliasToInt = int
+
+struct Wrapper<T> {
+    item: T | int
+}
+
+fun main(w: Wrapper<AliasToInt>) {}
+
+/**
+@compilation_should_fail
+@stderr union variants `AliasToInt` and `int` have the same runtime representation
+ */

--- a/tolk-tester/tests/invalid-typing/err-6522.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6522.tolk
@@ -1,0 +1,13 @@
+type AliasToInt = int
+type AliasToString = string
+
+type AIntOrString = AliasToInt | AliasToString
+
+struct D {
+    f: AIntOrString | int
+}
+
+/**
+@compilation_should_fail
+@stderr union variants `AliasToInt` and `int` have the same runtime representation
+ */

--- a/tolk-tester/tests/invalid-typing/err-6523.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6523.tolk
@@ -1,0 +1,14 @@
+type AliasToInt = int
+
+struct Wrapper<T> {
+    item: T
+}
+
+fun main(x: Wrapper<AliasToInt>) {
+    x is Wrapper<AliasToInt> | Wrapper<int>;
+}
+
+/**
+@compilation_should_fail
+@stderr union variants `Wrapper<AliasToInt>` and `Wrapper<int>` have the same runtime representation
+ */

--- a/tolk-tester/tests/invalid-typing/err-6524.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6524.tolk
@@ -1,0 +1,12 @@
+struct Wrapper<T> {
+    item: T
+}
+
+fun main(x: Wrapper<int | builder>) {
+    x as Wrapper<int | builder> | Wrapper<builder | int>;
+}
+
+/**
+@compilation_should_fail
+@stderr union variants `Wrapper<int | builder>` and `Wrapper<builder | int>` have the same runtime representation
+ */

--- a/tolk-tester/tests/invalid-typing/err-6525.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6525.tolk
@@ -1,0 +1,11 @@
+type UserId = int32
+type OwnerId = int32
+
+fun main(c: bool, u: UserId, o: OwnerId): UserId | builder | slice {
+    return c ? (u as UserId | builder) : (o as OwnerId | slice);
+}
+
+/**
+@compilation_should_fail
+@stderr can not convert type `OwnerId | slice` to ternary result type `UserId | builder | slice`
+ */

--- a/tolk-tester/tests/invalid-typing/err-6526.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6526.tolk
@@ -1,0 +1,14 @@
+type UserId = int32
+type OwnerId = int32
+
+fun main(c: bool, u: UserId, o: OwnerId): UserId {
+    return match (c) {
+        true => u,
+        false => o
+    };
+}
+
+/**
+@compilation_should_fail
+@stderr can not convert type `OwnerId` to match result type `UserId`
+ */

--- a/tolk-tester/tests/invalid-typing/err-mixed-3.tolk
+++ b/tolk-tester/tests/invalid-typing/err-mixed-3.tolk
@@ -21,3 +21,19 @@ enum Color { Red, Green, Blue }
 fun sumEnum() {
     return 1 + Color.Blue;
 }
+
+fun int.increment(mutate self) {
+    self += 1;
+}
+
+// @stderr can not mutate a temporary expression
+fun cantMutateTensorElem(a: int, b: int) {
+    (a, b).0.increment();
+}
+
+type MInt = int
+type Pair2_v1 = | (int, int)
+type Pair2_v2 = (MInt, MInt)
+
+// @stderr can not convert type `Pair2_v2` to ternary result type `Pair2_v1`
+const INVALID_TERNARY = 10>3 ? (1, 2) as Pair2_v1 : (1, 2) as Pair2_v2

--- a/tolk-tester/tests/lambdas-tests.tolk
+++ b/tolk-tester/tests/lambdas-tests.tolk
@@ -352,6 +352,28 @@ fun test23() {
     return (genericLambdaReuseT(123), genericLambdaReuseT(true));
 }
 
+@method_id(124)
+fun test24(n: int): (int, int) {
+    var x = 5;
+    repeat (n) {
+        x = 7;
+    }
+    return (x, 7);
+}
+
+@method_id(125)
+fun test25(n: int): (int, int) {
+    var x = 5;
+    repeat (n) {
+        x = 7;
+    }
+    val y = 7;
+    val f = fun() {
+        return y;
+    };
+    return (x, f());
+}
+
 
 fun main() {
     __expect_type(fun() {}, "() -> void");
@@ -387,4 +409,8 @@ fun main() {
 @testcase | 121 |        | 50
 @testcase | 122 |        | 1 2 3
 @testcase | 123 |        | 123 -1
+@testcase | 124 | 0      | 5 7
+@testcase | 124 | 1      | 7 7
+@testcase | 125 | 0      | 5 7
+@testcase | 125 | 1      | 7 7
 */

--- a/tolk-tester/tests/lazy-algo-tests.tolk
+++ b/tolk-tester/tests/lazy-algo-tests.tolk
@@ -4,6 +4,14 @@ struct A { a1: int7; a2: int8; a3: int8; }
 struct B { b1: int7; b2: int8; b3: int8; }
 type AOrB = A | B;
 
+@inline
+fun AOrB.getSecondField(self): int8 {
+    return match (self) {
+        A => self.a2,
+        B => self.b2,
+    };
+}
+
 @noinline
 fun A.getA1(self) {
     return self.a1;
@@ -1559,6 +1567,12 @@ fun algo316() {
     val o2 = lazy HasStrings.fromSlice(S0);
     __expect_lazy("[o2] skip (string), load s2");
     o2.s2.beginParse();
+}
+
+fun algo317(s: slice): int8 {
+    val a = lazy A.fromSlice(s);
+    __expect_lazy("[a] load a1 a2 a3");
+    return a.getSecondField();
 }
 
 

--- a/tolk-tester/tests/lazy-load-tests.tolk
+++ b/tolk-tester/tests/lazy-load-tests.tolk
@@ -1594,6 +1594,24 @@ fun demo317() {
     );
 }
 
+struct LazyAssignTrio {
+    a: uint8
+    b: uint8
+    c: uint8
+}
+
+fun LazyAssignTrio.hashInline(self): int {
+    __expect_inline(true);
+    return self.toCell().hash();
+}
+
+@method_id(318)
+fun demo318() {
+    var st = lazy LazyAssignTrio.fromSlice("010203".hexToSlice());
+    var other = lazy LazyAssignTrio.fromSlice("AABBCC".hexToSlice());
+    return (st = other).hashInline() == other.toCell().hash();
+}
+
 
 @method_id(400)
 fun demo400() {
@@ -2045,6 +2063,7 @@ fun main() {
 @testcase | 314 |                 | 11 20 [ 8 [ 8 8 ] ] [ 8 [ 11 20 ] ] 32 [ 8 [ 8 9 ] ]
 @testcase | 315 |                 | 8 8 66 44 [ [ (null) (null) 0 ] ]
 @testcase | 316 |                 | 2 3 99 7 3 99 100 2 100 99
+@testcase | 318 |                 | -1
 
 @testcase | 400 |                             | 5
 @testcase | 401 | x{0110} -1                  | 50

--- a/tolk-tester/tests/lists-tests.tolk
+++ b/tolk-tester/tests/lists-tests.tolk
@@ -387,6 +387,7 @@ fun test123() {
 
 const list1: lisp_list<int> = []
 const list2: lisp_list<int> = [1, 2]
+const nestedListUnion: lisp_list<lisp_list<int8> | int8> = [[1]]
 const list1Unknown: unknown = list1
 const list2Unknown: unknown = list2
 
@@ -400,6 +401,16 @@ fun test124() {
         list2Unknown,
         (list1 as unknown) == null,
     )
+}
+
+@method_id(125)
+fun test125() {
+    __expect_type(nestedListUnion, "lisp_list<lisp_list<int8> | int8>");
+    val head = nestedListUnion.getHead();
+    if (head is lisp_list<int8>) {
+        return (nestedListUnion.isEmpty(), head.getHead(), nestedListUnion.getTail().isEmpty());
+    }
+    throw 123;
 }
 
 
@@ -437,4 +448,5 @@ fun main() {
 @testcase | 122 |       | -1
 @testcase | 123 |       | -1 100 200 100 -1
 @testcase | 124 |       | (null) [ 1 [ 2 (null) ] ] (null) [ 1 [ 2 (null) ] ] -1
+@testcase | 125 |       | 0 1 -1
  */

--- a/tolk-tester/tests/logical-operators.tolk
+++ b/tolk-tester/tests/logical-operators.tolk
@@ -291,6 +291,19 @@ fun test125(c: bool): int {
     return x.0 + x.1 * 100;
 }
 
+fun failIfTrueKeepWithAsm(x: bool): bool
+    asm "DUP 9 THROWIF"
+
+@method_id(126)
+fun test126(x: int): int {
+    val b = x != 0;
+    try {
+        return failIfTrueKeepWithAsm(!b) as int;
+    } catch (exc) {
+        return 1000 + exc;
+    }
+}
+
 
 fun main() {
 
@@ -353,6 +366,7 @@ fun main() {
 @testcase | 124 | 0      | 2
 @testcase | 125 | -1     | 2010
 @testcase | 125 | 0      | 4030
+@testcase | 126 | 1      | 0
 
 @fif_codegen
 """

--- a/tolk-tester/tests/maps-tests.tolk
+++ b/tolk-tester/tests/maps-tests.tolk
@@ -68,6 +68,28 @@ struct LinkedMap {
     tree: map<int32, LinkedMap> = []
 }
 
+global gPackCalled: int;
+
+struct GenericValueInMap<T> {
+    value: T
+}
+
+fun GenericValueInMap<T>.packToBuilder(self, mutate b: builder) {
+    gPackCalled += 1;
+    b.storeUint(255, 8);
+    b.storeAny<T>(self.value);
+}
+
+fun GenericValueInMap<T>.unpackFromSlice(mutate s: slice): GenericValueInMap<T> {
+    gPackCalled += 10;
+    s.skipBits(8);
+    return { value: s.loadAny<T>() };
+}
+
+struct HolderWithGenericValueMap {
+    m: map<int32, GenericValueInMap<int8>>
+}
+
 fun LinkedMap.flattenValuesInto<T>(self, mutate out: array<T>): void {
     var i = 0;
     repeat (self.values.size()) {
@@ -633,6 +655,67 @@ fun test46() {
     return checkMapSetSnapshot(m, m.set(1, 42));
 }
 
+@method_id(147)
+fun test47() {
+    gPackCalled = 0;
+    var m = map<int32, GenericValueInMap<int8>> [];
+    m.set(1, { value: 42 });
+    return (HolderWithGenericValueMap { m }.toCell().beginParse().remainingBitsAndRefsCount(), m.mustGet(1).value, gPackCalled);
+}
+
+fun requireFound(r: MapLookupResult<int32>): void
+    asm "NIP 111 THROWIFNOT"
+
+@method_id(148)
+fun test48() {
+    var m = map<int32, int32> [];
+    try {
+        val r = m.get(7);
+        requireFound(r);
+        return 1;
+    } catch (ex, arg) {
+        return ex;
+    }
+}
+
+fun replaceWithAA(mutate b: builder): void
+    asm "DROP NEWC x{aa} STSLICECONST"
+
+struct MarkerWithCustomSerializer {}
+
+fun MarkerWithCustomSerializer.packToBuilder(self, mutate b: builder) {
+    replaceWithAA(mutate b);
+}
+
+fun MarkerWithCustomSerializer.unpackFromSlice(mutate s: slice): MarkerWithCustomSerializer {
+    s.skipBits(8);
+    return {};
+}
+
+@method_id(149)
+fun test49() {
+    var m = map<uint8, MarkerWithCustomSerializer> [];
+    try {
+        m.set(7, {});
+        return m.exists(7) as int;
+    } catch (errCode) {
+        return errCode;
+    }
+}
+
+@method_id(150)
+fun test50(x: int): int {
+    var d = createEmptyDict();
+    val valueBuilder = beginCell().storeUint(x, 16);
+    val key = 1;
+    val keepBuilder = beginCell().storeUint(0xaaaa, 16);
+    d.uDictSetBuilder(8, key, valueBuilder);
+
+    var (stored, found) = d.uDictGet(8, 1);
+    assert (found) throw 111;
+    var storedSlice = stored!;
+    return keepBuilder.endCell().beginParse().loadUint(16) + storedSlice.loadUint(16);
+}
 
 fun main() {
     __expect_type(createEmptyMap<int8, (int32, int64)>, "() -> map<int8, (int32, int64)>");
@@ -686,6 +769,10 @@ fun main() {
 @testcase | 144 |            | [ 1 2 3 4 5 6 7 ]
 @testcase | 145 |            | -1 1 8 1 3
 @testcase | 146 |            | 0 1
+@testcase | 147 |            | 1 1 42 11
+@testcase | 148 |            | 111
+@testcase | 149 |            | -1
+@testcase | 150 | 4660       | 48350
 
 @fif_codegen
 """

--- a/tolk-tester/tests/nullable-types.tolk
+++ b/tolk-tester/tests/nullable-types.tolk
@@ -5,6 +5,7 @@ fun getNullableIntNull(): int? asm "PUSHNULL";
 
 fun eqInt(x: int) { return x }
 fun eq<T>(x: T) { return x }
+fun isGt0(x: int): bool { return x > 0 }
 
 fun unwrap<T>(x: T?): T { return x!; }
 fun intOr0(x: int?): int { return null == x ? 0 : x!; }
@@ -104,10 +105,29 @@ fun test110() {
     var t : (int, Point?) = (0, {x: 10, y: 20});
     t.1!.y += 30;
     __expect_type(t.1, "Point?");
-    // this modifies `t.1`, not it's too hard for smart casts to follow, so `t.1` is left nullable
-    (t.1, 0).0 = {x: 100, y: 200};
+    t.1 = {x: 100, y: 200} as Point?;
     __expect_type(t.1, "Point?");
     return (t.1 == null, t.1);
+}
+
+@method_id(111)
+fun test111(x: int?): (bool, bool, bool, bool) {
+    return (
+        x! is int,
+        (x!) is int,
+        x !is int,
+        !isGt0(x!),
+    );
+}
+
+struct OnlyNullField {
+    marker: null
+}
+
+@method_id(112)
+fun test112(makeValue: bool) {
+    var value: OnlyNullField? = makeValue ? { marker: null } : null;
+    return (value, value == null);
 }
 
 fun main(x: int?, y: MIntN) {
@@ -130,4 +150,7 @@ fun main(x: int?, y: MIntN) {
 @testcase | 108 |     | 4
 @testcase | 109 |     | [ 3 4 ] 3 4
 @testcase | 110 |     | 0 100 200 typeid-1
+@testcase | 111 | 5   | -1 -1 0 0
+@testcase | 112 | 0   | (null) 0 -1
+@testcase | 112 | -1  | (null) typeid-2 0
  */

--- a/tolk-tester/tests/optimize-if-conditions.tolk
+++ b/tolk-tester/tests/optimize-if-conditions.tolk
@@ -331,6 +331,278 @@ fun test31TernaryZeroOnLeft(x: int, a: int, b: int): int {
     return (0 == x) ? a : b;
 }
 
+// --- 32. Do not fold through reassignment of the compared operand (`if`) ---
+
+@method_id(132)
+fun test32ReassignIf(x: int): int {
+    val c = x != 0;
+    x = 555;
+    if (c) { return 1; }
+    return 0;
+}
+
+// --- 33. Do not fold through reassignment of the compared operand (`?:`) ---
+
+@method_id(133)
+fun test33ReassignTernary(x: int, y: int, a: int, b: int): int {
+    val c = x == 0;
+    x = y;
+    return c ? a : b;
+}
+
+// --- 34. Do not fold through reassignment of the compared operand (`assert`) ---
+
+@method_id(134)
+fun test34ReassignAssert(x: int): int {
+    val c = x != 0;
+    x = 555;
+    try {
+        assert(c, 777);
+        return 1;
+    } catch {
+        return 0;
+    }
+}
+
+// --- 35. Same guard when the reassignment reads a global ---
+
+@method_id(135)
+fun test35ReassignFromGlobal(x: int): int {
+    gG = 777;
+    val c = x != 0;
+    x = gG;
+    if (c) { return 1; }
+    return 0;
+}
+
+// --- 36. Same guard when the reassignment is inside a nested block ---
+
+@method_id(136)
+fun test36ReassignInNestedIf(x: int, rewrite: int): int {
+    val c = x != 0;
+    if (rewrite != 0) {
+        x = 0;
+    }
+    if (c) { return 1; }
+    return 0;
+}
+
+// --- 37. PoC variant: ternary with `!= 0` and constant reassignment ---
+
+@method_id(137)
+fun test37ReassignTernaryNeqConst(x: int): int {
+    val c = x != 0;
+    x = 999;
+    return c ? 100 : 200;
+}
+
+// --- 38. PoC variant: assert with `== 0` and constant reassignment ---
+
+@method_id(138)
+fun test38ReassignAssertEqConst(x: int): int {
+    val c = x == 0;
+    x = 1;
+    assert(c, 42);
+    return 7;
+}
+
+// --- 39. PoC variant: assert with `== 0` and runtime reassignment ---
+
+@method_id(139)
+fun test39ReassignAssertEqRuntime(x: int, y: int): int {
+    val c = x == 0;
+    x = y;
+    assert(c, 999);
+    return 7;
+}
+
+// --- 40. PoC variant: reassignment from a global without a preceding write ---
+
+@method_id(140)
+fun test40ReassignFromGlobalNoWrite(x: int): int {
+    val c = x != 0;
+    x = gG;
+    if (c) { return 1; }
+    return 0;
+}
+
+// --- 41. `match (x) { 0 => ... }` lowers to `x == 0` and must be optimized ---
+
+@method_id(141)
+fun test41MatchZero(x: int): int {
+    return match (x) {
+        0 => 10,
+        else => 20,
+    };
+}
+
+// --- 42. A `match (x) { 0 => ... }` reassignment must not affect an earlier cond-var ---
+
+@method_id(142)
+fun test42MatchZeroReassignBeforeUse(x: int): int {
+    val wasZero = x == 0;
+    x = match (x) {
+        0 => 1,
+        else => 0,
+    };
+    if (wasZero) { return 10 + x; }
+    return 20 + x;
+}
+
+// --- 43. The cond-var (not the compared operand!) is conditionally rewritten inside a nested block ---
+
+@method_id(143)
+fun test43ReassignCondInNestedIf(x: int, flip: bool): int {
+    var cond = x != 0;
+    if (flip) {
+        cond = false;
+    }
+    if (cond) {
+        return 1;
+    }
+    return 2;
+}
+
+// --- 44. Same guard for ternaries (`__condsel` consumer) ---
+
+@method_id(144)
+fun test44ReassignCondInNestedTernary(x: int, flip: bool): int {
+    var cond = x != 0;
+    if (flip) {
+        cond = false;
+    }
+    return cond ? 1 : 2;
+}
+
+// --- 45. Rename-chain version: the consumer reads `b`, not `cond`, but `cond` is rewritten ---
+
+@method_id(145)
+fun test45ReassignCondViaRename(x: int, flip: bool): int {
+    var cond = x != 0;
+    if (flip) {
+        cond = false;
+    }
+    val b = cond;
+    if (b) {
+        return 1;
+    }
+    return 2;
+}
+
+// --- 46. Double-nested `== 0` in assert: `((x == 0) as int) == 0` ≡ `x != 0`.
+//        Each `_==_(...,0)` fold toggles `__throw_ifnot` <-> `__throw_if` ---
+
+@method_id(146)
+fun test46AssertDoubleNestedEq(x: int): int {
+    try {
+        assert(((x == 0) as int) == 0, 146);
+        return 1;
+    } catch (err) {
+        return err;
+    }
+}
+
+// --- 47. Triple-nested `== 0` in assert: three flips cancel to one ⇒ THROWIF.
+//        Semantically `assert(x == 0, N)`. ---
+
+@method_id(147)
+fun test47AssertTripleNestedEq(x: int): int {
+    try {
+        assert(((((x == 0) as int) == 0) as int) == 0, 147);
+        return 1;
+    } catch (err) {
+        return err;
+    }
+}
+
+// --- 48. Mixed `!=`-then-`==` in assert: outer `== 0` flips once,
+//        inner `!= 0` does not flip. Net: one flip ⇒ THROWIF. ---
+
+@method_id(148)
+fun test48AssertMixedNeqEq(x: int): int {
+    try {
+        assert(((x != 0) as int) == 0, 148);
+        return 1;
+    } catch (err) {
+        return err;
+    }
+}
+
+// --- 49. Same double-nested `== 0` pattern in a ternary; sanity / regression guard. ---
+
+@method_id(149)
+fun test49TernaryDoubleNestedEq(x: int, a: int, b: int): int {
+    return ((((x == 0) as int) == 0) ? a : b);
+}
+
+// --- 50. Self-referential `c = (c as int) != 0` ---
+
+@method_id(150)
+fun test50SelfRefIf(x: int): int {
+    var c = x != 0;
+    c = (c as int) != 0;
+    if (c) {
+        return 1;
+    }
+    return 0;
+}
+
+// --- 51. Ternary form of the same self-referential pattern. ---
+
+@method_id(151)
+fun test51SelfRefTernary(x: int): int {
+    var c = x != 0;
+    c = (c as int) != 0;
+    return c ? 11 : 22;
+}
+
+// --- 52. Assert form of the same self-referential pattern. ---
+
+@method_id(152)
+fun test52SelfRefAssert(x: int): int {
+    var c = x != 0;
+    c = (c as int) != 0;
+    try {
+        assert(c, 555);
+        return 1;
+    } catch (err) {
+        return err;
+    }
+}
+
+// --- 53. A long constant-condition chain delays exposing the `cond` rewrite ---
+
+fun test53_inner(x: int): int {
+    var gate = 0;
+    var cond = false;
+    if (true)        { gate = 1; } else { gate = 100; }
+    if (gate == 1)   { gate = 2; } else { gate = 100; }
+    if (gate == 2)   { gate = 3; } else { gate = 100; }
+    if (gate == 3)   { gate = 4; } else { gate = 100; }
+    if (gate == 4)   { gate = 5; } else { gate = 100; }
+    if (gate == 5)   { gate = 6; } else { gate = 100; }
+    if (gate == 6)   { gate = 7; } else { gate = 100; }
+    if (gate == 7)   { cond = x != 0; } else { cond = false; }
+    assert (cond) throw 123;
+    return x;
+}
+
+@method_id(153)
+fun test53LastIterAssertRewrite(x: int): int {
+    try {
+        return test53_inner(x);
+    } catch (err) {
+        return err;
+    }
+}
+
+// --- 54. `assert(!true, N)` is terminal just like `assert(false, N)`, `return` not needed ---
+
+@method_id(154)
+fun test54AssertNegatedConstFalse(): int {
+    assert(!true, 5);
+}
+
 fun main(): int {
     return 0;
 }
@@ -394,6 +666,62 @@ fun main(): int {
 @testcase | 130 |                 | 42
 @testcase | 131 | 0 9 7           | 9
 @testcase | 131 | 5 9 7           | 7
+@testcase | 132 | 0               | 0
+@testcase | 132 | 5               | 1
+@testcase | 133 | 0 777 10 20     | 10
+@testcase | 133 | 5 0 10 20       | 20
+@testcase | 134 | 0               | 0
+@testcase | 134 | 5               | 1
+@testcase | 135 | 0               | 0
+@testcase | 135 | 5               | 1
+@testcase | 136 | 5 1             | 1
+@testcase | 136 | 0 0             | 0
+@testcase | 137 | 0               | 200
+@testcase | 137 | 5               | 100
+@testcase | 138 | 0               | 7
+@testcase | 139 | 0 5             | 7
+@testcase | 140 | 0               | 0
+@testcase | 140 | 5               | 1
+@testcase | 141 | 0               | 10
+@testcase | 141 | 5               | 20
+@testcase | 142 | 0               | 11
+@testcase | 142 | 5               | 20
+@testcase | 143 | 5 -1            | 2
+@testcase | 143 | 5 0             | 1
+@testcase | 143 | 0 -1            | 2
+@testcase | 143 | 0 0             | 2
+@testcase | 144 | 5 -1            | 2
+@testcase | 144 | 5 0             | 1
+@testcase | 144 | 0 -1            | 2
+@testcase | 144 | 0 0             | 2
+@testcase | 145 | 5 -1            | 2
+@testcase | 145 | 5 0             | 1
+@testcase | 145 | 0 -1            | 2
+@testcase | 145 | 0 0             | 2
+@testcase | 146 | 0               | 146
+@testcase | 146 | 5               | 1
+@testcase | 146 | -3              | 1
+@testcase | 147 | 0               | 1
+@testcase | 147 | 5               | 147
+@testcase | 147 | -3              | 147
+@testcase | 148 | 0               | 1
+@testcase | 148 | 5               | 148
+@testcase | 148 | -3              | 148
+@testcase | 149 | 0 11 22         | 22
+@testcase | 149 | 5 11 22         | 11
+@testcase | 149 | -3 11 22        | 11
+@testcase | 150 | 0               | 0
+@testcase | 150 | 5               | 1
+@testcase | 150 | -3              | 1
+@testcase | 151 | 0               | 22
+@testcase | 151 | 5               | 11
+@testcase | 151 | -3              | 11
+@testcase | 152 | 0               | 555
+@testcase | 152 | 5               | 1
+@testcase | 152 | -3              | 1
+@testcase | 153 | 0               | 123
+@testcase | 153 | 5               | 5
+@testcase | 153 | -3              | -3
 
 @fif_codegen
 """
@@ -627,5 +955,88 @@ test30AssertConstTrue() PROC:<{
 test31TernaryZeroOnLeft() PROC:<{
     SWAP
     CONDSEL
+"""
+
+@fif_codegen
+"""
+test41MatchZero() PROC:<{
+    IF:<{
+      20 PUSHINT
+    }>ELSE<{
+      10 PUSHINT
+"""
+
+@fif_codegen
+"""
+test42MatchZeroReassignBeforeUse() PROC:<{
+    DUP
+    0 EQINT
+    SWAP
+    IF:<{
+      0 PUSHINT
+    }>ELSE<{
+      1 PUSHINT
+    }>
+    SWAP
+    IFJMP:<{
+      10 ADDCONST
+"""
+
+@fif_codegen
+"""
+test45ReassignCondViaRename() PROC:<{
+    SWAP
+    0 NEQINT
+    SWAP
+    IF:<{
+      DROP
+      FALSE
+    }>
+    IFJMP:<{
+      1 PUSHINT
+    }>
+    2 PUSHINT
+"""
+
+@fif_codegen
+"""
+    CONT:<{
+      146 THROWIFNOT
+"""
+
+@fif_codegen
+"""
+    CONT:<{
+      147 THROWIF
+"""
+
+@fif_codegen
+"""
+    CONT:<{
+      148 THROWIF
+"""
+
+@fif_codegen
+"""
+test49TernaryDoubleNestedEq() PROC:<{
+    CONDSEL
+"""
+
+@fif_codegen
+"""
+test50SelfRefIf() PROC:<{
+    0 NEQINT
+    0 NEQINT
+    IFJMP:<{
+      1 PUSHINT
+    }>
+    0 PUSHINT
+"""
+
+@fif_codegen
+"""
+test54AssertNegatedConstFalse() PROC:<{
+    5 THROW
+}>
 """
 */

--- a/tolk-tester/tests/overloads-tests.tolk
+++ b/tolk-tester/tests/overloads-tests.tolk
@@ -255,6 +255,9 @@ fun map<int8, V>.mySize(self): int3 { return 0 }
 fun map<int8, map<K, V>>.mySize(self): int4 { return 0 }
 fun map<int8, map<int16, V>>.mySize(self): int5 { return 0 }
 
+fun map<K, V|slice>.whichSlice(self): int2 { return 0 }
+fun map<K, slice>.whichSlice(self): int3 { return 0 }
+
 type MInt16 = int16
 type MInt16ov = MInt16
 type MMap32 = map<int32, map<bool, varint16>>
@@ -266,6 +269,7 @@ fun test14(
     m6: map<int8, map<int8,int8>?>, 
     m7: map<int8, bool|cell>, m8: map<MInt16, ()|cell|Point>,
     m9: map<address, address>,
+    m10: map<int8, slice>,
 ) {
     __expect_type(m1.mySize(), "int5");
     __expect_type(m2.mySize(), "int5");
@@ -276,6 +280,7 @@ fun test14(
     __expect_type(m7.mySize(), "int2");
     __expect_type(m8.mySize(), "int2");
     __expect_type(m9.mySize(), "int1");
+    __expect_type(m10.whichSlice(), "int3");
 }
 
 type ArrAlias<T> = array<T>

--- a/tolk-tester/tests/struct-tests.tolk
+++ b/tolk-tester/tests/struct-tests.tolk
@@ -356,7 +356,7 @@ fun test23(p: Point) {
 }
 
 @method_id(124)
-fun test24(x: JustInt | JustIntAlias2 | JustIntAlias): JustInt {
+fun test24(x: JustIntAlias2): JustInt {
     return match (x) {
         JustIntAlias => x
     };

--- a/tolk-tester/tests/ternary-tests.tolk
+++ b/tolk-tester/tests/ternary-tests.tolk
@@ -93,6 +93,16 @@ fun test111(g: bool) {
     return g ? (1, 2) : (3, 4);
 }
 
+fun fail112(): never {
+    throw 123;
+}
+
+@method_id(112)
+fun test112(flag: bool) {
+    var (_, _) = flag ? (1, 2) : fail112();
+    var (a, _) = flag ? (3, 4) : fail112();
+    return (112, a);
+}
 
 @method_id(200)
 fun test200(x: int) {
@@ -208,6 +218,7 @@ fun main() {}
 @testcase | 110 | -5      | 7
 @testcase | 111 | -1      | 1 2
 @testcase | 111 | 0       | 3 4
+@testcase | 112 | -1      | 112 3
 
 @testcase | 200 | 20      | 200
 @testcase | 201 | 5       | 5

--- a/tolk-tester/tests/type-aliases-tests.tolk
+++ b/tolk-tester/tests/type-aliases-tests.tolk
@@ -10,6 +10,8 @@ type MBool = | bool
 type Tuple2Int = [int, int]
 type UserId = int
 type OwnerId = int
+type FlagA = bool
+type FlagB = bool
 
 struct Point { x: int; y: int }
 type PointAlias = Point;
@@ -39,12 +41,12 @@ fun test1(x: MInt): MVoid {
     __expect_type(rand() != 0 ? (1, 2) as Pair2_v1 : (1, 2), "Pair2_v1");
     __expect_type(rand() != 0 ? (1, 2) as Pair2_v2 : (1, 2) as Pair2_v2, "Pair2_v2");
 
-    // since `Pair2_v1` and `Pair2_v2` underlying type is equal, a union of them can't be created
-    var d1 = (1, 2) as Pair2_v1 | Pair2_v2;
-    var d2 = (1, 2) as Pair2_v2 | Pair2_v1;
+    // exact duplicates collapsed
+    var d1 = (1, 2) as Pair2_v1 | Pair2_v1;
+    var d2 = (1, 2) as Pair2_v2 | Pair2_v2;
     __expect_type(d1, "Pair2_v1");
     __expect_type(d2, "Pair2_v2");
-    __expect_type(rand() != 0 ? (1, 2) as Pair2_v1 : (1, 2) as Pair2_v2, "Pair2_v1");
+    __expect_type(rand() != 0 ? (1, 2) as Pair2_v1 : ((1, 2) as Pair2_v2) as Pair2_v1, "Pair2_v1");
 
     __expect_type(x == 0, "bool");
 
@@ -334,43 +336,6 @@ fun test15() {
     )
 }
 
-type StrangeUnionInt = int | UserId
-type StrangeUnionInt2 = UserId | OwnerId
-
-struct ManyUnionFields {
-    f1: int | UserId
-    f2: StrangeUnionInt
-    f3: UserId | OwnerId
-    f4: OwnerId | UserId
-    f5: int | StrangeUnionInt2
-    f6: StrangeUnionInt2
-
-    f10: slice | int | UserId
-    f11: slice | UserId | int
-    f12: OwnerId | () | int | UserId | slice
-    f13: OwnerId | cell | StrangeUnionInt2?
-}
-
-fun test16(a: ManyUnionFields) {
-    __expect_type(a.f1, "int");
-    __expect_type(a.f2, "StrangeUnionInt");
-    __expect_type(a.f3, "UserId");
-    __expect_type(a.f5, "int");
-    __expect_type(a.f6, "StrangeUnionInt2");
-    a.f1 + a.f2 + a.f3 + a.f4 + a.f5 + a.f6;
-
-    __expect_type(a.f10, "slice | int");
-    __expect_type(a.f11, "slice | UserId");
-    __expect_type(a.f12, "OwnerId | () | slice");
-    __expect_type(a.f13, "OwnerId | cell | null");
-
-    match (a.f13) {
-        int => {}
-        cell => {}
-        null => {}
-    }
-}
-
 type SnakedCell<T> = cell
 
 fun test17(a: SnakedCell<int>, b: SnakedCell<MInt>, c: SnakedCell<MInt_v2>) {
@@ -502,6 +467,110 @@ get fun myAddress(): MyAddress? {
     return null
 }
 
+struct Raw {
+    x: int
+}
+
+type AliasRawOverrides = Raw
+
+fun AliasRawOverrides.packToBuilder(self, mutate b: builder) {
+    b.storeInt(self.x, 8);
+}
+
+fun AliasRawOverrides.unpackFromSlice(mutate s: slice): AliasRawOverrides {
+    return {x: s.loadInt(8)};
+}
+
+type AliasAliasRaw = AliasRawOverrides
+
+@method_id(122)
+fun test22() {
+    val w: AliasAliasRaw = {x: -7};
+    val c = w.toCell();
+    val decoded = AliasAliasRaw.fromSlice(c.beginParse());
+    return (c.beginParse().remainingBitsCount(), decoded.x);
+}
+
+type AliasAliasRawOverrides = AliasRawOverrides
+
+fun AliasAliasRawOverrides.packToBuilder(self, mutate b: builder) {
+    b.storeInt(self.x, 16);
+}
+
+fun AliasAliasRawOverrides.unpackFromSlice(mutate s: slice): AliasAliasRawOverrides {
+    return {x: s.loadInt(16)};
+}
+
+@method_id(123)
+fun test23() {
+    val e: AliasRawOverrides = {x: 7};
+    val ec = e.toCell();
+    val w: AliasAliasRawOverrides = {x: 4660};
+    val wc = w.toCell();
+    return (
+        ec.beginParse().remainingBitsCount(), AliasRawOverrides.fromSlice(ec.beginParse()).x,
+        wc.beginParse().remainingBitsCount(), AliasAliasRawOverrides.fromSlice(wc.beginParse()).x,
+    );
+}
+
+struct (0xAA) RawPrefixedA {
+    x: uint8
+}
+
+struct (0xBB) RawPrefixedB {
+    y: uint8
+}
+
+type WireA = RawPrefixedA
+type WireB = RawPrefixedB
+type WireUnion = WireA | WireB      // encoded as 0+packA / 1+packB (not struct prefixes)
+
+fun WireA.packToBuilder(self, mutate b: builder) {
+    b.storeUint(self.x, 8);
+}
+
+fun WireA.unpackFromSlice(mutate s: slice): WireA {
+    return RawPrefixedA {x: s.loadUint(8)};
+}
+
+fun WireB.packToBuilder(self, mutate b: builder) {
+    b.storeUint(self.y, 8);
+}
+
+fun WireB.unpackFromSlice(mutate s: slice): WireB {
+    return RawPrefixedB {y: s.loadUint(8)};
+}
+
+@method_id(124)
+fun test24() {
+    val a: WireA = RawPrefixedA {x: 7};
+    val u: WireUnion = a as WireUnion;
+    val unionSlice = u.toCell().beginParse();
+    val expected = beginCell().storeUint(0, 1).storeUint(7, 8).endCell();
+    val decodedUnion = WireUnion.fromCell(expected);
+    return (
+        a.toCell().beginParse().remainingBitsCount(),
+        unionSlice.remainingBitsCount(),
+        unionSlice.preloadUint(8),
+        unionSlice.bitsEqual(expected.beginParse()),
+        match (decodedUnion) {
+            WireA => decodedUnion.x as int,
+            WireB => decodedUnion.y + 100,
+        },
+    );
+}
+
+@method_id(125)
+fun test25(x: FlagA) {
+    return (
+        ((!!x) is FlagB) as int,
+        ((x == true) is FlagB) as int,
+        ((x == false) is FlagB) as int,
+        ((x != false) is FlagB) as int,
+        ((!!x) is FlagA) == ((!!x) is FlagB),
+    );
+}
+
 fun main(x: MInt, y: MInt?) {
     return y == null ? x : x + y;
 }
@@ -517,6 +586,10 @@ fun main(x: MInt, y: MInt?) {
 @testcase | 119 |     | 8 8 9
 @testcase | 120 |     | 16 8 10 10
 @testcase | 121 |     | 65535 0
+@testcase | 122 |     | 8 -7
+@testcase | 123 |     | 8 7 16 4660
+@testcase | 124 |     | 8 9 3 -1 7
+@testcase | 125 | 0   | -1 -1 -1 -1 -1
 
 @fif_codegen
 """

--- a/tolk-tester/tests/union-types-tests.tolk
+++ b/tolk-tester/tests/union-types-tests.tolk
@@ -24,12 +24,12 @@ fun testFlatten() {
     __expect_type(0 as (string | (string | (string | int) | (| cell | string?))), "string | int | cell | null");
 
     __expect_type(0 as (MInt | MNull), "MInt?");
-    __expect_type(0 as (MInt | slice | int), "MInt | slice");
+    __expect_type(0 as (MInt | slice | MInt), "MInt | slice");
     __expect_type(0 as (MIntN), "MIntN");
     __expect_type(0 as (MIntN | null), "int?");
     __expect_type(0 as (MIntN | MNull | MSlice), "int | null | MSlice");
     __expect_type(0 as (MIntN | MNull? | MSlice), "int | null | MSlice");
-    __expect_type(0 as (MInt | IntOrSliceOrBuilder | MSlice), "MInt | slice | builder");
+    __expect_type(0 as (MInt | builder | MSlice), "MInt | builder | MSlice");
     __expect_type((1, 2) as (Pair2 | Pair2Or3 | (slice, int?)), "Pair2 | (int, int, int) | (slice, int?)");
 
     __expect_type(0 as (int | int8), "int | int8");
@@ -112,8 +112,8 @@ fun test4() {
 
 @method_id(105)
 fun test5() {
-    var a: int | int | IntOrSlice = getIntOrSlice();
-    __expect_type(a, "int | slice");
+    var a: MInt | MInt | IntOrSlice = getIntOrSlice();
+    __expect_type(a, "MInt | slice");
     a = 5;
     return (a, a as IntOrSlice, a as IntOrSliceOrBuilder, a as MIntN);
 }

--- a/tolk-tester/tests/var-apply-tests.tolk
+++ b/tolk-tester/tests/var-apply-tests.tolk
@@ -381,6 +381,27 @@ fun testIndirectCalleeSnapshotBeforeArgs() {
     return (f(5), f(replaceWithAddTen122(mutate f)), f(5));
 }
 
+fun realFail123() {
+    throw 123;
+}
+
+@inline
+fun failViaCallable123() {
+    var f = realFail123;
+    return f();
+}
+
+@method_id(123)
+fun testIndirectNeverInTryCatch(): int {
+    var x: int;
+    try {
+        failViaCallable123();
+    } catch {
+        x = 2;
+    }
+    return x;
+}
+
 
 fun main() {}
 
@@ -414,4 +435,5 @@ fun main() {}
 @testcase | 120 |            | []
 @testcase | 121 |            | 100 [ 10 30 40 20 ]
 @testcase | 122 |            | 6 6 15
+@testcase | 123 |            | 2
  */

--- a/tolk/analyzer.cpp
+++ b/tolk/analyzer.cpp
@@ -1119,14 +1119,48 @@ static bool match_eq_neq_zero(const Op& op, bool& out_is_eq, int& out_zero_arg_i
 //   1. We see `_Let [t3] := t2` — single-slot rename, switch target to t2.
 //   2. We see `_Call [t2] := _==_(t1, 0)` — writes target and is not a `_Let`, so we return it.
 //
-// Returns nullptr if non-`_Let` writer of `target` not found.
-static Op* find_producer_in_list(OpList& list, int max_idx_exclusive, var_idx_t target) {
+struct ProducerLookupResult {
+  Op* op;
+  int idx;
+};
+
+static bool does_op_or_nested_blocks_write_var(const Op& op, var_idx_t target);
+
+static bool does_op_list_write_var(const OpList& list, var_idx_t target) {
+  for (const std::unique_ptr<Op>& op : list) {
+    if (does_op_or_nested_blocks_write_var(*op, target)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool does_op_or_nested_blocks_write_var(const Op& op, var_idx_t target) {
+  for (var_idx_t v : op.left) {
+    if (v == target) {
+      return true;
+    }
+  }
+  return does_op_list_write_var(op.block0, target) || does_op_list_write_var(op.block1, target);
+}
+
+// Walk `list` backwards, looking for the op that produced `target`.
+// Single-slot `_Let dst := src` ops are treated as renames (so the search continues with `target = src`).
+//
+// Returns `{op, i}` where `op` is the producing op (any non-`_Let` writer of `target`), `i` is its index in `list`.
+// Returns `{nullptr, -1}` in two cases:
+//   1. no writer of `target` is reachable
+//   2. `target` is conditionally rewritten inside the nested block of some intervening op,
+//      e.g. `var c = x != 0; if (flip) { c = false; } if (c) ...`.
+static ProducerLookupResult find_producer_in_list(OpList& list, int max_idx_exclusive, var_idx_t target) {
   for (int i = max_idx_exclusive - 1; i >= 0; --i) {
     Op* op = list[i].get();
     if (op->disabled()) {
       continue;
     }
 
+    // top-level write check (also handles `if`/`while` cond-var being read into `op.left`,
+    // but that's fine — we'd just stop the search, which is the safe direction)
     bool writes_target = false;
     for (var_idx_t v : op->left) {
       if (v == target) {
@@ -1134,6 +1168,12 @@ static Op* find_producer_in_list(OpList& list, int max_idx_exclusive, var_idx_t 
         break;
       }
     }
+
+    // nested-block write check
+    if (!writes_target && (does_op_list_write_var(op->block0, target) || does_op_list_write_var(op->block1, target))) {
+      return {nullptr, -1};
+    }
+
     if (!writes_target) {
       continue;
     }
@@ -1143,9 +1183,21 @@ static Op* find_producer_in_list(OpList& list, int max_idx_exclusive, var_idx_t 
       continue;
     }
 
-    return op;
+    return {op, i};
   }
-  return nullptr;
+  return {nullptr, -1};
+}
+
+// Guard for the `_==_` / `_!=_` to analyze that operand is NOT reassigned between the comparison and the consumer.
+// Our IR (Ops) is not SSA — `x = ...` reuses the same `var_idx_t`:
+// > val c = (x != 0); x = 555; if (c) { return 1; }
+static bool is_var_written_in_range(const OpList& list, int first_idx, int max_idx_exclusive, var_idx_t target) {
+  for (int i = first_idx; i < max_idx_exclusive; ++i) {
+    if (does_op_or_nested_blocks_write_var(*list[i], target)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Cheap "does this block end with a return?" check for `if (... == 0) return; else <big_block>` corner case.
@@ -1182,14 +1234,14 @@ static bool try_fold_condition(Op& cond_op, OpList& search_list, int search_max_
 
   while (true) {
     var_idx_t cond_var = cond_op.left[0];
-    Op* producer = find_producer_in_list(search_list, search_max_idx_exclusive, cond_var);
-    if (!producer) {
+    ProducerLookupResult producer = find_producer_in_list(search_list, search_max_idx_exclusive, cond_var);
+    if (!producer.op) {
       break;
     }
 
     bool is_eq = false;
     int zero_arg_idx = -1;
-    if (!match_eq_neq_zero(*producer, is_eq, zero_arg_idx)) {
+    if (!match_eq_neq_zero(*producer.op, is_eq, zero_arg_idx)) {
       break;
     }
     // for loops, the would-be branch swap would also flip "iterate"/"stop" — skip
@@ -1201,7 +1253,11 @@ static bool try_fold_condition(Op& cond_op, OpList& search_list, int search_max_
       break;
     }
 
-    var_idx_t inner_var = producer->right[1 - zero_arg_idx];
+    var_idx_t inner_var = producer.op->right[1 - zero_arg_idx];
+    if (is_var_written_in_range(search_list, producer.idx, search_max_idx_exclusive, inner_var)) {
+      break;
+    }
+
     cond_op.left[0] = inner_var;
     if (is_eq) {
       std::swap(cond_op.block0, cond_op.block1);
@@ -1270,18 +1326,22 @@ static bool try_fold_call_cond_arg(Op& call_op, OpList& search_list, int search_
 
   while (true) {
     var_idx_t cond_var = call_op.right[cond_arg_idx];
-    Op* producer = find_producer_in_list(search_list, search_max_idx_exclusive, cond_var);
-    if (!producer) {
+    ProducerLookupResult producer = find_producer_in_list(search_list, search_max_idx_exclusive, cond_var);
+    if (!producer.op) {
       break;
     }
 
     bool is_eq = false;
     int zero_arg_idx = -1;
-    if (!match_eq_neq_zero(*producer, is_eq, zero_arg_idx)) {
+    if (!match_eq_neq_zero(*producer.op, is_eq, zero_arg_idx)) {
       break;
     }
 
-    var_idx_t inner_var = producer->right[1 - zero_arg_idx];
+    var_idx_t inner_var = producer.op->right[1 - zero_arg_idx];
+    if (is_var_written_in_range(search_list, producer.idx, search_max_idx_exclusive, inner_var)) {
+      break;
+    }
+
     call_op.right[cond_arg_idx] = inner_var;
     if (is_eq) {
       if (swap_a >= 0 && swap_b >= 0) {
@@ -1290,6 +1350,7 @@ static bool try_fold_call_cond_arg(Op& call_op, OpList& search_list, int search_
       } else if (!flip_to.empty()) {
         // `__throw_if(code, cond)` <-> `__throw_ifnot(code, cond)`
         call_op.f_sym = lookup_function(flip_to);
+        flip_to = flip_to == "__throw_if" ? "__throw_ifnot" : "__throw_if";
       }
     }
     // important: `args` is cached, wipe it. `compute_used_vars` reads variable indices from `args`, not from `right`.

--- a/tolk/ast-from-tokens.cpp
+++ b/tolk/ast-from-tokens.cpp
@@ -189,9 +189,11 @@ static std::string parse_tok_string_const(std::string_view text, SrcRange cur_ra
   std::string unescaped;
   unescaped.reserve(text.size());
   for (size_t i = 0; i < text.size(); ++i) {
-    if (text[i] == '\r' && text[i + 1] == '\n') {   // normalize CRLF line endings to LF
+    if (text[i] == '\r') {   // normalize CR/CRLF line endings to LF
       unescaped += '\n';
-      ++i;
+      if (i + 1 < text.size() && text[i + 1] == '\n') {
+        i++;
+      }
       continue;
     }
     if (text[i] != '\\') {
@@ -210,6 +212,35 @@ static std::string parse_tok_string_const(std::string_view text, SrcRange cur_ra
     }
   }
   return unescaped;
+}
+
+// parse asm "HERE"; unlike regular strings, keep \n, \t, and other backslash sequences original
+static std::string parse_tok_asm_instruction(std::string_view text) {
+  int trim_n = text.starts_with(R"(""")") ? 3 : 1;
+  text = text.substr(trim_n, text.size() - 2 * trim_n);
+
+  std::string asm_str;
+  asm_str.reserve(text.size());
+  for (size_t i = 0; i < text.size(); ++i) {
+    if (text[i] == '\r') {   // normalize CR/CRLF line endings to LF
+      asm_str += '\n';
+      if (i + 1 < text.size() && text[i + 1] == '\n') {
+        i++;
+      }
+      continue;
+    }
+    if (text[i] != '\\') {
+      asm_str += text[i];
+      continue;
+    }
+    char after_slash = text[++i];
+    switch (after_slash) {
+      case '\'':
+      case '"':   asm_str += after_slash; break;
+      default:    asm_str += '\\'; asm_str += after_slash; break;
+    }
+  }
+  return asm_str;
 }
 
 // when we meet `(expr)` in parentheses, we keep `expr` in AST,
@@ -544,6 +575,9 @@ static AnyV parse_parameter(Lexer& lex, AnyTypeV self_type, bool in_lambda) {
   V<ast_identifier> v_ident = nullptr;
   bool is_self = false;
   if (lex.tok() == tok_identifier) {
+    if (lex.cur_str() == "self") {    // smb cheated "fun f(`self`: T)" in backticks
+      lex.error("`self` can not be used as a parameter name");
+    }
     v_ident = parse_identifier(lex, "parameter name");
   } else if (lex.tok() == tok_self) {
     if (!self_type) {
@@ -1294,19 +1328,14 @@ static AnyExprV parse_expr75(Lexer& lex) {
 static AnyExprV parse_expr40(Lexer& lex) {
   AnyExprV lhs = parse_expr75(lex);
   TokenType t = lex.tok();
-  while (t == tok_as || t == tok_is) {
+  while (t == tok_as || t == tok_is || t == tok_not_is) {
     lex.next();
     AnyTypeV rhs_type = parse_type_from_tokens(lex);
     SrcRange range = SrcRange::overlap(lhs->range, rhs_type->range);
     if (t == tok_as) {
       lhs = createV<ast_cast_as_operator>(range, lhs, rhs_type);
     } else {
-      // detect `a !is T`, which is parsed as `a! is T` (lhs = `a!`), don't confuse with `(a!) is T`
-      bool is_negated = lhs->kind == ast_not_null_operator && !lhs->was_parenthesized;
-      if (is_negated) {
-        lhs = lhs->as<ast_not_null_operator>()->get_expr();
-      }
-      lhs = createV<ast_is_type_operator>(range, lhs, rhs_type, is_negated);
+      lhs = createV<ast_is_type_operator>(range, lhs, rhs_type, t == tok_not_is);
     }
     t = lex.tok();
   }
@@ -1675,7 +1704,8 @@ static AnyV parse_asm_func_body(Lexer& lex, V<ast_identifier> name_ident, V<ast_
   std::vector<AnyV> asm_commands;
   lex.check(tok_string_const, "\"ASM COMMAND\"");
   while (lex.tok() == tok_string_const) {
-    auto v_asm_str = parse_expr100(lex)->as<ast_string_const>();
+    auto v_asm_str = createV<ast_string_const>(lex.cur_range(), parse_tok_asm_instruction(lex.cur_str()));
+    lex.next();
     if (v_asm_str->str_val.empty()) {
       err("invalid asm instruction").fire(v_asm_str);
     }

--- a/tolk/codegen.cpp
+++ b/tolk/codegen.cpp
@@ -819,6 +819,8 @@ bool Op::generate_code_step(Stack& stack, const OpList& parent_ops, size_t self_
           stack.mode |= Stack::_NeedRetAlt;
           block0.generate_code_all(stack);
           stack.enforce_state(layout1);
+          // repeat may execute zero times, so body constants are not valid after the loop
+          stack.forget_const();
         }
         stack.o << AsmOp::Custom(NULL_ORIGIN, "}>");
         return true;
@@ -921,6 +923,14 @@ bool Op::generate_code_step(Stack& stack, const OpList& parent_ops, size_t self_
       }
       if (block0.is_noreturn() || block1.is_noreturn()) {
         stack.o.retalt_ = true;
+      }
+      // For late-init variables alive at TRYCATCH entry but not yet on the stack:
+      // push NULL placeholders so falsely-fallthrough try stacks can still merge with catch.
+      for (const VarDescr& vd : var_info.list) {
+        if (!vd.is_unused() && stack.find(vd.idx) < 0) {
+          stack.o << AsmOp::Const(origin, "PUSHNULL");
+          stack.push_new_var(vd.idx);
+        }
       }
       Stack catch_stack{stack.o, stack.unique_constants, stack.named_vars, 0};
       std::vector<var_idx_t> catch_vars;

--- a/tolk/compilation-errors.h
+++ b/tolk/compilation-errors.h
@@ -105,6 +105,12 @@ struct Fatal final : std::exception {
   }
 };
 
+struct TooDeepStackFatal final : std::exception {
+  const char* what() const noexcept override {
+    return "too deep stack";
+  }
+};
+
 struct ThrownParseError final : std::exception {
   std::string in_function;
   SrcRange range;

--- a/tolk/constant-evaluator.cpp
+++ b/tolk/constant-evaluator.cpp
@@ -195,6 +195,10 @@ static ConstValExpression create_const_cast(ConstValExpression&& inner, TypePtr 
   if (already_int && cast_to == TypeDataInt::create()) {
     return inner;
   }
+  const ConstValAddress* already_address = std::get_if<ConstValAddress>(&inner);
+  if (already_address && cast_to == TypeDataAddress::internal()) {
+    return inner;
+  }
 
   // to store ConstValExpression inside (recursively), we need to place it into the heap;
   // the best way I've found is to create std::vector with a single element (std::unique_ptr doesn't work)
@@ -518,7 +522,7 @@ class ConstExpressionEvaluator {
     if (cast_to == TypeDataUnknown::create()) {   // `unknown` is forbidden in constants
       err("not a constant expression").fire(v);
     }
-    return create_const_cast(std::move(val), cast_to);
+    return create_const_cast_for_declared(std::move(val), v->get_expr()->inferred_type, cast_to);
   }
 
   // `ton("0.05")` and other compile-time functions
@@ -613,7 +617,7 @@ public:
       for (int i = 0; i < v_square->size(); ++i) {
         items.push_back(eval_any_v_or_fire(v_square->get_item(i)));
       }
-      return ConstValShapedTuple{std::move(items)};
+      return create_const_cast(ConstValShapedTuple{std::move(items)}, v_square->inferred_type);
     }
     if (auto v_object = v->try_as<ast_object_literal>()) {
       // we also support `const obj: SomeObject = { field: value, ... }`

--- a/tolk/lexer.cpp
+++ b/tolk/lexer.cpp
@@ -16,6 +16,7 @@
 */
 #include "lexer.h"
 #include "compilation-errors.h"
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 
@@ -38,6 +39,10 @@ template <class T>
 static T* singleton() {
   static T obj;
   return &obj;
+}
+
+static bool is_identifier_char(char c) {
+  return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '$';
 }
 
 // LexingTrie is a prefix tree storing all available Tolk language constructs.
@@ -357,6 +362,20 @@ struct ChunkSimpleToken final : ChunkLexerBase {
   }
 };
 
+// `!is` is a separate operator, but `!isSomething()` must remain `! isSomething()`.
+struct ChunkLogicalNotOrNotIs final : ChunkLexerBase {
+  bool parse(Lexer* lex) const override {
+    if (lex->char_at(1) == 'i' && lex->char_at(2) == 's' && !is_identifier_char(lex->char_at(3))) {
+      lex->add_token(tok_not_is, std::string_view(lex->c_str(), 3));
+      lex->skip_chars(3);
+    } else {
+      lex->add_token(tok_logical_not, std::string_view(lex->c_str(), 1));
+      lex->skip_chars(1);
+    }
+    return true;
+  }
+};
+
 // Spaces and other space-like symbols are just skipped.
 struct ChunkSkipWhitespace final : ChunkLexerBase {
   bool parse(Lexer* lex) const override {
@@ -459,8 +478,7 @@ struct ChunkIdentifierOrKeyword final : ChunkLexerBase {
     lex->skip_chars(1);
     while (!lex->is_eof()) {
       char c = lex->char_at();
-      bool allowed_in_identifier = std::isalnum(c) || c == '_' || c == '$';
-      if (!allowed_in_identifier) {
+      if (!is_identifier_char(c)) {
         break;
       }
       lex->skip_chars(1);
@@ -540,6 +558,7 @@ struct TolkLanguageGrammar {
     trie.add_pattern("[0-9]", singleton<ChunkNumber>());
     trie.add_pattern("[a-zA-Z_$]", singleton<ChunkIdentifierOrKeyword>());
     trie.add_prefix("`", singleton<ChunkIdentifierInBackticks>());
+    trie.add_prefix("!", singleton<ChunkLogicalNotOrNotIs>());
 
     register_token("+", 1, tok_plus);
     register_token("-", 1, tok_minus);
@@ -559,7 +578,6 @@ struct TolkLanguageGrammar {
     register_token("=", 1, tok_assign);
     register_token("<", 1, tok_lt);
     register_token(">", 1, tok_gt);
-    register_token("!", 1, tok_logical_not);
     register_token("&", 1, tok_bitwise_and);
     register_token("|", 1, tok_bitwise_or);
     register_token("^", 1, tok_bitwise_xor);

--- a/tolk/lexer.h
+++ b/tolk/lexer.h
@@ -126,6 +126,7 @@ enum TokenType {
   tok_double_arrow,
   tok_as,
   tok_is,
+  tok_not_is,
   tok_double_question,
 
   tok_tolk,

--- a/tolk/optimize.cpp
+++ b/tolk/optimize.cpp
@@ -16,6 +16,8 @@
 */
 #include "tolk.h"
 
+#include <cctype>
+
 namespace tolk {
 
 /*
@@ -23,6 +25,21 @@ namespace tolk {
  *   PEEPHOLE OPTIMIZER
  * 
  */
+
+// detect "8 STU" and "19 THROWIF", but skip "DUP 8 STU" and "SMTH 19 THROWIF" (that can come from `asm` functions)
+static bool is_single_arg_op_ending_with(std::string_view op, std::string_view suffix) {
+  if (!op.ends_with(suffix) || op.size() == suffix.size()) {
+    return false;
+  }
+
+  std::string_view prefix = op.substr(0, op.size() - suffix.size());
+  for (char c : prefix) {
+    if (std::isspace(static_cast<unsigned char>(c))) {
+      return false;
+    }
+  }
+  return true;
+}
 
 void Optimizer::unpack() {
   int len = static_cast<int>(asm_code.size());
@@ -89,7 +106,7 @@ bool Optimizer::find_const_op(int* op_idx, int cst) {
 // used for `T.fromSlice(s, {code:0xFFFF})`, where `tmp = 0xFFFF` + serialization match + `else throw tmp` is generated;
 // but since it's constant, it transforms to (unused 0xFFFF) + ... + else "65535 THROW", unwrapped here
 bool Optimizer::detect_rewrite_big_THROW() {
-  bool is_throw = op_[0]->is_custom() && op_[0]->op.ends_with(" THROW");
+  bool is_throw = is_single_arg_op_ending_with(op_[0]->op, " THROW");
   if (!is_throw) {
     return false;
   }
@@ -228,11 +245,12 @@ bool Optimizer::detect_rewrite_NEWC_PUSH_STUR() {
   if (!first_newc || pb_ < 3) {
     return false;
   }
-  bool next_push = op_[1]->is_const() && op_[1]->op.ends_with(" PUSHINT");  // actually there can be PUSHPOWDEC2, but ok
+  bool next_push = is_single_arg_op_ending_with(op_[1]->op, " PUSHINT");  // actually there can be PUSHPOWDEC2, but ok
   if (!next_push) {
     return false;
   }
-  bool next_stu_r = op_[2]->is_custom() && (op_[2]->op.ends_with(" STUR") || op_[2]->op.ends_with(" STIR"));
+  bool next_stu_r = is_single_arg_op_ending_with(op_[2]->op, " STUR") ||
+                    is_single_arg_op_ending_with(op_[2]->op, " STIR");
   if (!next_stu_r) {
     return false;
   }
@@ -260,7 +278,7 @@ bool Optimizer::detect_rewrite_LDxx_DROP() {
 
   std::string_view f = op_[0]->op;
   for (size_t i = 0; i < std::size(ends_with); ++i) {
-    if (f.ends_with(ends_with[i])) {
+    if (is_single_arg_op_ending_with(op_[0]->op, ends_with[i])) {
       p_ = 2;
       q_ = 1;
       oq_[0] = AsmOp::Custom(op_[0]->origin, op_[0]->op.substr(0, f.rfind(' ')) + repl_with[i], 0, 1);
@@ -305,11 +323,12 @@ bool Optimizer::detect_rewrite_SWAP_PUSH_STUR() {
   if (!first_swap || pb_ < 3) {
     return false;
   }
-  bool next_push = op_[1]->is_const() && op_[1]->op.ends_with(" PUSHINT");
+  bool next_push = is_single_arg_op_ending_with(op_[1]->op, " PUSHINT");
   if (!next_push) {
     return false;
   }
-  bool next_stu_r = op_[2]->is_custom() && (op_[2]->op.ends_with(" STUR") || op_[2]->op.ends_with(" STIR"));
+  bool next_stu_r = is_single_arg_op_ending_with(op_[2]->op, " STUR") ||
+                    is_single_arg_op_ending_with(op_[2]->op, " STIR");
   if (!next_stu_r) {
     return false;
   }
@@ -326,7 +345,7 @@ bool Optimizer::detect_rewrite_SWAP_PUSH_STUR() {
 // same for `STB` / `STREF` / `n STU` / `n STI`
 bool Optimizer::detect_rewrite_SWAP_STxxxR() {
   bool first_swap = op_[0]->is_swap();
-  if (!first_swap || pb_ < 2 || !op_[1]->is_custom()) {
+  if (!first_swap || pb_ < 2) {
     return false;
   }
 
@@ -337,7 +356,7 @@ bool Optimizer::detect_rewrite_SWAP_STxxxR() {
 
   std::string_view f = op_[1]->op;
   for (size_t i = 0; i < std::size(ends_with); ++i) {
-    if (f.ends_with(ends_with[i])) {
+    if (is_single_arg_op_ending_with(op_[1]->op, ends_with[i])) {
       p_ = 2;
       q_ = 1;
       oq_[0] = AsmOp::Custom(op_[1]->origin, op_[1]->op.substr(0, f.rfind(' ')) + repl_with[i], 1, 1);
@@ -361,7 +380,7 @@ bool Optimizer::detect_rewrite_SWAP_STxxxR() {
 // for logical negation `!boolVar`, a special fake `BOOLNOT` instruction was inserted
 bool Optimizer::detect_rewrite_BOOLNOT_THROWIF() {
   bool first_bool_not = op_[0]->is_custom() && op_[0]->op == "BOOLNOT";
-  if (!first_bool_not || pb_ < 2 || !op_[1]->is_custom()) {
+  if (!first_bool_not || pb_ < 2) {
     return false;
   }
 
@@ -370,7 +389,7 @@ bool Optimizer::detect_rewrite_BOOLNOT_THROWIF() {
 
   std::string_view f = op_[1]->op;
   for (size_t i = 0; i < std::size(ends_with); ++i) {
-    if (f.ends_with(ends_with[i])) {
+    if (is_single_arg_op_ending_with(op_[1]->op, ends_with[i])) {
       p_ = 2;
       q_ = 1;
       std::string new_op = op_[1]->op.substr(0, f.rfind(' ')) + repl_with[i];
@@ -387,7 +406,7 @@ bool Optimizer::detect_rewrite_BOOLNOT_THROWIF() {
 // particularly, this helps to optimize code like `assert (v == 0, N)` with just one `N THROWIF`
 bool Optimizer::detect_rewrite_0EQINT_THROWIF() {
   bool first_0eqint = op_[0]->is_custom() && (op_[0]->op == "0 EQINT" || op_[0]->op == "0 NEQINT");
-  if (!first_0eqint || pb_ < 2 || !op_[1]->is_custom()) {
+  if (!first_0eqint || pb_ < 2) {
     return false;
   }
 
@@ -396,7 +415,7 @@ bool Optimizer::detect_rewrite_0EQINT_THROWIF() {
 
   std::string_view f = op_[1]->op;
   for (size_t i = 0; i < std::size(ends_with); ++i) {
-    if (f.ends_with(ends_with[i])) {
+    if (is_single_arg_op_ending_with(op_[1]->op, ends_with[i])) {
       bool drop_cond = op_[0]->op == "0 NEQINT";
       p_ = 2;
       q_ = 1;
@@ -416,15 +435,17 @@ bool Optimizer::detect_rewrite_0EQINT_THROWIF() {
 // pattern `NEWC` + store const slice + XCHG + keyLen + DICTSETB -> push const slice + XCHG + keyLen + DICTSET
 // (useful for `someMap.set(k, constVal)` where constVal is represented as a const slice)
 bool Optimizer::detect_rewrite_DICTSETB_DICTSET() {
-  bool fifth_dict = pb_ >= 5 && op_[4]->is_custom() && op_[4]->op.starts_with("DICT");
+  bool fifth_dict = pb_ >= 5 && op_[4]->is_custom() && op_[4]->op.starts_with("DICT") &&
+                    op_[4]->op.find("()") == std::string::npos;
   if (!fifth_dict) {
     return false;
   }
 
   bool first_newc = op_[0]->op == "NEWC";
-  bool second_stsliceconst = op_[1]->op.ends_with(" STSLICECONST");
-  bool third_xchg = op_[2]->is_xchg() || op_[2]->op == "ROT" || op_[2]->op == "-ROT" || op_[2]->op.ends_with(" PUXC");
-  bool fourth_pushint = op_[3]->is_const() && op_[3]->op.ends_with(" PUSHINT");
+  bool second_stsliceconst = is_single_arg_op_ending_with(op_[1]->op, " STSLICECONST");
+  // DICT*SETB consumes `value key dict keyLen`, so before pushing keyLen the constant builder must be at s2
+  bool third_xchg = op_[2]->is_xchg(0, 2) || op_[2]->op == "-ROT" || op_[2]->op == "s2 s1 PUXC";
+  bool fourth_pushint = is_single_arg_op_ending_with(op_[3]->op, " PUSHINT");
   if (!first_newc || !second_stsliceconst || !third_xchg || !fourth_pushint) {
     return false;
   }
@@ -453,8 +474,8 @@ bool Optimizer::detect_rewrite_DICTSETB_DICTSET() {
 // especially useful for `dict.mustGet()` method with a small constant errno if a key not exists
 // (for large or dynamic excno, it's XCHGed from a stack, we need to keep stack aligned, don't remove nullswap)
 bool Optimizer::detect_rewrite_DICTGET_NULLSWAPIFNOT_THROWIFNOT() {
-  bool second_nullswap = pb_ >= 2 && op_[0]->is_custom() && op_[0]->op.ends_with(" NULLSWAPIFNOT");
-  if (!second_nullswap || !op_[1]->op.ends_with(" THROWIFNOT")) {
+  bool second_nullswap = pb_ >= 2 && is_single_arg_op_ending_with(op_[0]->op, " NULLSWAPIFNOT");
+  if (!second_nullswap || !is_single_arg_op_ending_with(op_[1]->op, " THROWIFNOT")) {
     return false;
   }
 
@@ -532,7 +553,7 @@ bool Optimizer::detect_rewrite_NEWC_STSLICECONST_BTOS() {
     return false;
   }
 
-  bool next_stsliceconst = op_[1]->is_custom() && op_[1]->op.ends_with(" STSLICECONST");
+  bool next_stsliceconst = is_single_arg_op_ending_with(op_[1]->op, " STSLICECONST");
   bool next_btos = op_[2]->is_custom() && op_[2]->op == "BTOS";
   if (!next_stsliceconst || !next_btos) {
     return false;
@@ -602,13 +623,13 @@ bool Optimizer::detect_rewrite_emptySlice_ENDS() {
 
 // pattern `N TUPLE` + `N UNTUPLE` -> nothing (but not vice versa, since `UNTUPLE` may throw)
 bool Optimizer::detect_rewrite_N_TUPLE_N_UNTUPLE() {
-  bool first_tuple = op_[0]->op.ends_with(" TUPLE");
-  if (!first_tuple || op_[0]->op.find(' ') != op_[0]->op.rfind(' ') || pb_ < 2) {
+  bool first_tuple = is_single_arg_op_ending_with(op_[0]->op, " TUPLE");
+  if (!first_tuple || pb_ < 2) {
     return false;
   }
 
-  bool second_untuple = op_[1]->op.ends_with(" UNTUPLE");
-  if (!second_untuple || op_[1]->op.find(' ') != op_[1]->op.rfind(' ')) {
+  bool second_untuple = is_single_arg_op_ending_with(op_[1]->op, " UNTUPLE");
+  if (!second_untuple) {
     return false;
   }
 
@@ -673,7 +694,7 @@ bool Optimizer::detect_rewrite_xxx_NOT() {
 
   std::string_view f = op_[0]->op;
   for (size_t i = 0; i < std::size(ends_with); ++i) {
-    if (f.ends_with(ends_with[i])) {
+    if (is_single_arg_op_ending_with(op_[0]->op, ends_with[i])) {
       p_ = 2;
       q_ = 1;
       std::string new_op = op_[0]->op.substr(0, f.rfind(' ')) + repl_with[i];
@@ -692,7 +713,8 @@ bool Optimizer::detect_rewrite_xxx_NOT() {
   // `!(a > 7)` -> `a <= 7` -> `a < 8` (but `GTINT` instead of `GREATER` for small numbers)
   // `7 GTINT` + `NOT` -> `8 LESSINT` (there is no `LEINT` instruction)
   // `8 LESSINT` + `NOT` -> `7 GTINT`
-  if (f.ends_with(" GTINT") || f.ends_with(" LESSINT")) {
+  if (is_single_arg_op_ending_with(op_[0]->op, " GTINT") ||
+      is_single_arg_op_ending_with(op_[0]->op, " LESSINT")) {
     bool is_gtint = f.ends_with(" GTINT");
     std::string s_number(f.substr(0, f.rfind(' ')));
     td::RefInt256 number = td::string_to_int256(s_number);

--- a/tolk/overload-resolution.cpp
+++ b/tolk/overload-resolution.cpp
@@ -150,6 +150,29 @@ static bool is_more_specific_generic(TypePtr typeA, TypePtr typeB, const Generic
      && !can_substitute_Ts_to_reach_actual(typeA, typeB, genericTsA);
 }
 
+// Find a receiver pattern that dominates all other applicable overloads:
+// - `map<K, slice>` beats both `map<K, V>` and `map<K, V | slice>`
+// - `Container<int>` beats `Container<T>`
+// But `map<int, V>` and `map<K, slice>` are incomparable, so no dominator exists.
+static const MethodCallCandidate* find_the_only_generic_dominator(const std::vector<MethodCallCandidate>& candidates) {
+  const MethodCallCandidate* dominator = nullptr;
+  for (const MethodCallCandidate& candidate : candidates) {
+    bool dominates_all = true;
+    for (const MethodCallCandidate& other : candidates) {
+      if (candidate.method_ref != other.method_ref) {
+        dominates_all &= is_more_specific_generic(candidate.original_receiver, other.original_receiver, candidate.method_ref->genericTs, other.method_ref->genericTs);
+      }
+    }
+    if (dominates_all) {
+      if (dominator) {
+        return nullptr;
+      }
+      dominator = &candidate;
+    }
+  }
+  return dominator;
+}
+
 // the main "overload resolution" entrypoint: given `obj.method()`, find best applicable methods;
 // if there are many (no one is better than others), a caller side will emit "ambiguous call"
 std::vector<MethodCallCandidate> resolve_methods_for_call(TypePtr provided_receiver, std::string_view called_name, bool skip_instantiations) {
@@ -205,7 +228,15 @@ std::vector<MethodCallCandidate> resolve_methods_for_call(TypePtr provided_recei
     return viable;
   }
 
-  // 2) better shape in terms of structural depth
+  // 2) find the overload that dominates all others
+  //    (prefer `Container<int>` over `Container<T>` and `map<K, slice>` over `map<K, V>`)
+  //    Check this before shape scoring, since shape is only a structural fallback:
+  //    for example, `map<K, V | slice>` is deeper, but `map<K, slice>` is more specific.
+  if (const MethodCallCandidate* dominator = find_the_only_generic_dominator(viable)) {
+    return {*dominator};
+  }
+
+  // 3) better shape in terms of structural depth
   //    (prefer `Container<T>` over `T` and `map<K1, map<K2,V2>>` over `map<K,V>`)
   ShapeScore best_shape = {ShapeKind::GenericT, -999};
   for (const MethodCallCandidate& candidate : viable) {
@@ -228,7 +259,7 @@ std::vector<MethodCallCandidate> resolve_methods_for_call(TypePtr provided_recei
     viable = std::move(best_by_shape);
   }
 
-  // 3) if there are both generic and non-generic functions of the same shape, filter out generic
+  // 4) if there are both generic and non-generic functions of the same shape, filter out generic
   n_generics = 0;
   for (const MethodCallCandidate& candidate : viable) {
     n_generics += candidate.is_generic();
@@ -243,23 +274,8 @@ std::vector<MethodCallCandidate> resolve_methods_for_call(TypePtr provided_recei
     return non_generic;
   }
 
-  // 4) find the overload that dominates all others
-  //    (prefer `Container<int>` over `Container<T>` and `map<K, slice>` over `map<K, V>`)
-  const MethodCallCandidate* dominator = nullptr;
-  for (const MethodCallCandidate& candidate : viable) {
-    bool dominates_all = true;
-    for (const MethodCallCandidate& other : viable) {
-      if (candidate.method_ref != other.method_ref) {
-        dominates_all &= is_more_specific_generic(candidate.original_receiver, other.original_receiver, candidate.method_ref->genericTs, other.method_ref->genericTs);
-      }
-    }
-    if (dominates_all) {
-      tolk_assert(!dominator);
-      dominator = &candidate;
-    }
-  }
-
-  if (dominator) {
+  // 5) now choose inside the remaining best-shaped subset
+  if (const MethodCallCandidate* dominator = find_the_only_generic_dominator(viable)) {
     return {*dominator};
   }
   return viable;

--- a/tolk/pack-unpack-api.cpp
+++ b/tolk/pack-unpack-api.cpp
@@ -86,6 +86,12 @@ public:
   explicit PackUnpackAvailabilityChecker(std::vector<MethodCallCandidate>* out_un_pack_candidates)
     : out_un_pack_candidates(out_un_pack_candidates) {}
 
+  // During type inference, this class is also used only to collect custom pack/unpack methods
+  // that need generic instantiation. In that mode, skip checks that estimate finalized binary layout.
+  bool is_collecting_out_candidates_only() const {
+    return out_un_pack_candidates != nullptr;
+  }
+
   std::optional<CantSerializeBecause> detect_why_cant_serialize(TypePtr any_type, bool is_pack, int cell_ref_depth) {
     if (any_type->try_as<TypeDataIntN>()) {
       return {};
@@ -122,7 +128,7 @@ public:
       StructPtr struct_ref = t_struct->struct_ref;
 
       if (CustomPackUnpackF f = get_custom_pack_unpack_function(t_struct, out_un_pack_candidates)) {
-        return out_un_pack_candidates ? std::nullopt : check_custom_pack_unpack(t_struct, f, is_pack);
+        return is_collecting_out_candidates_only() ? std::nullopt : check_custom_pack_unpack(t_struct, f, is_pack);
       }
 
       if (struct_ref->is_instantiation_of_CellT()) {
@@ -156,7 +162,7 @@ public:
 
     if (const auto* t_enum = any_type->try_as<TypeDataEnum>()) {
       if (CustomPackUnpackF f = get_custom_pack_unpack_function(t_enum, out_un_pack_candidates)) {
-        return out_un_pack_candidates ? std::nullopt : check_custom_pack_unpack(t_enum, f, is_pack);
+        return is_collecting_out_candidates_only() ? std::nullopt : check_custom_pack_unpack(t_enum, f, is_pack);
       }
 
       if (t_enum->enum_ref->members.empty()) {
@@ -180,6 +186,9 @@ public:
         if (auto why = detect_why_cant_serialize(variant, is_pack, cell_ref_depth)) {
           return CantSerializeBecause("because variant #" + std::to_string(i + 1) + " of type `" + variant->as_human_readable() + "` can't be serialized", why.value());
         }
+      }
+      if (is_collecting_out_candidates_only()) {
+        return {};
       }
       if (t_union->or_null == TypeDataVoid::create()) {
         return CantSerializeBecause("because `void | null` has no binary representation");
@@ -223,6 +232,9 @@ public:
       if (auto why = detect_why_cant_serialize(t_array->innerT, is_pack, cell_ref_depth)) {
         return CantSerializeBecause("because array of type `" + t_array->innerT->as_human_readable() + "` can't be serialized", why.value());
       }
+      if (is_collecting_out_candidates_only()) {
+        return {};
+      }
       PackSize sizeT = estimate_serialization_size(t_array->innerT);
       if ((sizeT.max_refs >= 4 || sizeT.min_bits >= 1022) && !sizeT.is_unpredictable_infinity()) {    // one cell and one bit is for snaking
         return CantSerializeBecause("because `" + t_array->innerT->as_human_readable() + "` is too big and won't fit into a nested cell");
@@ -239,7 +251,7 @@ public:
       }
 
       if (CustomPackUnpackF f = get_custom_pack_unpack_function(t_alias, out_un_pack_candidates)) {
-        return out_un_pack_candidates ? std::nullopt : check_custom_pack_unpack(t_alias, f, is_pack);
+        return is_collecting_out_candidates_only() ? std::nullopt : check_custom_pack_unpack(t_alias, f, is_pack);
       }
 
       if (auto why = detect_why_cant_serialize(t_alias->underlying_type, is_pack, cell_ref_depth)) {

--- a/tolk/pack-unpack-serializers.cpp
+++ b/tolk/pack-unpack-serializers.cpp
@@ -66,8 +66,10 @@ static bool is_same_custom_serialization_receiver(TypePtr receiver_type, TypePtr
 static std::vector<MethodCallCandidate> filter_pack_candidates(TypePtr receiver_type, const std::vector<MethodCallCandidate>& candidates) {
   int min_generics = 100;
   for (const MethodCallCandidate& c : candidates) {
-    int n_generics = c.is_generic() ? c.substitutedTs.size() : 0;
-    min_generics = std::min(min_generics, n_generics);
+    if (is_same_custom_serialization_receiver(receiver_type, c.instantiated_receiver)) {
+      int n_generics = c.is_generic() ? c.substitutedTs.size() : 0;
+      min_generics = std::min(min_generics, n_generics);
+    }
   }
 
   std::vector<MethodCallCandidate> filtered;
@@ -114,6 +116,13 @@ CustomPackUnpackF get_custom_pack_unpack_function(TypePtr receiver_type, std::ve
   }
   if (!c_unpack.empty()) {
     f.f_unpack = c_unpack[0].method_ref;
+  }
+
+  // for `type A = B`, if `A` does not declare its own serializers, take them from B
+  if (!f) {
+    if (const TypeDataAlias* t_alias = receiver_type->try_as<TypeDataAlias>()) {
+      f = get_custom_pack_unpack_function(t_alias->underlying_type, out_candidates);
+    }
   }
 
   if (out_candidates) {
@@ -1513,6 +1522,16 @@ struct S_CustomReceiverForPackUnpack final : ISerializer {
 // Special case: a `void` variant doesn't participate in the prefix tree —
 // it's matched at runtime by `slice.isEmpty()`, not by reading any prefix bits.
 
+static StructPtr get_struct_with_union_opcode(TypePtr variant) {
+  if (get_custom_pack_unpack_function(variant)) {
+    return nullptr;
+  }
+  if (const TypeDataStruct* variant_struct = variant->unwrap_alias()->try_as<TypeDataStruct>()) {
+    return variant_struct->struct_ref;
+  }
+  return nullptr;
+}
+
 // Check opcodes within a union are not equal to each other, e.g.
 // > struct (0x1234) A
 // > struct (0x1234) B
@@ -1521,9 +1540,9 @@ struct S_CustomReceiverForPackUnpack final : ISerializer {
 static void check_opcodes_are_not_equal(const std::vector<TypePtr>& variants, std::string& because_msg) {
   int n = static_cast<int>(variants.size()) - (variants.back() == TypeDataVoid::create());
   for (int i = 0; i < n; ++i) {
-    StructPtr lhs_struct = variants[i]->unwrap_alias()->try_as<TypeDataStruct>()->struct_ref;
+    StructPtr lhs_struct = get_struct_with_union_opcode(variants[i]);
     for (int j = i + 1; j < n; ++j) {
-      StructPtr rhs_struct = variants[j]->unwrap_alias()->try_as<TypeDataStruct>()->struct_ref;
+      StructPtr rhs_struct = get_struct_with_union_opcode(variants[j]);
       if (lhs_struct->opcode == rhs_struct->opcode) {
         because_msg = "because both structs `" + lhs_struct->as_human_readable() + "` and `" + rhs_struct->as_human_readable() + "` have serialization prefix " + lhs_struct->opcode.format_as_string(false);
         return;
@@ -1545,12 +1564,12 @@ std::vector<PackOpcode> auto_generate_opcodes_for_union(TypePtr union_type, std:
   StructPtr last_struct_no_opcode = nullptr;
   for (int i = 0; i < t_union->size(); ++i) {
     TypePtr variant = t_union->variants[i];
-    if (const TypeDataStruct* variant_struct = variant->unwrap_alias()->try_as<TypeDataStruct>()) {
-      if (variant_struct->struct_ref->opcode.exists()) {
+    if (StructPtr variant_struct = get_struct_with_union_opcode(variant)) {
+      if (variant_struct->opcode.exists()) {
         n_have_opcode++;
-        last_struct_with_opcode = variant_struct->struct_ref;
+        last_struct_with_opcode = variant_struct;
       } else {
-        last_struct_no_opcode = variant_struct->struct_ref;
+        last_struct_no_opcode = variant_struct;
       }
     } else if (variant == TypeDataNullLiteral::create()) {
       has_null = true;
@@ -1574,7 +1593,7 @@ std::vector<PackOpcode> auto_generate_opcodes_for_union(TypePtr union_type, std:
     }
     for (TypePtr variant : t_union->variants) {
       if (variant != TypeDataVoid::create()) {
-        result.push_back(variant->unwrap_alias()->try_as<TypeDataStruct>()->struct_ref->opcode);
+        result.push_back(get_struct_with_union_opcode(variant)->opcode);
       } else {
         result.emplace_back(0, 0);
       }
@@ -1766,8 +1785,8 @@ static std::unique_ptr<ISerializer> get_serializer_for_type(TypePtr any_type) {
     bool all_have_opcode = true;
     bool has_void = false;
     for (TypePtr variant : t_union->variants) {
-      const TypeDataStruct* variant_struct = variant->unwrap_alias()->try_as<TypeDataStruct>();
-      all_have_opcode &= variant_struct && variant_struct->struct_ref->opcode.exists();
+      StructPtr variant_struct = get_struct_with_union_opcode(variant);
+      all_have_opcode &= variant_struct && variant_struct->opcode.exists();
       has_void |= variant == TypeDataVoid::create();
     }
     if (t_union->size() == 2 && !all_have_opcode && !has_void) {

--- a/tolk/pipe-ast-to-legacy.cpp
+++ b/tolk/pipe-ast-to-legacy.cpp
@@ -193,40 +193,12 @@ class LValContext {
     }
   };
 
-  // every lval index of a tensor/struct inside a shaped tuple is registered here
-  // example: `var t: [Point]` and `t.0.x = 10` (we need to update the 0-th element)
-  // note, that `globalPoint.x = 10` is not registered here: only inner-shape modifications
-  struct ModifiedTensorIndex {
-    AnyExprV tensor_obj;      // it's a sink expression: `t.0.x`, not `getT().0.x`
-    int stack_offset;
-    std::vector<var_idx_t> ir_field;
-
-    void apply(CodeBlob& code, AnyV origin) const {
-      LValContext local_lval;
-      std::vector obj_ir_idx = pre_compile_expr(tensor_obj, code, nullptr, &local_lval);
-      std::vector field_ir_idx(obj_ir_idx.begin() + stack_offset, obj_ir_idx.begin() + stack_offset + static_cast<int>(ir_field.size()));
-
-      vars_modification_watcher.trigger_callbacks(field_ir_idx, origin);
-      code.add_let(origin, field_ir_idx, ir_field);
-      local_lval.after_let(std::move(field_ir_idx), code, origin);
-    }
-  };
-
   AnyExprV mutated_self_obj = nullptr;    // for `g.inc().inc()` it's `g`, returned from the inner call to the outer
-  std::vector<std::variant<ModifiedGlobal, ModifiedShapedTupleIndex, ModifiedTensorIndex>> modifications;
+  std::vector<std::variant<ModifiedGlobal, ModifiedShapedTupleIndex>> modifications;
 
   static bool vector_contains(const std::vector<var_idx_t>& ir_vars, var_idx_t ir_idx) {
     for (var_idx_t var_in_vector : ir_vars) {
       if (var_in_vector == ir_idx) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  static bool vector_contains(const std::vector<var_idx_t>& ir_vars, const std::vector<var_idx_t>& ir_idx_arr) {
-    for (var_idx_t ir_idx : ir_idx_arr) {
-      if (vector_contains(ir_vars, ir_idx)) {
         return true;
       }
     }
@@ -257,10 +229,6 @@ public:
     modifications.emplace_back(ModifiedShapedTupleIndex{shaped_obj, index_at, std::move(ir_field)});
   }
 
-  void capture_tensor_index_modification(AnyExprV tensor_obj, int stack_offset, std::vector<var_idx_t> ir_field) {
-    modifications.emplace_back(ModifiedTensorIndex{tensor_obj, stack_offset, std::move(ir_field)});
-  }
-
   void after_let(std::vector<var_idx_t>&& let_left_vars, CodeBlob& code, AnyV origin) const {
     for (const auto& modification : modifications) {
       if (const auto* m_glob = std::get_if<ModifiedGlobal>(&modification)) {
@@ -275,10 +243,6 @@ public:
         std::vector<bool> was_modified_by_let;
         if (vector_contains(let_left_vars, m_tup->ir_field, was_modified_by_let)) {
           m_tup->apply_partially_rewrite(code, origin, std::move(was_modified_by_let));
-        }
-      } else if (const auto* m_tens = std::get_if<ModifiedTensorIndex>(&modification)) {
-        if (vector_contains(let_left_vars, m_tens->ir_field)) {
-          m_tens->apply(code, origin);
         }
       }
     }
@@ -388,7 +352,7 @@ const LazyVariableLoadedState* CodeBlob::get_lazy_variable(LocalVarPtr var_ref) 
   return nullptr;
 }
 
-// detect `st` by vertex "st" or by an identity-preserving wrapper like `(st = st)`
+// detect `st` by vertex "st"; for `(st = rhs)`, the expression value is `rhs`
 const LazyVariableLoadedState* CodeBlob::get_lazy_variable(AnyExprV v) const {
   if (auto as_ref = v->try_as<ast_reference>()) {
     if (LocalVarPtr var_ref = as_ref->sym->try_as<LocalVarPtr>()) {
@@ -396,7 +360,7 @@ const LazyVariableLoadedState* CodeBlob::get_lazy_variable(AnyExprV v) const {
     }
   }
   if (auto as_assign = v->try_as<ast_assign>()) {
-    return get_lazy_variable(as_assign->get_lhs());
+    return get_lazy_variable(as_assign->get_rhs());
   }
   return nullptr;
 }
@@ -633,17 +597,6 @@ static std::vector<var_idx_t> pre_compile_tensor(CodeBlob& code, const std::vect
   return pre_compile_tensor_merging(code, args, lval_ctx_for_arg, target_types, origin_for_loc_marks, origin_overrides);
 }
 
-static std::vector<var_idx_t> pre_compile_tensor_with_lval_at(CodeBlob& code, V<ast_tensor> v, int index_at, LValContext* lval_ctx) {
-  std::vector<TypePtr> target_types;
-  target_types.reserve(v->size());
-  for (AnyExprV ith_item : v->get_items()) {
-    target_types.push_back(ith_item->inferred_type);
-  }
-  std::vector<LValContext*> lval_ctx_for_arg(v->size(), nullptr);
-  lval_ctx_for_arg[index_at] = lval_ctx;
-  return pre_compile_tensor_merging(code, v->get_items(), lval_ctx_for_arg, target_types, {}, {});
-}
-
 static std::vector<var_idx_t> pre_compile_let(CodeBlob& code, AnyExprV lhs, AnyExprV rhs) {
   // [lhs] = rhs; it's un-tuple to N left vars
   if (lhs->kind == ast_square_brackets) {
@@ -809,7 +762,8 @@ std::vector<var_idx_t> gen_inline_fun_call_in_place(CodeBlob& code, TypePtr ret_
   // specially handle `point.getX()` if point is a lazy var: to make `self.toCell()` work and `self.x` asserted;
   // (only methods preserve lazy, `getXOf(point)` does not, though theoretically can be done)
   const LazyVariableLoadedState* lazy_receiver = self_obj ? code.get_lazy_variable(self_obj) : nullptr;
-  if (lazy_receiver) {
+  bool preserve_lazy_receiver = lazy_receiver && f_inlined->parameters[0].declared_type->equal_to(lazy_receiver->declared_type);
+  if (preserve_lazy_receiver) {
     LocalVarPtr self_var_ref = &f_inlined->parameters[0];             // `self` becomes lazy while inlining
     code.lazy_variables.emplace_back(self_var_ref, lazy_receiver);  // (points to the same slice, immutable tail, etc.)
   }
@@ -826,7 +780,7 @@ std::vector<var_idx_t> gen_inline_fun_call_in_place(CodeBlob& code, TypePtr ret_
     code.add_debug_mark(DebugMarkLocalVar{
       .local_ref = &param_i,
       .ir_slots = param_i.ir_idx,
-      .ir_lazy_slice = (lazy_receiver && i == 0) ? lazy_receiver->ir_slice[0] : -1,
+      .ir_lazy_slice = (preserve_lazy_receiver && i == 0) ? lazy_receiver->ir_slice[0] : -1,
     });
   }
 
@@ -1371,10 +1325,6 @@ static std::vector<var_idx_t> process_dot_access(V<ast_dot_access> v, CodeBlob& 
       int stack_width = field_ref->declared_type->get_width_on_stack();
       int stack_offset = calc_offset_on_stack(t_struct->struct_ref, field_ref->field_idx);
       std::vector rvect(lhs_vars.begin() + stack_offset, lhs_vars.begin() + stack_offset + stack_width);
-      if (lval_ctx && v->get_obj()->inferred_type->unwrap_alias()->try_as<TypeDataShapedTuple>()) {
-        tolk_assert(is_valid_lvalue_path(v));
-        lval_ctx->capture_tensor_index_modification(v->get_obj(), stack_offset, rvect);
-      }
       // an object field might be smart cast at this point, for example we're in `if (user.t != null)`
       // it means that we must drop the null flag (if `user.t` is a tensor), or maybe perform other stack transformations
       // (from original rvect = (vars of user.t) to fit smart cast)
@@ -1384,17 +1334,11 @@ static std::vector<var_idx_t> process_dot_access(V<ast_dot_access> v, CodeBlob& 
     // `tensorVar.0`
     if (const TypeDataTensor* t_tensor = obj_type->try_as<TypeDataTensor>()) {
       int index_at = std::get<int>(v->target);
-      std::vector lhs_vars = lval_ctx && v->get_obj()->kind == ast_tensor     // `(a,b,c).0 = rhs`, only `a` with lval_ctx
-          ? pre_compile_tensor_with_lval_at(code, v->get_obj()->as<ast_tensor>(), index_at, lval_ctx)
-          : pre_compile_expr(v->get_obj(), code, nullptr, lval_ctx);
+      std::vector lhs_vars = pre_compile_expr(v->get_obj(), code, nullptr, lval_ctx);
       // since a tensor of N elems are N vars on a stack actually, calculate offset
       int stack_width = t_tensor->items[index_at]->get_width_on_stack();
       int stack_offset = calc_offset_on_stack(t_tensor, index_at);
       std::vector rvect(lhs_vars.begin() + stack_offset, lhs_vars.begin() + stack_offset + stack_width);
-      if (lval_ctx && v->get_obj()->inferred_type->unwrap_alias()->try_as<TypeDataShapedTuple>()) {
-        tolk_assert(is_valid_lvalue_path(v));
-        lval_ctx->capture_tensor_index_modification(v->get_obj(), stack_offset, rvect);
-      }
       // a tensor index might be smart cast at this point, for example we're in `if (t.1 != null)`
       rvect = transition_to_target_type(std::move(rvect), code, t_tensor->items[index_at], v->inferred_type, v->get_obj());
       return transition_to_target_type(std::move(rvect), code, target_type, v);
@@ -2338,26 +2282,23 @@ static void convert_asm_body_to_AsmOp(FunctionPtr fun_ref, FunctionBodyAsm* asm_
   int width = fun_ref->inferred_return_type->get_width_on_stack();
   std::vector<AsmOp> asm_ops;
   for (AnyV v_child : fun_ref->ast_root->as<ast_function_declaration>()->get_body()->as<ast_asm_body>()->get_asm_commands()) {
-    std::string_view ops = v_child->as<ast_string_const>()->str_val; // <op>\n<op>\n...
-    std::string op;
-    for (char c : ops) {
-      if (c == '\n' || c == '\r') {
-        if (!op.empty()) {
-          asm_ops.push_back(AsmOp::Parse(v_child, op, cnt, width));
-          if (asm_ops.back().is_custom()) {
-            cnt = width;
-          }
-          op.clear();
-        }
-      } else {
-        op.push_back(c);
-      }
+    // `op` is what's inside quotes on an asm function; it's either simple "NEWC" etc., or """\n multi line \n""";
+    // note: for a multi-line insert it as a big string, don't parse line-by-line
+    std::string_view op = v_child->as<ast_string_const>()->str_val;
+    // trim if multiline
+    while (!op.empty() && std::isspace(op[0])) {
+      op = op.substr(1);
     }
-    if (!op.empty()) {
-      asm_ops.push_back(AsmOp::Parse(v_child, op, cnt, width));
-      if (asm_ops.back().is_custom()) {
-        cnt = width;
-      }
+    while (!op.empty() && std::isspace(op[op.size() - 1])) {
+      op = op.substr(0, op.size() - 1);
+    }
+    if (op.empty()) {
+      err("empty asm instruction").fire(v_child);
+    }
+    // if it's "SWAP" and similar, parse it as a special instruction, not as AsmOp::_Custom
+    asm_ops.push_back(AsmOp::Parse(v_child, std::string(op), cnt, width));
+    if (asm_ops.back().is_custom()) {
+      cnt = width;
     }
   }
 

--- a/tolk/pipe-check-inferred-types.cpp
+++ b/tolk/pipe-check-inferred-types.cpp
@@ -618,6 +618,16 @@ class CheckInferredTypesVisitor final : public ASTVisitorFunctionBody {
 
     if (cond->is_always_true || cond->is_always_false) {
       warning_condition_always_true_or_false(cur_f, cond->range, cond, "ternary operator");
+      return;
+    }
+
+    AnyExprV when_true = v->get_when_true();
+    AnyExprV when_false = v->get_when_false();
+    if (!v->inferred_type->can_rhs_be_assigned(when_true->inferred_type)) {
+      err_type_mismatch("can not convert type {src} to ternary result type {dst}", when_true->inferred_type, v->inferred_type).collect(when_true, cur_f);
+    }
+    if (!v->inferred_type->can_rhs_be_assigned(when_false->inferred_type)) {
+      err_type_mismatch("can not convert type {src} to ternary result type {dst}", when_false->inferred_type, v->inferred_type).collect(when_false, cur_f);
     }
   }
 
@@ -692,6 +702,15 @@ class CheckInferredTypesVisitor final : public ASTVisitorFunctionBody {
     TypePtr subject_type = v_subject->inferred_type;
     const TypeDataEnum* subject_enum = subject_type->unwrap_alias()->try_as<TypeDataEnum>();
     const TypeDataUnion* subject_union = subject_type->unwrap_alias()->try_as<TypeDataUnion>();
+
+    if (!v->is_statement()) {
+      for (int i = 0; i < v->get_arms_count(); ++i) {
+        AnyExprV arm_body = v->get_arm(i)->get_body();
+        if (!v->inferred_type->can_rhs_be_assigned(arm_body->inferred_type)) {
+          err_type_mismatch("can not convert type {src} to match result type {dst}", arm_body->inferred_type, v->inferred_type).collect(arm_body, cur_f);
+        }
+      }
+    }
 
     std::vector<int> covered_variants;        // union variant indexes; for non-union, the only matching type is 0
     std::vector<EnumMemberPtr> covered_enum;  // for `match` over an enum, we want it to be exhaustive

--- a/tolk/pipe-generate-fif-output.cpp
+++ b/tolk/pipe-generate-fif-output.cpp
@@ -305,6 +305,8 @@ static void generate_output_func(std::ostream& os, FunctionPtr fun_ref) {
       code->print(std::cerr, 6);
     }
   }
+  code->compute_used_code_vars();
+  code->fwd_analyze();
   code->mark_noreturn();
   if (G_settings.verbosity >= 3) {
     // code->print(std::cerr, 15);
@@ -320,18 +322,25 @@ static void generate_output_func(std::ostream& os, FunctionPtr fun_ref) {
     mode |= Stack::_InlineAny;
   }
 
-  std::vector<AsmOp> asm_code = code->generate_asm_code(mode);
-  if (G_settings.optimization_level >= 2) {
-    asm_code = optimize_asm_code(std::move(asm_code));
+  try {
+    std::vector<AsmOp> asm_code = code->generate_asm_code(mode);
+    if (G_settings.optimization_level >= 2) {
+      asm_code = optimize_asm_code(std::move(asm_code));
+    }
+    output_asm_code_for_fun(
+      os,
+      fun_ref,
+      std::move(asm_code),
+      G_settings.stack_layout_comments,
+      G_settings.tolk_src_as_line_comments,
+      G_settings.emit_debug_marks
+    );
+  } catch (const TooDeepStackFatal&) {
+    err("generated TVM stack is too deep while compiling function `{}`.\n"
+        "TVM can not store more than 255 elements on the stack.\n"
+        "hint: try splitting very wide tensors/structs, storing parts in cells/tuples",
+        fun_ref).fire(fun_ref->ident_anchor, fun_ref);
   }
-  output_asm_code_for_fun(
-    os,
-    fun_ref,
-    std::move(asm_code),
-    G_settings.stack_layout_comments,
-    G_settings.tolk_src_as_line_comments,
-    G_settings.emit_debug_marks
-  );
 
   if (G_settings.verbosity >= 2) {
     std::cerr << "--------------\n";

--- a/tolk/pipe-infer-types-and-calls.cpp
+++ b/tolk/pipe-infer-types-and-calls.cpp
@@ -202,9 +202,11 @@ static TypePtr try_pick_instantiated_generic_from_hint(TypePtr hint, StructPtr l
 static TypePtr try_pick_instantiated_generic_from_hint(TypePtr hint, AliasDefPtr lookup_ref) {
   // when a generic type alias points to a generic struct actually: `type WrapperAlias<T> = Wrapper<T>`
   if (const TypeDataGenericTypeWithTs* as_instT = lookup_ref->underlying_type->try_as<TypeDataGenericTypeWithTs>()) {
-    return as_instT->struct_ref
-         ? try_pick_instantiated_generic_from_hint(hint, as_instT->struct_ref)
-         : try_pick_instantiated_generic_from_hint(hint, as_instT->alias_ref);
+    TypePtr picked = as_instT->struct_ref
+                   ? try_pick_instantiated_generic_from_hint(hint, as_instT->struct_ref)
+                   : try_pick_instantiated_generic_from_hint(hint, as_instT->alias_ref);
+    const TypeDataAlias* picked_alias = picked ? picked->try_as<TypeDataAlias>() : nullptr;
+    return picked_alias && picked_alias->alias_ref->base_alias_ref == lookup_ref ? picked : nullptr;
   }
   // it's something weird, when a generic alias refs non-generic type
   // example: `type StrangeInt<T> = int`, hint is `StrangeInt<builder>`, lookup `StrangeInt`
@@ -443,7 +445,7 @@ class InferTypesAndCallsAndFieldsVisitor final {
 
   static ExprFlow infer_local_var_lhs(V<ast_local_var_lhs> v, FlowContext&& flow, bool used_as_condition) {
     // `var v = rhs`, inferring is called for `v`
-    // at the moment of inferring left side of assignment, we don't know type of rhs (since lhs is executed first)
+    // at the moment of inferring left side of assignment, we don't know type of rhs yet
     // so, mark `v` as "not inferred"
     // later, v's inferred_type will be reassigned; see process_assignment_lhs_after_infer_rhs()
     assign_inferred_type(v, v->type_node ? v->type_node->resolved_type : TypeDataNotInferred::create());
@@ -453,8 +455,8 @@ class InferTypesAndCallsAndFieldsVisitor final {
 
   ExprFlow infer_assignment(V<ast_assign> v, FlowContext&& flow, bool used_as_condition) {
     // v is assignment: `x = 5` / `var x = 5` / `var x: slice = 5` / `(cs,_) = f()` / `val (a,[b],_) = (a,t,0)`
-    // execution flow is: lhs first, rhs second (at IR generation, also lhs is evaluated first, unlike FunC)
-    // after inferring lhs, use it for hint when inferring rhs
+    // infer lhs first only to know the assignment target type and use it as a hint when inferring rhs;
+    // at IR generation, rhs is evaluated before lhs;
     // example: `var i: int = t.tupleAt(0)` is ok (hint=int, T=int), but `var i = t.tupleAt(0)` not, since `tupleAt<T>(t,i): T`
     AnyExprV lhs = v->get_lhs();
     AnyExprV rhs = v->get_rhs();

--- a/tolk/pipe-lazy-load-insertions.cpp
+++ b/tolk/pipe-lazy-load-insertions.cpp
@@ -169,7 +169,8 @@ static bool does_function_satisfy_for_lazy_operator(FunctionPtr fun_ref, bool al
     if (f_body->size() == 1) {
       if (auto f_returns = f_body->get_item(0)->try_as<ast_return_statement>(); f_returns && f_returns->has_return_value()) {
         if (auto f_returns_call = f_returns->get_return_value()->try_as<ast_function_call>()) {
-          return does_function_satisfy_for_lazy_operator(f_returns_call->fun_maybe, false);
+          return does_function_satisfy_for_lazy_operator(f_returns_call->fun_maybe, false)
+              && fun_ref->inferred_return_type->equal_to(f_returns_call->inferred_type);
         }
       }
     }
@@ -564,9 +565,14 @@ struct LazyVarInFunction {
 
     // handle if `msg` is used only in `match (msg) { ... }`
     // (it may even be not a union, just a struct with opcode, and `match` with `else`)
+    const TypeDataStruct* t_struct = var_ref->declared_type->unwrap_alias()->try_as<TypeDataStruct>();
+    bool is_union = t_struct == nullptr;
     bool used_only_as_match = var_usages.used_for_matching == 1 && !var_usages.used_for_reading && !var_usages.used_for_toCell && !var_usages.used_for_writing && !var_usages.used_reassigned_type;
     bool variants_not_reassigned = std::all_of(var_usages.variants.begin(), var_usages.variants.end(), [](const ExprUsagesWhileCollecting& variant_usages) { return !variant_usages.used_reassigned_type; });
     if (used_only_as_match && variants_not_reassigned) {
+      if (!is_union && var_usages.total_usages_with_fields - var_usages.used_for_matching > var_usages.variants.front().total_usages_with_fields) {
+        err("`lazy` will not work here, because variable `{}` is used both for lazy matching and in a non-lazy manner", var_ref).fire(created_by_lazy_op->keyword_range(), cur_f);
+      }
       v_lazy_match_var_itself = var_usages.used_as_match_subj.front();
       load_points.reserve(var_usages.variants.size());
       for (ExprUsagesWhileCollecting& variant_usages : var_usages.variants) {
@@ -578,13 +584,14 @@ struct LazyVarInFunction {
 
     // okay, variable is used not only as `match`;
     // prohibit this to a union: lazy union may only be matched, nothing more (`msg is A` etc. don't work)
-    const TypeDataStruct* t_struct = var_ref->declared_type->unwrap_alias()->try_as<TypeDataStruct>();
-    bool is_union = t_struct == nullptr;
     if (is_union && used_only_as_match) {
       err("`lazy` will not work here, because variable `{}` changes its type inside `match`\n""hint: probably, it's reassigned, or called a method with a different receiver", var_ref).fire(created_by_lazy_op->keyword_range(), cur_f);
     }
     if (is_union) {
       err("`lazy` will not work here, because variable `{}` is used in a non-lazy manner\n""hint: lazy union may be used only in `match` statement, exactly once", var_ref).fire(created_by_lazy_op->keyword_range(), cur_f);
+    }
+    if (var_usages.used_for_matching) {
+      err("`lazy` will not work here, because variable `{}` is used both for lazy matching and in a non-lazy manner", var_ref).fire(created_by_lazy_op->keyword_range(), cur_f);
     }
 
     // so, it's just a struct, `lazy Point`; we've already calculated all statements where its fields are used
@@ -674,8 +681,10 @@ class CollectUsagesInStatementVisitor final : public ASTVisitorFunctionBody {
         }
 
         // if receiver is another type, e.g. `fun (A|B).method(self)`, called from `match (v) { A => v.method() }`
-        if (!fun_ref->parameters[0].declared_type->equal_to(lazy_expr->expr_type)) {
+        bool receiver_type_matches_lazy_expr = fun_ref->parameters[0].declared_type->equal_to(lazy_expr->expr_type);
+        if (!receiver_type_matches_lazy_expr) {
           lazy_expr->on_used_reassigned_type();
+          lazy_expr->on_used_rw(false);
         }
         // for `obj.f.method()`, mark lazy_expr=obj.f "used" anyway
         if (s_expr.index_path) {    
@@ -683,7 +692,7 @@ class CollectUsagesInStatementVisitor final : public ASTVisitorFunctionBody {
         }
         // if we have `st.save()` / `p.getX()` / `obj.f.method()`, which will be inlined when transforming to IR,
         // dig into that method's body to fetch used fields `self.x` etc.
-        if (can_method_be_inlined_preserving_lazy(fun_ref)) {
+        if (receiver_type_matches_lazy_expr && can_method_be_inlined_preserving_lazy(fun_ref)) {
           auto v_body_block = fun_ref->ast_root->try_as<ast_function_declaration>()->get_body()->try_as<ast_block_statement>();
           ExprUsagesWhileCollecting inner_usages = collect_expr_usages_in_block(lazy_expr->name_str + "(=self)", SinkExpression(&fun_ref->parameters[0]), lazy_expr->expr_type, v_body_block);
           inner_usages.treat_match_like_read();   // nested lazy match in inlined functions doesn't work, it's not wrapped into aux vertex

--- a/tolk/pipe-mini-borrow-checker.cpp
+++ b/tolk/pipe-mini-borrow-checker.cpp
@@ -39,7 +39,8 @@
  *
  *   To track which variables/fields are being mutated, we use is_valid_lvalue_path() with sink collection:
  * it traverses the lvalue path and collects SinkExpression for each "leaf" variable being mutated.
- * For tensors like `(a, b)`, both `a` and `b` are collected. For `(a, b).0`, only `a` is collected.
+ * For tensors like `(a, b)`, both `a` and `b` are collected.
+ * Tensor literal projections like `(a, b).0` are not valid lvalue paths.
  */
 
 namespace tolk {

--- a/tolk/pipe-optimize-boolean-expr.cpp
+++ b/tolk/pipe-optimize-boolean-expr.cpp
@@ -51,6 +51,7 @@ class OptimizerBooleanExpressionsReplacer final : public ASTReplacerInFunctionBo
     auto v_bool = createV<ast_bool_const>(range, bool_val);
     v_bool->assign_inferred_type(TypeDataBool::create());
     v_bool->assign_rvalue_true();
+    v_bool->mutate()->assign_always_true_or_false(bool_val ? 1 : 2);
     return v_bool;
   }
 
@@ -82,6 +83,7 @@ class OptimizerBooleanExpressionsReplacer final : public ASTReplacerInFunctionBo
     if (v->tok == tok_logical_not) {
       // `!!boolVar` => `boolVar` (the inner operand is always bool, integers disallowed by type checker)
       if (auto inner_not = v->get_rhs()->try_as<ast_unary_operator>(); inner_not && inner_not->tok == tok_logical_not) {
+        inner_not->get_rhs()->mutate()->assign_inferred_type(TypeDataBool::create());   // in case it was alias to bool
         return inner_not->get_rhs();
       }
       // `!true` / `!false`
@@ -102,6 +104,7 @@ class OptimizerBooleanExpressionsReplacer final : public ASTReplacerInFunctionBo
       if (expect_boolean(lhs->inferred_type) && rhs->kind == ast_bool_const) {
         // `boolVar == true` / `boolVar != false`
         if (rhs->as<ast_bool_const>()->bool_val ^ (v->tok == tok_neq)) {
+          lhs->mutate()->assign_inferred_type(TypeDataBool::create());    // in case it was alias to bool
           return lhs;
         }
         // `boolVar != true` / `boolVar == false`

--- a/tolk/pipe-resolve-identifiers.cpp
+++ b/tolk/pipe-resolve-identifiers.cpp
@@ -267,7 +267,7 @@ class AssignSymInsideFunctionVisitor final : public ASTVisitorFunctionBody {
 
   void visit(V<ast_block_statement> v) override {
     // function's body block has the same scope as parameters
-    if (v == cur_f->ast_root->as<ast_function_declaration>()->get_body()) {
+    if (cur_f && v == cur_f->ast_root->as<ast_function_declaration>()->get_body()) {
       parent::visit(v);
       return;
     }

--- a/tolk/pipe-resolve-types.cpp
+++ b/tolk/pipe-resolve-types.cpp
@@ -49,6 +49,7 @@ void patch_builtins_after_stdlib_loaded();
  * Example: `type A<T> = Ok<T>`, then `Ok<T>` is not ready yet, it's left as TypeDataGenericTypeWithTs.
  */
 
+// `bool` means: false = symbol is being resolved, true = all type pointers are resolved
 static thread_local std::unordered_map<StructPtr, bool> visited_structs;
 static thread_local std::unordered_map<AliasDefPtr, bool> visited_aliases;
 
@@ -68,6 +69,14 @@ static Error err_never_type_not_allowed_inside_union(TypePtr disallowed_variant)
 
 static Error err_generic_type_used_without_T(const std::string& type_name_with_Ts) {
   return err("type `{}` is generic, you should provide type arguments", type_name_with_Ts);
+}
+
+// having `AliasToInt | int` and similar (invalid duplicate inside a union), show an error
+static void validate_no_invalid_duplicates_in_union(const std::vector<TypeDataUnion::InvalidDuplicateVariant>& invalid_duplicates, FunctionPtr cur_f, SrcRange range) {
+  for (const TypeDataUnion::InvalidDuplicateVariant& duplicate : invalid_duplicates) {
+    err("union variants `{}` and `{}` have the same runtime representation\n""hint: remove one variant or wrap it into a distinct struct",
+        duplicate.existing_variant, duplicate.skipped_variant).fire(range, cur_f);
+  }
 }
 
 static TypePtr parse_intN_uintN(std::string_view strN, bool is_unsigned) {
@@ -236,7 +245,9 @@ class TypeNodesVisitorResolver {
 
       case ast_type_vertical_bar_union: {
         std::vector<TypePtr> variants = finalize_type_node(v->as<ast_type_vertical_bar_union>()->get_variants());
-        TypePtr result = TypeDataUnion::create(std::move(variants));
+        std::vector<TypeDataUnion::InvalidDuplicateVariant> invalid_duplicates;
+        TypePtr result = TypeDataUnion::create(std::move(variants), &invalid_duplicates);
+        validate_no_invalid_duplicates_in_union(invalid_duplicates, cur_f, v->range);
         if (const TypeDataUnion* t_union = result->try_as<TypeDataUnion>()) {
           validate_resulting_union_type(t_union, cur_f, v->range);
         }
@@ -261,10 +272,17 @@ class TypeNodesVisitorResolver {
 
   // given `Wrapper<T>`, ensure that resolving was happened, and struct has genericTs now
   static void ensure_struct_genericTs_resolved(StructPtr struct_ref) {
+    static thread_local std::vector<StructPtr> called_stack;
     if (auto v_genericsT_list = struct_ref->ast_root->as<ast_struct_declaration>()->genericsT_list) {
       if (!struct_ref->genericTs) {
+        bool contains = std::find(called_stack.begin(), called_stack.end(), struct_ref) != called_stack.end();
+        if (contains) {
+          err("type `{}` circularly references itself", struct_ref).fire(struct_ref->ident_anchor);
+        }
+        called_stack.push_back(struct_ref);
         const GenericsDeclaration* genericTs = construct_genericTs(nullptr, v_genericsT_list);
         struct_ref->mutate()->assign_resolved_genericTs(genericTs);
+        called_stack.pop_back();
       }
     }
   }
@@ -276,9 +294,7 @@ class TypeNodesVisitorResolver {
   // example: `var w: KKK`, nullptr will be returned
   static TypePtr try_resolve_user_defined_type(FunctionPtr cur_f, SrcRange range, const Symbol* sym, bool allow_without_type_arguments) {
     if (AliasDefPtr alias_ref = sym->try_as<AliasDefPtr>()) {
-      if (!visited_aliases.contains(alias_ref)) {
-        visit_symbol(alias_ref);
-      }
+      visit_symbol(alias_ref);
       // check AST for genericsT_list, not is_generic_alias()
       // because during mutual recursion in default type arguments, genericTs may not be assigned yet
       bool has_generic_params = alias_ref->ast_root->as<ast_type_alias_declaration>()->genericsT_list != nullptr;
@@ -420,14 +436,14 @@ public:
   }
 
   static void visit_symbol(AliasDefPtr alias_ref) {
-    static thread_local std::vector<AliasDefPtr> called_stack;
-
+    auto [it_visited, inserted] = visited_aliases.insert({alias_ref, false});
     // prevent recursion like `type A = B; type B = A` (we can't create TypeDataAlias without a resolved underlying type)
-    bool contains = std::find(called_stack.begin(), called_stack.end(), alias_ref) != called_stack.end();
-    if (contains) {
-      err("type `{}` circularly references itself", alias_ref).fire(alias_ref->ident_anchor);
+    if (!inserted) {
+      if (!it_visited->second) {
+        err("type `{}` circularly references itself", alias_ref).fire(alias_ref->ident_anchor);
+      }
+      return;
     }
-    called_stack.push_back(alias_ref);
 
     if (auto v_genericsT_list = alias_ref->ast_root->as<ast_type_alias_declaration>()->genericsT_list) {
       const GenericsDeclaration* genericTs = construct_genericTs(nullptr, v_genericsT_list);
@@ -437,12 +453,14 @@ public:
     TypeNodesVisitorResolver visitor(nullptr, alias_ref->genericTs, alias_ref->substitutedTs, false);
     TypePtr underlying_type = visitor.finalize_type_node(alias_ref->underlying_type_node);
     alias_ref->mutate()->assign_resolved_type(underlying_type);
-    visited_aliases.insert({alias_ref, 1});
-    called_stack.pop_back();
+    it_visited->second = true;
   }
 
   static void visit_symbol(StructPtr struct_ref) {
-    visited_structs.insert({struct_ref, 1});
+    auto [it_visited, inserted] = visited_structs.insert({struct_ref, false});
+    if (!inserted) {
+      return;
+    }
 
     ensure_struct_genericTs_resolved(struct_ref);
 
@@ -459,6 +477,7 @@ public:
         field_ref->mutate()->assign_resolved_abi_type(abi_client_type);
       }
     }
+    it_visited->second = true;
   }
 
   static const GenericsDeclaration* construct_genericTs(TypePtr receiver_type, V<ast_genericsT_list> v_list) {
@@ -756,8 +775,17 @@ class InfiniteStructSizeDetector {
     }
 
     // Some nominal references intentionally defer struct fields until a later top-level pass.
-    if (!visited_structs.contains(struct_ref)) {
+    auto it_visited = visited_structs.find(struct_ref);
+    if (it_visited == visited_structs.end()) {
       TypeNodesVisitorResolver::visit_symbol(struct_ref);
+      it_visited = visited_structs.find(struct_ref);
+    }
+    tolk_assert(it_visited != visited_structs.end());
+
+    if (!it_visited->second) {
+      // a generic instantiation can discover another generic struct while an outer struct
+      // is still resolving its own fields; after the graph becomes complete, it will be re-visited
+      return;
     }
 
     called_stack.push_back(struct_ref);
@@ -803,14 +831,10 @@ void pipeline_resolve_types_and_aliases() {
         visitor.start_visiting_constant(v_const->const_ref);
 
       } else if (auto v_alias = v->try_as<ast_type_alias_declaration>()) {
-        if (!visited_aliases.contains(v_alias->alias_ref)) {
-          TypeNodesVisitorResolver::visit_symbol(v_alias->alias_ref);
-        }
+        TypeNodesVisitorResolver::visit_symbol(v_alias->alias_ref);
 
       } else if (auto v_struct = v->try_as<ast_struct_declaration>()) {
-        if (!visited_structs.contains(v_struct->struct_ref)) {
-          TypeNodesVisitorResolver::visit_symbol(v_struct->struct_ref);
-        }
+        TypeNodesVisitorResolver::visit_symbol(v_struct->struct_ref);
         visitor.start_visiting_struct_fields(v_struct->struct_ref);
 
       } else if (auto v_enum = v->try_as<ast_enum_declaration>()) {

--- a/tolk/smart-casts-cfg.cpp
+++ b/tolk/smart-casts-cfg.cpp
@@ -260,7 +260,7 @@ BoolState calculate_bool_lca(BoolState a, BoolState b) {
 // but `var v: HINT = <same>` is okay, if hint is valid;
 // for instance, `var v: int = cond ? someInt32 : someInt64` is ok: no unification
 TypeInferringUnifyStrategy::TypeInferringUnifyStrategy(TypePtr hint) {
-  bool is_valid_hint = hint != nullptr && hint != TypeDataNotInferred::create() && hint != TypeDataUnknown::create() && !hint->has_genericT_inside();
+  bool is_valid_hint = hint != nullptr && hint != TypeDataUnknown::create() && !hint->has_not_inferred_inside() && !hint->has_genericT_inside();
   if (is_valid_hint) {
     dest_hint = hint;
   }
@@ -516,7 +516,7 @@ SinkExpression extract_sink_expression_from_vertex(AnyExprV v) {
 // Its main property: "safe to be re-evaluated" while transforming AST to IR.
 // Valid: `v` / `v.field` / `v.0!.nested` / `(a, b)`
 //        (all can be used as `lvalue = rhs` / `f(mutate lvalue)` / `lvalue.mutatingMethod()`)
-// Invalid: `v.id().field` / `(v = rhs).field` / `Point{x,y}.x`
+// Invalid: `v.id().field` / `(v = rhs).field` / `Point{x,y}.x` / `(a, b).0`
 //        (none can be used as lvalue, for example `Point{x,y}.x = 100` is denied)
 //
 // It's conceptually similar to extract_sink_expression_from_vertex, but NOT the same:
@@ -554,12 +554,9 @@ bool is_valid_lvalue_path(AnyExprV v, std::vector<SinkExpression>* out_sinks, bo
     int index_at = as_dot->is_target_indexed_access()
         ? std::get<int>(as_dot->target)
         : std::get<StructFieldPtr>(as_dot->target)->field_idx;
-    // for `(a, b).0`, resolve `a`; for `tensorVar.0`, resolve `tensorVar` (just continue forward)
-    if (as_dot->is_target_indexed_access()) {
-      AnyExprV obj = unwrap_not_null_operator(as_dot->get_obj());
-      if (auto as_tensor = obj->try_as<ast_tensor>()) {
-        return is_valid_lvalue_path(as_tensor->get_item(index_at), out_sinks);
-      }
+    // deny `(a, b).0` as lvalue, but allow `tensorVar.0`
+    if (unwrap_not_null_operator(as_dot->get_obj())->try_as<ast_tensor>()) {
+      return false;
     }
     std::vector<SinkExpression> inner_sinks;
     bool inner_valid = is_valid_lvalue_path(as_dot->get_obj(), &inner_sinks, true);

--- a/tolk/tolk-main.cpp
+++ b/tolk/tolk-main.cpp
@@ -237,21 +237,24 @@ td::Result<std::string> fs_read_callback(CompilerSettings::FsReadCallbackKind ki
       return res_realpath;
     }
     case CompilerSettings::FsReadCallbackKind::ReadFile: {
-      struct stat f_stat;
-      int res = stat(query, &f_stat);   // query here is already resolved realpath
-      if (res != 0 || (f_stat.st_mode & S_IFMT) != S_IFREG) {
+      // query here is already resolved realpath
+      std::ifstream ifs(query, std::ios::binary | std::ios::ate);
+      if (!ifs) {
         return td::Status::Error(std::string{"cannot open file "} + query);
       }
 
-      size_t file_size = static_cast<size_t>(f_stat.st_size);
-      std::string str;
-      str.resize(file_size);
-      FILE* f = fopen(query, "rb");
-      if (!f) {
-        return td::Status::Error(std::string{"cannot open file "} + query);
+      std::streampos end_pos = ifs.tellg();
+      if (end_pos == std::ifstream::pos_type(-1)) {
+        return td::Status::Error(std::string{"cannot read file "} + query);
       }
-      fread(str.data(), file_size, 1, f);
-      fclose(f);
+
+      std::string str;
+      str.resize(static_cast<size_t>(end_pos));
+      ifs.seekg(0, std::ios::beg);
+      ifs.read(str.data(), static_cast<std::streamsize>(str.size()));
+      if (!ifs) {
+        return td::Status::Error(std::string{"cannot read file "} + query);
+      }
       return std::move(str);
     }
     default: {

--- a/tolk/tolk-version.h
+++ b/tolk/tolk-version.h
@@ -18,6 +18,6 @@
 
 namespace tolk {
 
-constexpr const char* TOLK_VERSION = "1.4.0";
+constexpr const char* TOLK_VERSION = "1.4.1";
 
 } // namespace tolk

--- a/tolk/tolk.h
+++ b/tolk/tolk.h
@@ -887,7 +887,7 @@ struct Stack {
   void forget_const();
   void validate(int i) const {
     if (i > 255) {
-      throw Fatal("Too deep stack");
+      throw TooDeepStackFatal();
     }
     tolk_assert(i >= 0 && i < depth() && "invalid stack reference");
   }

--- a/tolk/type-system.cpp
+++ b/tolk/type-system.cpp
@@ -217,19 +217,19 @@ TypePtr TypeDataBitsN::create(int n_width, bool is_bits) {
   return new TypeDataBitsN(n_width, is_bits);
 }
 
-TypePtr TypeDataUnion::create(std::vector<TypePtr>&& variants) {
+TypePtr TypeDataUnion::create(std::vector<TypePtr>&& variants, std::vector<InvalidDuplicateVariant>* out_invalid_duplicates) {
   // flatten variants and remove duplicates
   // note, that `int | slice` and `int | int | slice` are different TypePtr, but actually the same variants;
-  // note, that `UserId | OwnerId` (both are aliases to `int`) will emit `UserId` (OwnerId is a duplicate)
+  // note that `AliasToInt | int` is rejected: out_invalid_duplicates is filled, and fired while resolving AST types
   std::vector<TypePtr> flat_variants;
   flat_variants.reserve(variants.size());
   for (TypePtr variant : variants) {
     if (const TypeDataUnion* nested_union = variant->unwrap_alias()->try_as<TypeDataUnion>()) {
       for (TypePtr nested_variant : nested_union->variants) {
-        append_union_type_variant(nested_variant, flat_variants);
+        append_union_type_variant(nested_variant, flat_variants, out_invalid_duplicates);
       }
     } else {
-      append_union_type_variant(variant, flat_variants);
+      append_union_type_variant(variant, flat_variants, out_invalid_duplicates);
     }
   }
   // detect, whether it's `T?` or `T1 | T2 | ...`
@@ -1253,6 +1253,10 @@ bool TypeDataAlias::can_hold_tvm_null_instead() const {
   return underlying_type->can_hold_tvm_null_instead();
 }
 
+bool TypeDataNullLiteral::can_hold_tvm_null_instead() const {
+  return false;
+}
+
 bool TypeDataStruct::can_hold_tvm_null_instead() const {
   if (get_width_on_stack() != 1) {    // example that can hold null: `{ field: int }`
     return false;                     // another example: `{ e: Empty, field: ((), int) }`
@@ -1467,13 +1471,16 @@ bool TypeDataMapKV::equal_to(TypePtr rhs) const {
 }
 
 
-// union types creation is a bit tricky: nested unions are flattened, duplicates are removed
-// so, a resolved union type has variants, each will be assigned a unique type_id (tagged unions)
-void TypeDataUnion::append_union_type_variant(TypePtr variant, std::vector<TypePtr>& out_unique_variants) {
-  // having `UserId | OwnerId` (both are aliases to `int`) merge them into just `UserId`, because underlying are equal
+void TypeDataUnion::append_union_type_variant(TypePtr variant, std::vector<TypePtr>& out_unique_variants, std::vector<InvalidDuplicateVariant>* out_invalid_duplicates) {
   TypePtr underlying_variant = variant->unwrap_alias();
   for (TypePtr existing : out_unique_variants) {
     if (existing->equal_to(underlying_variant)) {
+      // we allow `int | int`, but disallow `AliasToInt | int` as identical runtime representation;
+      // the same disallows `Wrapper<int|slice> | Wrapper<slice|int>`
+      bool is_invalid = existing->as_human_readable() != variant->as_human_readable();
+      if (out_invalid_duplicates && is_invalid) {
+        out_invalid_duplicates->emplace_back(existing, variant);
+      }
       return;
     }
   }

--- a/tolk/type-system.h
+++ b/tolk/type-system.h
@@ -74,6 +74,7 @@ protected:
     flag_contains_genericT_inside = 1 << 2,
     flag_contains_type_alias_inside = 1 << 3,
     flag_contains_mapKV_inside = 1 << 4,
+    flag_contains_not_inferred_inside = 1 << 5,
   };
 
   explicit TypeData(int flags_with_children)
@@ -102,6 +103,7 @@ public:
   bool has_genericT_inside() const { return flags & flag_contains_genericT_inside; }
   bool has_type_alias_inside() const { return flags & flag_contains_type_alias_inside; }
   bool has_mapKV_inside() const { return flags & flag_contains_mapKV_inside; }
+  bool has_not_inferred_inside() const { return flags & flag_contains_not_inferred_inside; }
 
   using ReplacerCallbackT = std::function<TypePtr(TypePtr child)>;
 
@@ -394,6 +396,7 @@ public:
   void as_abi_json(std::string& out, JsonTypeExporter& registry) const override;
   bool can_rhs_be_assigned(TypePtr rhs) const override;
   bool can_be_casted_with_as_operator(TypePtr cast_to) const override;
+  bool can_hold_tvm_null_instead() const override;
 };
 
 /*
@@ -641,22 +644,32 @@ public:
  * - `T | null`, if T is 1 slot  (like `int | null`), then it's still 1 slot
  * - `T | null`, if T is N slots (like `(int, int)?`), it's stored as N+1 slots (the last for type_id if T or 0 if null)
  * - `T1 | T2 | ...` is a tagged union: occupy max(T_i)+1 slots (1 for type_id)
- * When a union is created, variants are flattened, duplicates are removed: `int | UserId | IntOrSlice` = `int | slice`,
- * duplicates are detected based on `equal_to()`, and a union can be tested on having `has_variant_equal_to()`.
+ * When a union is created, variants are flattened, duplicates are removed: `int | int | IntOrSlice` = `int | slice`.
+ * Duplicates are detected based on `equal_to()`, and a union can be tested on having `has_variant_equal_to()`.
+ * Unions with indistinguishable aliases, like `AliasToInt | int`, are rejected while resolving AST types.
  */
 class TypeDataUnion final : public TypeData {
+public:
+  // when flattening `int | AliasToInt` based on equal_to, this contains invalid duplicates;
+  // note: `int | int` is valid, it's just `int`, not added here
+  struct InvalidDuplicateVariant {
+    TypePtr existing_variant;   // `int` (variant already added)
+    TypePtr skipped_variant;    // `AliasToInt` (not added, it's a duplicate)
+  };
+
+private:
   TypeDataUnion(int children_flags, TypePtr or_null, std::vector<TypePtr>&& variants)
     : TypeData(children_flags)
     , or_null(or_null)
     , variants(std::move(variants)) {}
 
-  static void append_union_type_variant(TypePtr variant, std::vector<TypePtr>& out_unique_variants);
+  static void append_union_type_variant(TypePtr variant, std::vector<TypePtr>& out_unique_variants, std::vector<InvalidDuplicateVariant>* out_invalid_duplicates);
 
 public:
   const TypePtr or_null;                  // if `T | null`, then T is here (variants = [T, null] then); otherwise, nullptr
   const std::vector<TypePtr> variants;    // T_i, flattened, no duplicates; may include aliases, but not other unions
 
-  static TypePtr create(std::vector<TypePtr>&& variants);
+  static TypePtr create(std::vector<TypePtr>&& variants, std::vector<InvalidDuplicateVariant>* out_invalid_duplicates = nullptr);
   static TypePtr create_nullable(TypePtr nullable) { return create({nullable, TypeDataNullLiteral::create()}); }
 
   int size() const { return static_cast<int>(variants.size()); }
@@ -745,7 +758,7 @@ public:
  * For example, `var (a, b, c) = (1, 2)`, `c` will be left "not inferred" and fired at type checking.
  */
 class TypeDataNotInferred final : public TypeData {
-  TypeDataNotInferred() : TypeData(0) {}
+  TypeDataNotInferred() : TypeData(flag_contains_not_inferred_inside) {}
 
   static TypePtr singleton;
   friend void type_system_init();


### PR DESCRIPTION
This is a minor update covering various corner cases.

- allow string literals more than 32k symbols
- correctly handle CR/CRLF line endings
- prohibit degenerated unions like `int | AliasInt` indistingushable at runtime
- prevent a couple of compiler crashes when using `lazy` incorrectly
- fixes for tricky cases with assignments inside conditions
- disallow `(a,b).0` to be a valid lvalue anymore
- preserve `asm` functions as-is, don't involve them in peephole optimizations
- better handle too deep functions reaching TVM stack limit

MR to tolk-js:
* https://github.com/ton-blockchain/tolk-js/pull/20

Acton v1.1 will contain Tolk v1.4.1