### PR TITLE
VLOG categories

### DIFF
--- a/adnl/adnl-address-list.cpp
+++ b/adnl/adnl-address-list.cpp
@@ -59,12 +59,12 @@ class AdnlNetworkConnectionTunnel : public AdnlNetworkConnection {
  public:
   void send(AdnlNodeIdShort src, AdnlNodeIdShort dst, td::uint32 priority, td::BufferSlice message) override {
     if (!encryptor_) {
-      VLOG(ADNL_INFO) << "tunnel: message [" << src << "->" << dst << "to bad tunnel. dropping";
+      VLOG(adnl, INFO) << "tunnel: message [" << src << "->" << dst << "to bad tunnel. dropping";
       return;
     }
     auto dataR = encryptor_->encrypt(message.as_slice());
     if (dataR.is_error()) {
-      VLOG(ADNL_INFO) << "tunnel: message [" << src << "->" << dst << ": failed to encrypt: " << dataR.move_as_error();
+      VLOG(adnl, INFO) << "tunnel: message [" << src << "->" << dst << ": failed to encrypt: " << dataR.move_as_error();
       return;
     }
     auto data = dataR.move_as_ok();
@@ -85,7 +85,7 @@ class AdnlNetworkConnectionTunnel : public AdnlNetworkConnection {
   void start_up() override {
     auto R = pub_key_.create_encryptor();
     if (R.is_error()) {
-      VLOG(ADNL_INFO) << "tunnel: bad public key: " << R.move_as_error();
+      VLOG(adnl, INFO) << "tunnel: bad public key: " << R.move_as_error();
       return;
     }
     encryptor_ = R.move_as_ok();

--- a/adnl/adnl-address-list.cpp
+++ b/adnl/adnl-address-list.cpp
@@ -24,6 +24,10 @@
 #include "adnl-address-list.hpp"
 #include "adnl-peer-table.h"
 
+// Defined in this light translation unit so that pulling the category definition into a static link
+// does not drag in the peer-table object and, through it, adnl's optional dht dependency.
+DEFINE_LOG_CATEGORY(adnl, VERBOSITY_NAME(WARNING))
+
 namespace ton {
 
 namespace adnl {

--- a/adnl/adnl-channel.cpp
+++ b/adnl/adnl-channel.cpp
@@ -79,7 +79,7 @@ AdnlChannelImpl::AdnlChannelImpl(AdnlNodeIdShort local_id, AdnlNodeIdShort peer_
 
   peer_pair_ = peer_pair;
 
-  VLOG(ADNL_INFO) << this << ": created";
+  VLOG(adnl, INFO) << this << ": created";
 }
 
 void AdnlChannelImpl::decrypt(td::BufferSlice raw_data, td::Promise<AdnlPacket> promise) {
@@ -99,7 +99,7 @@ void AdnlChannelImpl::send_message(td::uint32 priority, td::actor::ActorId<AdnlN
                                    td::BufferSlice data) {
   auto E = encryptor_->encrypt(data.as_slice());
   if (E.is_error()) {
-    VLOG(ADNL_ERROR) << this << ": dropping OUT message: can not encrypt: " << E.move_as_error();
+    VLOG(adnl, ERROR) << this << ": dropping OUT message: can not encrypt: " << E.move_as_error();
     return;
   }
   auto enc = E.move_as_ok();
@@ -115,7 +115,7 @@ void AdnlChannelImpl::receive(td::IPAddress addr, td::BufferSlice data) {
   auto P = td::PromiseCreator::lambda([peer = peer_pair_, channel_id = channel_in_id_, addr, id = print_id(),
                                        size = data.size()](td::Result<AdnlPacket> R) {
     if (R.is_error()) {
-      VLOG(ADNL_WARNING) << id << ": dropping IN message: can not decrypt: " << R.move_as_error();
+      VLOG(adnl, WARNING) << id << ": dropping IN message: can not decrypt: " << R.move_as_error();
     } else {
       auto packet = R.move_as_ok();
       packet.set_remote_addr(addr);

--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -48,7 +48,7 @@ void AdnlLocalId::receive(td::IPAddress addr, td::BufferSlice data) {
   [](AdnlLocalId *self, td::IPAddress addr, td::BufferSlice data) -> td::actor::Task<> {
     auto R = co_await self->receive_coro(addr, std::move(data)).wrap();
     if (R.is_error()) {
-      VLOG(ADNL_NOTICE) << self << ": dropping IN message from " << addr << ": " << R.move_as_error();
+      VLOG(adnl, INFO) << self << ": dropping IN message from " << addr << ": " << R.move_as_error();
     }
     co_return {};
   }(this, std::move(addr), std::move(data))
@@ -104,8 +104,8 @@ void AdnlLocalId::deliver(AdnlNodeIdShort src, td::BufferSlice data) {
       return;
     }
   }
-  VLOG(ADNL_INFO) << this << ": dropping IN message from " << src
-                  << ": no callbacks for custom message. firstint=" << td::TlParser(s.as_slice()).fetch_int();
+  VLOG(adnl, INFO) << this << ": dropping IN message from " << src
+                   << ": no callbacks for custom message. firstint=" << td::TlParser(s.as_slice()).fetch_int();
 }
 
 void AdnlLocalId::deliver_query(AdnlNodeIdShort src, td::BufferSlice data, td::Promise<td::BufferSlice> promise) {
@@ -117,8 +117,8 @@ void AdnlLocalId::deliver_query(AdnlNodeIdShort src, td::BufferSlice data, td::P
       return;
     }
   }
-  VLOG(ADNL_INFO) << this << ": dropping IN message from " << src
-                  << ": no callbacks for custom query. firstint=" << td::TlParser(s.as_slice()).fetch_int();
+  VLOG(adnl, INFO) << this << ": dropping IN message from " << src
+                   << ": no callbacks for custom query. firstint=" << td::TlParser(s.as_slice()).fetch_int();
   promise.set_error(td::Status::Error(ErrorCode::warning, PSTRING() << "dropping IN message from " << src
                                                                     << ": no callbacks for custom query. firstint="
                                                                     << td::TlParser(s.as_slice()).fetch_int()));
@@ -155,14 +155,14 @@ void AdnlLocalId::update_address_list(AdnlAddressList addr_list) {
   addr_list_.set_reinit_date(Adnl::adnl_start_time());
   addr_list_.set_version(static_cast<td::int32>(td::Clocks::system()));
 
-  VLOG(ADNL_INFO) << this << ": updated addr list. New version set to " << addr_list_.version();
+  VLOG(adnl, INFO) << this << ": updated addr list. New version set to " << addr_list_.version();
 
   publish_address_list();
 }
 
 void AdnlLocalId::publish_address_list() {
   if (dht_node_.empty() || addr_list_.empty() || (addr_list_.size() == 0 && !addr_list_.has_reverse())) {
-    VLOG(ADNL_NOTICE) << this << ": skipping public addr list, because localid (or dht node) not fully initialized";
+    VLOG(adnl, INFO) << this << ": skipping public addr list, because localid (or dht node) not fully initialized";
     return;
   }
 
@@ -201,9 +201,9 @@ void AdnlLocalId::publish_address_list() {
 
           auto E = td::PromiseCreator::lambda([print_id](td::Result<td::Unit> R) {
             if (R.is_error()) {
-              VLOG(ADNL_NOTICE) << print_id << ": failed to update addr list in DHT: " << R.move_as_error();
+              VLOG(adnl, INFO) << print_id << ": failed to update addr list in DHT: " << R.move_as_error();
             } else {
-              VLOG(ADNL_INFO) << print_id << ": updated dht addr list";
+              VLOG(adnl, INFO) << print_id << ": updated dht addr list";
             }
           });
 
@@ -220,9 +220,9 @@ void AdnlLocalId::publish_address_list() {
     td::actor::send_closure(
         dht_node_, &dht::Dht::register_reverse_connection, id_, [print_id = print_id()](td::Result<td::Unit> R) {
           if (R.is_error()) {
-            VLOG(ADNL_NOTICE) << print_id << ": failed to register reverse connection in DHT: " << R.move_as_error();
+            VLOG(adnl, INFO) << print_id << ": failed to register reverse connection in DHT: " << R.move_as_error();
           } else {
-            VLOG(ADNL_INFO) << print_id << ": registered reverse connection";
+            VLOG(adnl, INFO) << print_id << ": registered reverse connection";
           }
         });
   }
@@ -243,7 +243,7 @@ AdnlLocalId::AdnlLocalId(AdnlNodeIdFull id, AdnlAddressList addr_list, td::uint3
     addr_list_.set_version(static_cast<td::int32>(td::Clocks::system()));
   }
 
-  VLOG(ADNL_INFO) << this << ": created local id " << short_id_;
+  VLOG(adnl, INFO) << this << ": created local id " << short_id_;
 }
 
 void AdnlLocalId::get_self_node(td::Promise<AdnlNode> promise) {

--- a/adnl/adnl-network-manager.cpp
+++ b/adnl/adnl-network-manager.cpp
@@ -94,32 +94,32 @@ void AdnlNetworkManagerImpl::receive_udp_message(td::UdpMessage message, size_t 
     return;
   }
   if (message.error.is_error()) {
-    VLOG(ADNL_WARNING) << this << ": dropping ERROR message: " << message.error;
+    VLOG(adnl, WARNING) << this << ": dropping ERROR message: " << message.error;
     return;
   }
   if (message.data.size() < 32) {
-    VLOG(ADNL_WARNING) << this << ": received too small packet of size " << message.data.size();
+    VLOG(adnl, WARNING) << this << ": received too small packet of size " << message.data.size();
     return;
   }
   if (message.data.size() >= get_mtu() + 128) {
-    VLOG(ADNL_NOTICE) << this << ": received huge packet of size " << message.data.size();
+    VLOG(adnl, INFO) << this << ": received huge packet of size " << message.data.size();
   }
   CHECK(idx < udp_sockets_.size());
   auto &socket = udp_sockets_[idx];
   if (socket.in_desc == std::numeric_limits<size_t>::max()) {
-    VLOG(ADNL_WARNING) << this << ": received packet to port without InDesc";
+    VLOG(adnl, WARNING) << this << ": received packet to port without InDesc";
     return;
   }
   AdnlCategoryMask cat_mask = in_desc_[socket.in_desc].cat_mask;
   if (message.data.size() >= get_mtu()) {
-    VLOG(ADNL_NOTICE) << this << ": received huge packet of size " << message.data.size();
+    VLOG(adnl, INFO) << this << ": received huge packet of size " << message.data.size();
   }
   received_messages_++;
   if (received_messages_ % 64 == 0) {
-    VLOG(ADNL_DEBUG) << this << ": received " << received_messages_ << " udp messages";
+    VLOG(adnl, DEBUG) << this << ": received " << received_messages_ << " udp messages";
   }
 
-  VLOG(ADNL_EXTRA_DEBUG) << this << ": received message of size " << message.data.size();
+  VLOG(adnl, DEBUG) << this << ": received message of size " << message.data.size();
   callback_->receive_packet(message.address, cat_mask, std::move(message.data));
 }
 
@@ -127,13 +127,13 @@ void AdnlNetworkManagerImpl::send_udp_packet(AdnlNodeIdShort src_id, AdnlNodeIdS
                                              td::uint32 priority, td::BufferSlice data) {
   auto it = adnl_id_2_cat_.find(src_id);
   if (it == adnl_id_2_cat_.end()) {
-    VLOG(ADNL_WARNING) << this << ": dropping OUT message [" << src_id << "->" << dst_id << "]: unknown src";
+    VLOG(adnl, WARNING) << this << ": dropping OUT message [" << src_id << "->" << dst_id << "]: unknown src";
     return;
   }
 
   auto out = choose_out_iface(it->second, priority);
   if (!out) {
-    VLOG(ADNL_WARNING) << this << ": dropping OUT message [" << src_id << "->" << dst_id << "]: no out rules";
+    VLOG(adnl, WARNING) << this << ": dropping OUT message [" << src_id << "->" << dst_id << "]: no out rules";
     return;
   }
 

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -31,6 +31,8 @@
 #include "adnl-tunnel.h"
 #include "utils.hpp"
 
+DEFINE_LOG_CATEGORY(adnl, VERBOSITY_NAME(WARNING))
+
 namespace ton {
 
 namespace adnl {
@@ -51,7 +53,7 @@ td::actor::ActorOwn<Adnl> Adnl::create(std::string db, td::actor::ActorId<keyrin
 
 void AdnlPeerTableImpl::receive_packet(td::IPAddress addr, AdnlCategoryMask cat_mask, td::BufferSlice data) {
   if (data.size() < 32) {
-    VLOG(ADNL_WARNING) << this << ": dropping IN message [?->?]: message too short: len=" << data.size();
+    VLOG(adnl, WARNING) << this << ": dropping IN message [?->?]: message too short: len=" << data.size();
     return;
   }
 
@@ -61,7 +63,7 @@ void AdnlPeerTableImpl::receive_packet(td::IPAddress addr, AdnlCategoryMask cat_
   auto it = local_ids_.find(dst);
   if (it != local_ids_.end()) {
     if (!cat_mask.test(it->second.cat)) {
-      VLOG(ADNL_WARNING) << this << ": dropping IN message [?->" << dst << "]: category mismatch";
+      VLOG(adnl, WARNING) << this << ": dropping IN message [?->" << dst << "]: category mismatch";
       return;
     }
     td::actor::send_closure(it->second.local_id, &AdnlLocalId::receive, addr, std::move(data));
@@ -72,15 +74,15 @@ void AdnlPeerTableImpl::receive_packet(td::IPAddress addr, AdnlCategoryMask cat_
   auto it2 = channels_.find(dst_chan_id);
   if (it2 != channels_.end()) {
     if (!cat_mask.test(it2->second.second)) {
-      VLOG(ADNL_WARNING) << this << ": dropping IN message to channel [?->" << dst << "]: category mismatch";
+      VLOG(adnl, WARNING) << this << ": dropping IN message to channel [?->" << dst << "]: category mismatch";
       return;
     }
     td::actor::send_closure(it2->second.first, &AdnlChannel::receive, addr, std::move(data));
     return;
   }
 
-  VLOG(ADNL_DEBUG) << this << ": dropping IN message [?->" << dst << "]: unknown dst " << dst
-                   << " (len=" << (data.size() + 32) << ")";
+  VLOG(adnl, DEBUG) << this << ": dropping IN message [?->" << dst << "]: unknown dst " << dst
+                    << " (len=" << (data.size() + 32) << ")";
 }
 
 void AdnlPeerTableImpl::update_id(AdnlPeerTableImpl::PeerInfo &peer_info, AdnlNodeIdFull &&peer_id) {
@@ -124,7 +126,7 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
   packet.run_basic_checks().ensure();
 
   if (!packet.inited_from_short()) {
-    VLOG(ADNL_INFO) << this << ": dropping IN message [?->" << dst << "]: destination not set";
+    VLOG(adnl, INFO) << this << ": dropping IN message [?->" << dst << "]: destination not set";
     return;
   }
   AdnlNodeIdShort src = packet.from_short();
@@ -132,13 +134,13 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
   auto it = peers_.find(src);
   if (it == peers_.end()) {
     if (!packet.inited_from()) {
-      VLOG(ADNL_NOTICE) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                        << "]: unknown peer and no full src in packet";
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: unknown peer and no full src in packet";
       return;
     }
     if (network_manager_.empty()) {
-      VLOG(ADNL_NOTICE) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                        << "]: unknown peer and network manager uninitialized";
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: unknown peer and network manager uninitialized";
       return;
     }
 
@@ -147,8 +149,8 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
 
   auto it2 = local_ids_.find(dst);
   if (it2 == local_ids_.end()) {
-    VLOG(ADNL_ERROR) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                     << "]: unknown dst (but how did we decrypt message?)";
+    VLOG(adnl, ERROR) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                      << "]: unknown dst (but how did we decrypt message?)";
     return;
   }
 
@@ -162,7 +164,7 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
 
 void AdnlPeerTableImpl::add_peer(AdnlNodeIdShort local_id, AdnlNodeIdFull id, AdnlAddressList addr_list) {
   auto id_short = id.compute_short_id();
-  VLOG(ADNL_DEBUG) << this << ": adding peer " << id_short << " for local id " << local_id;
+  VLOG(adnl, DEBUG) << this << ": adding peer " << id_short << " for local id " << local_id;
 
   auto it2 = local_ids_.find(local_id);
   CHECK(it2 != local_ids_.end());
@@ -178,7 +180,7 @@ void AdnlPeerTableImpl::add_peer(AdnlNodeIdShort local_id, AdnlNodeIdFull id, Ad
 void AdnlPeerTableImpl::add_static_nodes_from_config(AdnlNodesList nodes) {
   for (auto &node : nodes.nodes()) {
     auto id_short = node.compute_short_id();
-    VLOG(ADNL_INFO) << "[staticnodes] adding static node " << id_short;
+    VLOG(adnl, INFO) << "[staticnodes] adding static node " << id_short;
     static_nodes_.emplace(id_short, std::move(node));
   }
 }
@@ -211,8 +213,8 @@ void AdnlPeerTableImpl::answer_query(AdnlNodeIdShort src, AdnlNodeIdShort dst, A
 void AdnlPeerTableImpl::send_query(AdnlNodeIdShort src, AdnlNodeIdShort dst, std::string name,
                                    td::Promise<td::BufferSlice> promise, td::Timestamp timeout, td::BufferSlice data) {
   if (data.size() > huge_packet_max_size()) {
-    VLOG(ADNL_WARNING) << "dropping too big packet [" << src << "->" << dst << "]: size=" << data.size();
-    VLOG(ADNL_WARNING) << "DUMP: " << td::buffer_to_hex(data.as_slice().truncate(128));
+    VLOG(adnl, WARNING) << "dropping too big packet [" << src << "->" << dst << "]: size=" << data.size();
+    VLOG(adnl, WARNING) << "DUMP: " << td::buffer_to_hex(data.as_slice().truncate(128));
     return;
   }
 
@@ -230,7 +232,7 @@ void AdnlPeerTableImpl::send_query(AdnlNodeIdShort src, AdnlNodeIdShort dst, std
 void AdnlPeerTableImpl::add_id_ex(AdnlNodeIdFull id, AdnlAddressList addr_list, td::uint8 cat, td::uint32 mode) {
   CHECK(id.pubkey().is_ed25519());
   auto a = id.compute_short_id();
-  VLOG(ADNL_INFO) << "adnl: adding local id " << a;
+  VLOG(adnl, INFO) << "adnl: adding local id " << a;
 
   auto it = local_ids_.find(a);
 
@@ -254,7 +256,7 @@ void AdnlPeerTableImpl::add_id_ex(AdnlNodeIdFull id, AdnlAddressList addr_list, 
 }
 
 void AdnlPeerTableImpl::del_id(AdnlNodeIdShort id, td::Promise<td::Unit> promise) {
-  VLOG(ADNL_INFO) << "adnl: deleting local id " << id;
+  VLOG(adnl, INFO) << "adnl: deleting local id " << id;
   local_ids_.erase(id);
   promise.set_value(td::Unit());
 }
@@ -473,8 +475,8 @@ void AdnlPeerTableImpl::get_stats_peer(AdnlNodeIdShort peer_id, AdnlPeerTableImp
         peer_pair.actor, &AdnlPeerPair::get_stats, all,
         [local_id = local_id, peer_id = peer_id, callback](td::Result<tl_object_ptr<ton_api::adnl_stats_peerPair>> R) {
           if (R.is_error()) {
-            VLOG(ADNL_NOTICE) << "failed to get stats for peer pair " << peer_id << "->" << local_id << " : "
-                              << R.move_as_error();
+            VLOG(adnl, INFO) << "failed to get stats for peer pair " << peer_id << "->" << local_id << " : "
+                             << R.move_as_error();
             td::actor::send_closure(callback, &Cb::dec_pending);
           } else {
             td::actor::send_closure(callback, &Cb::got_peer_pair_stats, R.move_as_ok());
@@ -542,7 +544,7 @@ void AdnlPeerTableImpl::get_stats(bool all, td::Promise<tl_object_ptr<ton_api::a
     td::actor::send_closure(local_id.local_id, &AdnlLocalId::get_stats, all,
                             [id = id, callback](td::Result<tl_object_ptr<ton_api::adnl_stats_localId>> R) {
                               if (R.is_error()) {
-                                VLOG(ADNL_NOTICE)
+                                VLOG(adnl, INFO)
                                     << "failed to get stats for local id " << id << " : " << R.move_as_error();
                                 td::actor::send_closure(callback, &Cb::dec_pending);
                               } else {
@@ -555,7 +557,7 @@ void AdnlPeerTableImpl::get_stats(bool all, td::Promise<tl_object_ptr<ton_api::a
     get_stats_peer(id, peer, all,
                    [id = id, callback](td::Result<std::vector<tl_object_ptr<ton_api::adnl_stats_peerPair>>> R) {
                      if (R.is_error()) {
-                       VLOG(ADNL_NOTICE) << "failed to get stats for peer " << id << " : " << R.move_as_error();
+                       VLOG(adnl, INFO) << "failed to get stats for peer " << id << " : " << R.move_as_error();
                        td::actor::send_closure(callback, &Cb::dec_pending);
                      } else {
                        td::actor::send_closure(callback, &Cb::got_peer_stats, R.move_as_ok());
@@ -599,7 +601,7 @@ void AdnlPeerTableImpl::gc_peer_pairs(AdnlNodeIdShort local_id, LocalIdInfo &loc
   while (local_id_info.peers_gc_order.size() > MAX_IDLE_PEER_PAIRS) {
     auto it = local_id_info.peers_gc_order.begin();
     AdnlNodeIdShort gc_peer_id = it->second;
-    VLOG(ADNL_NOTICE) << "Removing idle peer pair l_id=" << local_id << " p_id=" << gc_peer_id;
+    VLOG(adnl, INFO) << "Removing idle peer pair l_id=" << local_id << " p_id=" << gc_peer_id;
     peers_[gc_peer_id].peers.erase(local_id);
     if (peers_[gc_peer_id].peers.empty()) {
       // FIXME: if PeerInfo is empty from the start, it won't be erased ever

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -31,8 +31,6 @@
 #include "adnl-tunnel.h"
 #include "utils.hpp"
 
-DEFINE_LOG_CATEGORY(adnl, VERBOSITY_NAME(WARNING))
-
 namespace ton {
 
 namespace adnl {

--- a/adnl/adnl-peer-table.h
+++ b/adnl/adnl-peer-table.h
@@ -24,21 +24,17 @@
 #include "common/io.hpp"
 #include "td/actor/actor.h"
 #include "td/utils/BufferedUdp.h"
+#include "td/utils/logging.h"
 
 #include "adnl-packet.h"
 #include "adnl.h"
 #include "utils.hpp"
 
+DECLARE_LOG_CATEGORY(adnl)
+
 namespace ton {
 
 namespace adnl {
-
-constexpr int VERBOSITY_NAME(ADNL_ERROR) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(ADNL_WARNING) = verbosity_INFO;
-constexpr int VERBOSITY_NAME(ADNL_NOTICE) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(ADNL_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(ADNL_DEBUG) = verbosity_DEBUG + 1;
-constexpr int VERBOSITY_NAME(ADNL_EXTRA_DEBUG) = verbosity_DEBUG + 10;
 
 class AdnlChannelIdShortImpl {
  public:

--- a/adnl/adnl-peer-table.hpp
+++ b/adnl/adnl-peer-table.hpp
@@ -51,8 +51,8 @@ class AdnlPeerTableImpl : public AdnlPeerTable {
   }
   void send_message_ex(AdnlNodeIdShort src, AdnlNodeIdShort dst, td::BufferSlice data, td::uint32 flags) override {
     if (data.size() > huge_packet_max_size()) {
-      VLOG(ADNL_WARNING) << "dropping too big packet [" << src << "->" << dst << "]: size=" << data.size();
-      VLOG(ADNL_WARNING) << "DUMP: " << td::buffer_to_hex(data.as_slice().truncate(128));
+      VLOG(adnl, WARNING) << "dropping too big packet [" << src << "->" << dst << "]: size=" << data.size();
+      VLOG(adnl, WARNING) << "DUMP: " << td::buffer_to_hex(data.as_slice().truncate(128));
       return;
     }
     send_message_in(src, dst, AdnlMessage{adnlmessage::AdnlMessageCustom{std::move(data)}}, flags);

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -148,25 +148,25 @@ void AdnlPeerPairImpl::receive_packet_checked(AdnlPacket packet) {
   request_reverse_ping_after_ = td::Timestamp::in(15.0);
   auto d = Adnl::adnl_start_time();
   if (packet.dst_reinit_date() > d) {
-    VLOG(ADNL_WARNING) << this << ": dropping IN message: too new our reinit date " << packet.dst_reinit_date();
+    VLOG(adnl, WARNING) << this << ": dropping IN message: too new our reinit date " << packet.dst_reinit_date();
     return;
   }
   if (packet.reinit_date() > td::Clocks::system() + 60) {
-    VLOG(ADNL_NOTICE) << this << ": dropping IN message: too new peer reinit date " << packet.reinit_date();
+    VLOG(adnl, INFO) << this << ": dropping IN message: too new peer reinit date " << packet.reinit_date();
     return;
   }
   if (packet.reinit_date() > reinit_date_) {
     reinit(packet.reinit_date());
   }
   if (packet.reinit_date() > 0 && packet.reinit_date() < reinit_date_) {
-    VLOG(ADNL_NOTICE) << this << ": dropping IN message: old peer reinit date " << packet.reinit_date();
+    VLOG(adnl, INFO) << this << ": dropping IN message: old peer reinit date " << packet.reinit_date();
     return;
   }
   if (packet.dst_reinit_date() > 0 && packet.dst_reinit_date() < d) {
     if (!packet.addr_list().empty()) {
       auto addr_list = packet.addr_list();
       if (packet.remote_addr().is_valid() && addr_list.size() == 0) {
-        VLOG(ADNL_DEBUG) << "adding implicit address " << packet.remote_addr();
+        VLOG(adnl, DEBUG) << "adding implicit address " << packet.remote_addr();
         addr_list.add_udp_adnl_address(packet.remote_addr());
       }
       update_addr_list(std::move(addr_list));
@@ -174,23 +174,23 @@ void AdnlPeerPairImpl::receive_packet_checked(AdnlPacket packet) {
     if (!packet.priority_addr_list().empty()) {
       update_addr_list(packet.priority_addr_list());
     }
-    VLOG(ADNL_NOTICE) << this << ": dropping IN message old our reinit date " << packet.dst_reinit_date()
-                      << " date=" << d;
+    VLOG(adnl, INFO) << this << ": dropping IN message old our reinit date " << packet.dst_reinit_date()
+                     << " date=" << d;
     auto M = OutboundAdnlMessage{adnlmessage::AdnlMessageNop{}, 0};
     send_message(std::move(M));
     return;
   }
   if (packet.seqno() > 0) {
     if (received_packet(packet.seqno())) {
-      VLOG(ADNL_INFO) << this << ": dropping IN message: old seqno: " << packet.seqno() << " (current max " << in_seqno_
-                      << ")";
+      VLOG(adnl, INFO) << this << ": dropping IN message: old seqno: " << packet.seqno() << " (current max "
+                       << in_seqno_ << ")";
       return;
     }
   }
   if (packet.confirm_seqno() > 0) {
     if (packet.confirm_seqno() > out_seqno_) {
-      VLOG(ADNL_WARNING) << this << ": dropping IN message: new ack seqno: " << packet.confirm_seqno()
-                         << " (current max sent " << out_seqno_ << ")";
+      VLOG(adnl, WARNING) << this << ": dropping IN message: new ack seqno: " << packet.confirm_seqno()
+                          << " (current max sent " << out_seqno_ << ")";
       return;
     }
   }
@@ -217,7 +217,7 @@ void AdnlPeerPairImpl::receive_packet_checked(AdnlPacket packet) {
   if (!packet.addr_list().empty()) {
     auto addr_list = packet.addr_list();
     if (packet.remote_addr().is_valid() && addr_list.size() == 0) {
-      VLOG(ADNL_DEBUG) << "adding implicit address " << packet.remote_addr();
+      VLOG(adnl, DEBUG) << "adding implicit address " << packet.remote_addr();
       addr_list.add_udp_adnl_address(packet.remote_addr());
     }
     update_addr_list(std::move(addr_list));
@@ -228,7 +228,7 @@ void AdnlPeerPairImpl::receive_packet_checked(AdnlPacket packet) {
 
   received_messages_++;
   if (received_messages_ % 64 == 0) {
-    VLOG(ADNL_INFO) << this << ": received " << received_messages_ << " messages";
+    VLOG(adnl, INFO) << this << ": received " << received_messages_ << " messages";
   }
   for (auto &M : packet.messages().vector()) {
     deliver_message(std::move(M));
@@ -240,7 +240,7 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
   set_idle_mark(false);
   add_packet_stats(serialized_size, /* in = */ true, /* channel = */ true);
   if (id != channel_in_id_) {
-    VLOG(ADNL_NOTICE) << this << ": dropping IN message: outdated channel id" << id;
+    VLOG(adnl, INFO) << this << ": dropping IN message: outdated channel id" << id;
     return;
   }
   if (channel_inited_ && !channel_ready_) {
@@ -258,13 +258,13 @@ void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_s
   packet.run_basic_checks().ensure();
 
   if (!encryptor_) {
-    VLOG(ADNL_NOTICE) << this << "dropping IN message: unitialized id";
+    VLOG(adnl, INFO) << this << "dropping IN message: unitialized id";
     return;
   }
 
   auto S = encryptor_->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
   if (S.is_error()) {
-    VLOG(ADNL_NOTICE) << this << "dropping IN message: bad signature: " << S;
+    VLOG(adnl, INFO) << this << "dropping IN message: bad signature: " << S;
     return;
   }
 
@@ -280,7 +280,7 @@ void AdnlPeerPairImpl::send_messages_from_queue() {
     out_messages_queue_total_size_ -= out_messages_queue_.front().first.size();
     add_expired_msg_stats(out_messages_queue_.front().first.size());
     out_messages_queue_.pop_front();
-    VLOG(ADNL_NOTICE) << this << ": dropping OUT message: message in queue expired";
+    VLOG(adnl, INFO) << this << ": dropping OUT message: message in queue expired";
   }
   if (out_messages_queue_.empty()) {
     return;
@@ -291,7 +291,7 @@ void AdnlPeerPairImpl::send_messages_from_queue() {
   if (connR.is_error()) {
     disable_dht_query_ = false;
     retry_send_at_.relax(td::Timestamp::in(message_in_queue_ttl_ - 1.0));
-    VLOG(ADNL_INFO) << this << ": delaying OUT messages: cannot get conn: " << connR.move_as_error();
+    VLOG(adnl, INFO) << this << ": delaying OUT messages: cannot get conn: " << connR.move_as_error();
     alarm();
     return;
   }
@@ -441,7 +441,7 @@ void AdnlPeerPairImpl::send_messages(std::vector<OutboundAdnlMessage> messages) 
   while (out_messages_queue_total_size_ > MAX_MESSAGE_QUEUE_TOTAL_SIZE) {
     out_messages_queue_total_size_ -= out_messages_queue_.back().first.size();
     out_messages_queue_.pop_back();
-    VLOG(ADNL_NOTICE) << this << ": dropping OUT message: queue is too big";
+    VLOG(adnl, INFO) << this << ": dropping OUT message: queue is too big";
   }
 }
 
@@ -464,22 +464,22 @@ void AdnlPeerPairImpl::send_packet_continue(AdnlPacket packet, td::actor::ActorI
       add_packet_stats(B.size(), /* in = */ false, /* channel = */ true);
       td::actor::send_closure(channel_, &AdnlChannel::send_message, priority_, conn, std::move(B));
     } else {
-      VLOG(ADNL_WARNING) << this << ": dropping OUT message [" << local_id_ << "->" << peer_id_short_
-                         << "]: channel destroyed in process";
+      VLOG(adnl, WARNING) << this << ": dropping OUT message [" << local_id_ << "->" << peer_id_short_
+                          << "]: channel destroyed in process";
     }
     return;
   }
 
   if (!encryptor_) {
-    VLOG(ADNL_INFO) << this << ": dropping OUT message [" << local_id_ << "->" << peer_id_short_
-                    << "]: empty encryptor";
+    VLOG(adnl, INFO) << this << ": dropping OUT message [" << local_id_ << "->" << peer_id_short_
+                     << "]: empty encryptor";
     return;
   }
 
   auto res = encryptor_->encrypt(B.as_slice());
   if (res.is_error()) {
-    VLOG(ADNL_WARNING) << this << ": dropping OUT message [" << local_id_ << "->" << peer_id_short_
-                       << "]: failed to encrypt: " << res.move_as_error();
+    VLOG(adnl, WARNING) << this << ": dropping OUT message [" << local_id_ << "->" << peer_id_short_
+                        << "]: failed to encrypt: " << res.move_as_error();
     return;
   }
   auto X = res.move_as_ok();
@@ -567,7 +567,7 @@ void AdnlPeerPairImpl::create_channel(pubkeys::Ed25519 pub, td::uint32 date) {
 
     td::actor::send_closure(peer_table_, &AdnlPeerTable::register_channel, channel_in_id_, local_id_, channel_.get());
   } else {
-    VLOG(ADNL_WARNING) << this << ": failed to create channel: " << R.move_as_error();
+    VLOG(adnl, WARNING) << this << ": failed to create channel: " << R.move_as_error();
   }
 }
 
@@ -577,12 +577,12 @@ void AdnlPeerPairImpl::process_message(const adnlmessage::AdnlMessageCreateChann
 
 void AdnlPeerPairImpl::process_message(const adnlmessage::AdnlMessageConfirmChannel &message) {
   if (message.peer_key() != channel_pub_) {
-    VLOG(ADNL_NOTICE) << this << ": received adnl.message.confirmChannel with bad peer_key";
+    VLOG(adnl, INFO) << this << ": received adnl.message.confirmChannel with bad peer_key";
     return;
   }
   create_channel(message.key(), message.date());
   if (!channel_inited_ || peer_channel_pub_ != message.key()) {
-    VLOG(ADNL_NOTICE) << this << ": received adnl.message.confirmChannel with old key";
+    VLOG(adnl, INFO) << this << ": received adnl.message.confirmChannel with old key";
     return;
   }
   if (!channel_ready_) {
@@ -628,12 +628,12 @@ void AdnlPeerPairImpl::process_message(const adnlmessage::AdnlMessageAnswer &mes
   auto Q = out_queries_.find(message.query_id());
 
   if (Q == out_queries_.end()) {
-    VLOG(ADNL_NOTICE) << this << ": dropping IN answer: unknown query id " << message.query_id();
+    VLOG(adnl, INFO) << this << ": dropping IN answer: unknown query id " << message.query_id();
     return;
   }
 
   if (message.data().size() > Adnl::huge_packet_max_size()) {
-    VLOG(ADNL_NOTICE) << this << ": dropping IN answer: too big answer size";
+    VLOG(adnl, INFO) << this << ": dropping IN answer: too big answer size";
     return;
   }
 
@@ -645,11 +645,11 @@ void AdnlPeerPairImpl::process_message(const adnlmessage::AdnlMessagePart &messa
   respond_with_nop();
   auto size = message.total_size();
   if (size > huge_packet_max_size()) {
-    VLOG(ADNL_INFO) << this << ": dropping too big huge message: size=" << size;
+    VLOG(adnl, INFO) << this << ": dropping too big huge message: size=" << size;
     return;
   }
   if (message.hash().is_zero()) {
-    VLOG(ADNL_INFO) << this << ": dropping huge message with zero hash";
+    VLOG(adnl, INFO) << this << ": dropping huge message with zero hash";
     return;
   }
   if (message.hash() != huge_message_hash_) {
@@ -665,11 +665,11 @@ void AdnlPeerPairImpl::process_message(const adnlmessage::AdnlMessagePart &messa
   }
   auto data = message.data();
   if (data.size() + message.offset() > size) {
-    VLOG(ADNL_WARNING) << this << ": dropping huge message with bad part";
+    VLOG(adnl, WARNING) << this << ": dropping huge message with bad part";
     return;
   }
   if (size != huge_message_.size()) {
-    VLOG(ADNL_WARNING) << this << ": dropping huge message part with inconsistent size";
+    VLOG(adnl, WARNING) << this << ": dropping huge message part with inconsistent size";
     return;
   }
   if (message.offset() == huge_message_offset_) {
@@ -681,14 +681,14 @@ void AdnlPeerPairImpl::process_message(const adnlmessage::AdnlMessagePart &messa
     if (huge_message_offset_ == huge_message_.size()) {
       //td::actor::send_closure(local_actor_, &AdnlLocalId::deliver, peer_id_short_, std::move(huge_message_));
       if (sha256_bits256(huge_message_.as_slice()) != huge_message_hash_) {
-        VLOG(ADNL_WARNING) << this << ": dropping huge message: hash mismatch";
+        VLOG(adnl, WARNING) << this << ": dropping huge message: hash mismatch";
         return;
       }
       huge_message_hash_.set_zero();
       huge_message_offset_ = 0;
       auto MR = fetch_tl_object<ton_api::adnl_Message>(std::move(huge_message_), true);
       if (MR.is_error()) {
-        VLOG(ADNL_WARNING) << this << ": dropping huge message part with bad data";
+        VLOG(adnl, WARNING) << this << ": dropping huge message part with bad data";
         return;
       }
       auto M = AdnlMessage{MR.move_as_ok()};
@@ -795,7 +795,7 @@ void AdnlPeerPairImpl::update_addr_list(AdnlAddressList addr_list) {
   //CHECK(addr_list.size() > 0);
 
   if (addr_list.reinit_date() > td::Clocks::system() + 60) {
-    VLOG(ADNL_WARNING) << "dropping addr list with too new reinit date";
+    VLOG(adnl, WARNING) << "dropping addr list with too new reinit date";
     return;
   }
 
@@ -817,7 +817,7 @@ void AdnlPeerPairImpl::update_addr_list(AdnlAddressList addr_list) {
     return;
   }
 
-  VLOG(ADNL_INFO) << this << ": updating addr list to version " << addr_list.version() << " size=" << addr_list.size();
+  VLOG(adnl, INFO) << this << ": updating addr list to version " << addr_list.version() << " size=" << addr_list.size();
 
   const auto addrs = addr_list.adnl_addrs();
   has_reverse_addr_ = addr_list.has_reverse();
@@ -980,7 +980,7 @@ void AdnlPeerPairImpl::got_data_from_dht(td::Result<AdnlNode> R) {
   dht_query_active_ = false;
   next_dht_query_at_ = td::Timestamp::in(td::Random::fast(60.0, 120.0));
   if (R.is_error()) {
-    VLOG(ADNL_INFO) << this << ": dht query failed: " << R.move_as_error();
+    VLOG(adnl, INFO) << this << ": dht query failed: " << R.move_as_error();
     return;
   }
   auto value = R.move_as_ok();
@@ -997,7 +997,7 @@ void AdnlPeerPairImpl::update_peer_id(AdnlNodeIdFull id) {
     if (R.is_ok()) {
       encryptor_ = R.move_as_ok();
     } else {
-      VLOG(ADNL_WARNING) << this << ": failed to create encryptor: " << R.move_as_error();
+      VLOG(adnl, WARNING) << this << ": failed to create encryptor: " << R.move_as_error();
     }
   }
   CHECK(!peer_id_.empty());
@@ -1007,7 +1007,7 @@ void AdnlPeerPairImpl::request_reverse_ping() {
   if (request_reverse_ping_active_ || !request_reverse_ping_after_.is_in_past()) {
     return;
   }
-  VLOG(ADNL_INFO) << this << ": requesting reverse ping";
+  VLOG(adnl, INFO) << this << ": requesting reverse ping";
   request_reverse_ping_after_ = td::Timestamp::in(15.0);
   request_reverse_ping_active_ = true;
   td::actor::send_closure(
@@ -1027,9 +1027,9 @@ void AdnlPeerPairImpl::request_reverse_ping() {
 void AdnlPeerPairImpl::request_reverse_ping_result(td::Result<td::Unit> R) {
   request_reverse_ping_active_ = false;
   if (R.is_ok()) {
-    VLOG(ADNL_INFO) << this << ": reverse ping requested";
+    VLOG(adnl, INFO) << this << ": reverse ping requested";
   } else {
-    VLOG(ADNL_INFO) << this << ": failed to request reverse ping: " << R.move_as_error();
+    VLOG(adnl, INFO) << this << ": failed to request reverse ping: " << R.move_as_error();
   }
 }
 
@@ -1094,7 +1094,7 @@ void AdnlPeerPairImpl::set_idle_mark(bool value) {
     alarm_timestamp().relax(mark_idle_at_ = td::Timestamp::in(MARK_IDLE_TIMEOUT));
   }
   if (idle_mark_ != value) {
-    VLOG(ADNL_INFO) << this << ": marked as " << (value ? "idle" : "not idle");
+    VLOG(adnl, INFO) << this << ": marked as " << (value ? "idle" : "not idle");
     td::actor::send_closure(peer_table_, &AdnlPeerTable::set_peer_pair_idle, local_id_, peer_id_short_, value);
   }
   idle_mark_ = value;

--- a/adnl/adnl-tunnel.cpp
+++ b/adnl/adnl-tunnel.cpp
@@ -30,18 +30,18 @@ void AdnlInboundTunnelEndpoint::receive_packet(AdnlNodeIdShort src, td::IPAddres
 void AdnlInboundTunnelEndpoint::receive_packet_cont(AdnlNodeIdShort src, td::IPAddress src_addr,
                                                     td::BufferSlice datagram, size_t idx) {
   if (datagram.size() <= 32) {
-    VLOG(ADNL_INFO) << "dropping too short datagram";
+    VLOG(adnl, INFO) << "dropping too short datagram";
     return;
   }
   if (datagram.as_slice().truncate(32) != decrypt_via_[idx].as_slice()) {
-    VLOG(ADNL_INFO) << "invalid tunnel midpoint";
+    VLOG(adnl, INFO) << "invalid tunnel midpoint";
     return;
   }
   datagram.confirm_read(32);
 
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), src, src_addr, idx](td::Result<td::BufferSlice> R) {
     if (R.is_error()) {
-      VLOG(ADNL_INFO) << "dropping tunnel packet: failed to decrypt: " << R.move_as_error();
+      VLOG(adnl, INFO) << "dropping tunnel packet: failed to decrypt: " << R.move_as_error();
       return;
     } else {
       td::actor::send_closure(SelfId, &AdnlInboundTunnelEndpoint::decrypted_packet, src, src_addr, R.move_as_ok(), idx);
@@ -59,7 +59,7 @@ void AdnlInboundTunnelEndpoint::decrypted_packet(AdnlNodeIdShort src, td::IPAddr
   }
   auto F = fetch_tl_object<ton_api::adnl_tunnelPacketContents>(std::move(data), true);
   if (F.is_error()) {
-    VLOG(ADNL_INFO) << "dropping tunnel packet: failed to fetch: " << F.move_as_error();
+    VLOG(adnl, INFO) << "dropping tunnel packet: failed to fetch: " << F.move_as_error();
     return;
   }
   auto packet = F.move_as_ok();

--- a/dht/dht-query.cpp
+++ b/dht/dht-query.cpp
@@ -34,7 +34,7 @@ void DhtQuery::send_queries() {
   while (pending_queries_.size() > k_ * 2) {
     pending_queries_.erase(--pending_queries_.end());
   }
-  VLOG(DHT_EXTRA_DEBUG) << this << ": sending new queries. active=" << active_queries_ << " max_active=" << a_;
+  VLOG(dht, DEBUG) << this << ": sending new queries. active=" << active_queries_ << " max_active=" << a_;
   while (pending_queries_.size() > 0 && active_queries_ < a_) {
     auto id_xor = *pending_queries_.begin();
     if (result_list_.size() == k_ && *result_list_.rbegin() < id_xor) {
@@ -42,7 +42,7 @@ void DhtQuery::send_queries() {
     }
     active_queries_++;
     auto id = id_xor ^ key_;
-    VLOG(DHT_EXTRA_DEBUG) << this << ": sending " << get_name() << " query to " << id;
+    VLOG(dht, DEBUG) << this << ": sending " << get_name() << " query to " << id;
     pending_queries_.erase(id_xor);
 
     auto it = nodes_.find(id_xor);
@@ -60,21 +60,21 @@ void DhtQuery::send_queries() {
       list.push_back(it->second.node.clone());
     }
     CHECK(list.size() <= k_);
-    VLOG(DHT_EXTRA_DEBUG) << this << ": finalizing " << get_name() << " query. List size=" << list.size();
+    VLOG(dht, DEBUG) << this << ": finalizing " << get_name() << " query. List size=" << list.size();
     finish(std::move(list));
     stop();
   }
 }
 
 void DhtQuery::add_nodes(DhtNodesList list) {
-  VLOG(DHT_EXTRA_DEBUG) << this << ": " << get_name() << " query: received " << list.size() << " new dht nodes";
+  VLOG(dht, DEBUG) << this << ": " << get_name() << " query: received " << list.size() << " new dht nodes";
   for (auto &node : list.list()) {
     auto id = node.get_key();
     auto id_xor = key_ ^ id;
     if (nodes_.find(id_xor) != nodes_.end()) {
       continue;
     }
-    VLOG(DHT_EXTRA_DEBUG) << this << ": " << get_name() << " query: adding " << id << " key";
+    VLOG(dht, DEBUG) << this << ": " << get_name() << " query: adding " << id << " key";
     td::actor::send_closure(node_, &DhtMember::add_full_node, id, node.clone(), false);
     nodes_[id_xor].node = std::move(node);
     pending_queries_.insert(id_xor);
@@ -118,15 +118,15 @@ void DhtQueryFindNodes::send_one_query(adnl::AdnlNodeIdShort id) {
 
 void DhtQueryFindNodes::on_result(td::Result<td::BufferSlice> R, adnl::AdnlNodeIdShort dst) {
   if (R.is_error()) {
-    VLOG(DHT_INFO) << this << ": failed find nodes query " << get_src() << "->" << dst << ": " << R.move_as_error();
+    VLOG(dht, INFO) << this << ": failed find nodes query " << get_src() << "->" << dst << ": " << R.move_as_error();
     finish_query(dst, false);
     return;
   }
 
   auto Res = fetch_tl_object<ton_api::dht_nodes>(R.move_as_ok(), true);
   if (Res.is_error()) {
-    VLOG(DHT_WARNING) << this << ": incorrect result on dht.findNodes query from " << dst << ": "
-                      << Res.move_as_error();
+    VLOG(dht, WARNING) << this << ": incorrect result on dht.findNodes query from " << dst << ": "
+                       << Res.move_as_error();
   } else {
     add_nodes(DhtNodesList{Res.move_as_ok(), our_network_id()});
   }
@@ -173,14 +173,14 @@ void DhtQueryFindValue::send_one_query_nodes(adnl::AdnlNodeIdShort id) {
 
 void DhtQueryFindValue::on_result(td::Result<td::BufferSlice> R, adnl::AdnlNodeIdShort dst) {
   if (R.is_error()) {
-    VLOG(DHT_INFO) << this << ": failed find value query " << get_src() << "->" << dst << ": " << R.move_as_error();
+    VLOG(dht, INFO) << this << ": failed find value query " << get_src() << "->" << dst << ": " << R.move_as_error();
     finish_query(dst, false);
     return;
   }
   auto Res = fetch_tl_object<ton_api::dht_ValueResult>(R.move_as_ok(), true);
   if (Res.is_error()) {
-    VLOG(DHT_WARNING) << this << ": dropping incorrect answer on dht.findValue query from " << dst << ": "
-                      << Res.move_as_error();
+    VLOG(dht, WARNING) << this << ": dropping incorrect answer on dht.findValue query from " << dst << ": "
+                       << Res.move_as_error();
     finish_query(dst, false);
     return;
   }
@@ -194,13 +194,13 @@ void DhtQueryFindValue::on_result(td::Result<td::BufferSlice> R, adnl::AdnlNodeI
               [&](ton_api::dht_valueFound &v) {
                 auto valueR = DhtValue::create(std::move(v.value_), true);
                 if (valueR.is_error()) {
-                  VLOG(DHT_WARNING) << this << ": received incorrect dht answer on find value query from " << dst
-                                    << ": " << valueR.move_as_error();
+                  VLOG(dht, WARNING) << this << ": received incorrect dht answer on find value query from " << dst
+                                     << ": " << valueR.move_as_error();
                   return;
                 }
                 auto value = valueR.move_as_ok();
                 if (value.key_id() != key_) {
-                  VLOG(DHT_WARNING) << this << ": received value for bad key on find value query from " << dst;
+                  VLOG(dht, WARNING) << this << ": received value for bad key on find value query from " << dst;
                   return;
                 }
                 if (value.expired() || !value.check_is_acceptable()) {
@@ -225,14 +225,14 @@ void DhtQueryFindValue::on_result(td::Result<td::BufferSlice> R, adnl::AdnlNodeI
 
 void DhtQueryFindValue::on_result_nodes(td::Result<td::BufferSlice> R, adnl::AdnlNodeIdShort dst) {
   if (R.is_error()) {
-    VLOG(DHT_INFO) << this << ": failed find nodes query " << get_src() << "->" << dst << ": " << R.move_as_error();
+    VLOG(dht, INFO) << this << ": failed find nodes query " << get_src() << "->" << dst << ": " << R.move_as_error();
     finish_query(dst, false);
     return;
   }
   auto Res = fetch_tl_object<ton_api::dht_nodes>(R.move_as_ok(), true);
   if (Res.is_error()) {
-    VLOG(DHT_WARNING) << this << ": dropping incorrect answer on dht.findNodes query from " << dst << ": "
-                      << Res.move_as_error();
+    VLOG(dht, WARNING) << this << ": dropping incorrect answer on dht.findNodes query from " << dst << ": "
+                       << Res.move_as_error();
     finish_query(dst, false);
     return;
   }
@@ -303,7 +303,7 @@ void DhtQueryStore::start_up() {
 void DhtQueryStore::send_stores(td::Result<DhtNodesList> R) {
   if (R.is_error()) {
     auto S = R.move_as_error();
-    VLOG(DHT_NOTICE) << this << ": failed to get nearest nodes to " << value_.key_id() << ": " << S;
+    VLOG(dht, INFO) << this << ": failed to get nearest nodes to " << value_.key_id() << ": " << S;
     promise_.set_error(std::move(S));
     stop();
     return;
@@ -334,12 +334,12 @@ void DhtQueryStore::send_stores(td::Result<DhtNodesList> R) {
 void DhtQueryStore::store_ready(td::Result<td::BufferSlice> R) {
   if (R.is_error()) {
     fail_++;
-    VLOG(DHT_INFO) << this << ": failed store query: " << R.move_as_error();
+    VLOG(dht, INFO) << this << ": failed store query: " << R.move_as_error();
   } else {
     auto R2 = fetch_tl_object<ton_api::dht_stored>(R.move_as_ok(), true);
     if (R2.is_error()) {
       fail_++;
-      VLOG(DHT_WARNING) << this << ": can not parse answer (expected dht.stored): " << R2.move_as_error();
+      VLOG(dht, WARNING) << this << ": can not parse answer (expected dht.stored): " << R2.move_as_error();
     } else {
       success_++;
     }
@@ -390,7 +390,7 @@ void DhtQueryRegisterReverseConnection::start_up() {
 void DhtQueryRegisterReverseConnection::send_queries(td::Result<DhtNodesList> R) {
   if (R.is_error()) {
     auto S = R.move_as_error();
-    VLOG(DHT_NOTICE) << this << ": failed to get nearest nodes to " << key_id_ << ": " << S;
+    VLOG(dht, INFO) << this << ": failed to get nearest nodes to " << key_id_ << ": " << S;
     promise_.set_error(std::move(S));
     stop();
     return;
@@ -399,7 +399,7 @@ void DhtQueryRegisterReverseConnection::send_queries(td::Result<DhtNodesList> R)
 
   remaining_ = static_cast<td::uint32>(list.size());
   if (remaining_ == 0) {
-    VLOG(DHT_NOTICE) << this << ": failed to get nearest nodes to " << key_id_ << ": no nodes";
+    VLOG(dht, INFO) << this << ": failed to get nearest nodes to " << key_id_ << ": no nodes";
     promise_.set_error(td::Status::Error("no dht nodes"));
     stop();
     return;
@@ -417,12 +417,12 @@ void DhtQueryRegisterReverseConnection::send_queries(td::Result<DhtNodesList> R)
 void DhtQueryRegisterReverseConnection::ready(td::Result<td::BufferSlice> R) {
   if (R.is_error()) {
     fail_++;
-    VLOG(DHT_INFO) << this << ": failed register reverse connection query: " << R.move_as_error();
+    VLOG(dht, INFO) << this << ": failed register reverse connection query: " << R.move_as_error();
   } else {
     auto R2 = fetch_tl_object<ton_api::dht_stored>(R.move_as_ok(), true);
     if (R2.is_error()) {
       fail_++;
-      VLOG(DHT_WARNING) << this << ": can not parse answer (expected dht.stored): " << R2.move_as_error();
+      VLOG(dht, WARNING) << this << ": can not parse answer (expected dht.stored): " << R2.move_as_error();
     } else {
       success_++;
     }
@@ -455,14 +455,14 @@ void DhtQueryRequestReversePing::send_one_query(adnl::AdnlNodeIdShort id) {
 
 void DhtQueryRequestReversePing::on_result(td::Result<td::BufferSlice> R, adnl::AdnlNodeIdShort dst) {
   if (R.is_error()) {
-    VLOG(DHT_INFO) << this << ": failed reverse ping query " << get_src() << "->" << dst << ": " << R.move_as_error();
+    VLOG(dht, INFO) << this << ": failed reverse ping query " << get_src() << "->" << dst << ": " << R.move_as_error();
     finish_query(dst, false);
     return;
   }
   auto Res = fetch_tl_object<ton_api::dht_ReversePingResult>(R.move_as_ok(), true);
   if (Res.is_error()) {
-    VLOG(DHT_WARNING) << this << ": dropping incorrect answer on dht.requestReversePing query from " << dst << ": "
-                      << Res.move_as_error();
+    VLOG(dht, WARNING) << this << ": dropping incorrect answer on dht.requestReversePing query from " << dst << ": "
+                       << Res.move_as_error();
     finish_query(dst, false);
     return;
   }

--- a/dht/dht-remote-node.cpp
+++ b/dht/dht-remote-node.cpp
@@ -95,7 +95,7 @@ void DhtRemoteNode::send_ping(bool client_only, td::actor::ActorId<adnl::Adnl> a
     }
     auto P = td::PromiseCreator::lambda([key, node, adnl, our_network_id](td::Result<td::BufferSlice> R) {
       if (R.is_error()) {
-        VLOG(DHT_INFO) << "[dht]: received error for query to " << key << ": " << R.move_as_error();
+        VLOG(dht, INFO) << "[dht]: received error for query to " << key << ": " << R.move_as_error();
         return;
       }
       auto F = fetch_tl_object<ton_api::dht_node>(R.move_as_ok(), true);
@@ -105,12 +105,12 @@ void DhtRemoteNode::send_ping(bool client_only, td::actor::ActorId<adnl::Adnl> a
         if (N.is_ok()) {
           td::actor::send_closure(node, &DhtMember::receive_ping, key, N.move_as_ok());
         } else {
-          VLOG(DHT_WARNING) << "[dht]: bad answer from " << key
-                            << ": dropping bad getSignedAddressList() query answer: " << N.move_as_error();
+          VLOG(dht, WARNING) << "[dht]: bad answer from " << key
+                             << ": dropping bad getSignedAddressList() query answer: " << N.move_as_error();
         }
       } else {
-        VLOG(DHT_WARNING) << "[dht]: bad answer from " << key
-                          << ": dropping invalid getSignedAddressList() query answer: " << F.move_as_error();
+        VLOG(dht, WARNING) << "[dht]: bad answer from " << key
+                           << ": dropping invalid getSignedAddressList() query answer: " << F.move_as_error();
       }
     });
     auto Q = create_serialize_tl_object<ton_api::dht_getSignedAddressList>();

--- a/dht/dht.cpp
+++ b/dht/dht.cpp
@@ -30,6 +30,8 @@
 #include "dht.h"
 #include "dht.hpp"
 
+DEFINE_LOG_CATEGORY(dht, VERBOSITY_NAME(WARNING))
+
 namespace ton {
 
 namespace dht {
@@ -242,7 +244,7 @@ td::Status DhtMemberImpl::store_in(DhtValue value) {
     return td::Status::Error("ttl is too big");
   }
   if (value.expired()) {
-    VLOG(DHT_INFO) << this << ": dropping expired value: " << value.key_id() << " expire_at = " << value.ttl();
+    VLOG(dht, INFO) << this << ": dropping expired value: " << value.key_id() << " expire_at = " << value.ttl();
     return td::Status::OK();
   }
   TRY_STATUS(value.check());
@@ -260,7 +262,7 @@ td::Status DhtMemberImpl::store_in(DhtValue value) {
     }
     CHECK(values_ttl_order_.insert({it->second.ttl(), it->first}).second);
   } else {
-    VLOG(DHT_INFO) << this << ": dropping too remote value: " << value.key_id() << " distance = " << dist;
+    VLOG(dht, INFO) << this << ": dropping too remote value: " << value.key_id() << " distance = " << dist;
   }
   return td::Status::OK();
 }
@@ -272,7 +274,7 @@ void DhtMemberImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::dht_store 
   if (V.is_error()) {
     promise.set_error(td::Status::Error(ErrorCode::protoviolation,
                                         PSTRING() << "dropping invalid dht_store() value: " << V.error().to_string()));
-    VLOG(DHT_INFO) << this << ": dropping invalid value: " << V.move_as_error();
+    VLOG(dht, INFO) << this << ": dropping invalid value: " << V.move_as_error();
     return;
   }
   auto b = store_in(V.move_as_ok());
@@ -280,7 +282,7 @@ void DhtMemberImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::dht_store 
   if (b.is_ok()) {
     promise.set_value(create_serialize_tl_object<ton_api::dht_stored>());
   } else {
-    VLOG(DHT_INFO) << this << ": dropping store() query from " << src << ": " << b.move_as_error();
+    VLOG(dht, INFO) << this << ": dropping store() query from " << src << ": " << b.move_as_error();
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "dropping dht_store() query"));
   }
 }
@@ -367,36 +369,36 @@ void DhtMemberImpl::receive_query(adnl::AdnlNodeIdShort src, td::BufferSlice dat
           auto key = node.get_key();
           add_full_node(key, std::move(node), true);
         } else {
-          VLOG(DHT_WARNING) << this << ": dropping bad node: unexpected adnl id";
+          VLOG(dht, WARNING) << this << ": dropping bad node: unexpected adnl id";
         }
       } else {
-        VLOG(DHT_WARNING) << this << ": dropping bad node " << N.move_as_error();
+        VLOG(dht, WARNING) << this << ": dropping bad node " << N.move_as_error();
       }
     }
   }
   auto R = fetch_tl_object<ton_api::Function>(std::move(data), true);
 
   if (R.is_error()) {
-    VLOG(DHT_WARNING) << this << ": dropping unknown query to DHT node: " << R.move_as_error();
+    VLOG(dht, WARNING) << this << ": dropping unknown query to DHT node: " << R.move_as_error();
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "failed to parse dht query"));
     return;
   }
 
   auto Q = R.move_as_ok();
   if (td::Random::fast(0, 127) == 0) {
-    VLOG(DHT_DEBUG) << this << ": ping=" << ping_queries_ << " fnode=" << find_node_queries_
-                    << " fvalue=" << find_value_queries_ << " store=" << store_queries_
-                    << " addrlist=" << get_addr_list_queries_;
-    VLOG(DHT_DEBUG) << this << ": query to DHT from " << src << ": " << ton_api::to_string(Q);
+    VLOG(dht, DEBUG) << this << ": ping=" << ping_queries_ << " fnode=" << find_node_queries_
+                     << " fvalue=" << find_value_queries_ << " store=" << store_queries_
+                     << " addrlist=" << get_addr_list_queries_;
+    VLOG(dht, DEBUG) << this << ": query to DHT from " << src << ": " << ton_api::to_string(Q);
   }
 
-  VLOG(DHT_EXTRA_DEBUG) << this << ": query to DHT from " << src << ": " << ton_api::to_string(Q);
+  VLOG(dht, DEBUG) << this << ": query to DHT from " << src << ": " << ton_api::to_string(Q);
 
   ton_api::downcast_call(*Q, [&](auto &object) { this->process_query(src, object, std::move(promise)); });
 }
 
 void DhtMemberImpl::add_full_node(DhtKeyId key, DhtNode node, bool set_active) {
-  VLOG(DHT_EXTRA_DEBUG) << this << ": adding full node " << key;
+  VLOG(dht, DEBUG) << this << ": adding full node " << key;
 
   auto eid = key ^ key_;
   auto bit = eid.count_leading_zeroes();
@@ -414,7 +416,7 @@ void DhtMemberImpl::add_full_node(DhtKeyId key, DhtNode node, bool set_active) {
 }
 
 void DhtMemberImpl::receive_ping(DhtKeyId key, DhtNode result) {
-  VLOG(DHT_EXTRA_DEBUG) << this << ": received ping from " << key;
+  VLOG(dht, DEBUG) << this << ": received ping from " << key;
 
   auto eid = key ^ key_;
   auto bit = eid.count_leading_zeroes();
@@ -438,13 +440,13 @@ void DhtMemberImpl::receive_message(adnl::AdnlNodeIdShort src, td::BufferSlice d
       TRY_RESULT_PREFIX(encryptor, node.pub_id().pubkey().create_encryptor(), "failed to create encryptor: ");
       TRY_STATUS_PREFIX(encryptor->check_signature(serialize_tl_object(f->target_, true), f->signature_),
                         "invalid signature: ");
-      VLOG(DHT_INFO) << this << ": sending reverse ping to " << node.compute_short_id();
+      VLOG(dht, INFO) << this << ": sending reverse ping to " << node.compute_short_id();
       td::actor::send_closure(adnl_, &adnl::Adnl::add_peer, client, node.pub_id(), node.addr_list());
       td::actor::send_closure(adnl_, &adnl::Adnl::send_message, client, node.compute_short_id(), td::BufferSlice());
       return td::Status::OK();
     }();
     if (S.is_error()) {
-      VLOG(DHT_INFO) << this << ": " << S;
+      VLOG(dht, INFO) << this << ": " << S;
     }
   }
 }
@@ -554,12 +556,12 @@ void DhtMemberImpl::request_reverse_ping_cont(adnl::AdnlNode target, td::BufferS
 }
 
 void DhtMemberImpl::check() {
-  VLOG(DHT_INFO) << this << ": ping=" << ping_queries_ << " fnode=" << find_node_queries_
-                 << " fvalue=" << find_value_queries_ << " store=" << store_queries_
-                 << " addrlist=" << get_addr_list_queries_;
-  VLOG(DHT_INFO) << this << ": values=" << values_.size() << " our_values=" << our_values_.size();
-  VLOG(DHT_INFO) << this << ": reverse_conns=" << reverse_connections_.size()
-                 << " our_reverse_conns=" << our_reverse_connections_.size();
+  VLOG(dht, INFO) << this << ": ping=" << ping_queries_ << " fnode=" << find_node_queries_
+                  << " fvalue=" << find_value_queries_ << " store=" << store_queries_
+                  << " addrlist=" << get_addr_list_queries_;
+  VLOG(dht, INFO) << this << ": values=" << values_.size() << " our_values=" << our_values_.size();
+  VLOG(dht, INFO) << this << ": reverse_conns=" << reverse_connections_.size()
+                  << " our_reverse_conns=" << our_reverse_connections_.size();
   for (auto &bucket : buckets_) {
     bucket.check(client_only_, adnl_, actor_id(this), id_);
   }
@@ -593,7 +595,7 @@ void DhtMemberImpl::check() {
           if (it->second.key().update_rule()->need_republish()) {
             auto P = td::PromiseCreator::lambda([print_id = print_id()](td::Result<td::Unit> R) {
               if (R.is_error()) {
-                VLOG(DHT_INFO) << print_id << ": failed to store: " << R.move_as_error();
+                VLOG(dht, INFO) << print_id << ": failed to store: " << R.move_as_error();
               }
             });
             send_store(it->second.clone(), std::move(P));
@@ -635,7 +637,7 @@ void DhtMemberImpl::check() {
       if (it->second.ttl() > td::Clocks::system() + 60) {
         auto P = td::PromiseCreator::lambda([print_id = print_id()](td::Result<td::Unit> R) {
           if (R.is_error()) {
-            VLOG(DHT_INFO) << print_id << ": failed to store: " << R.move_as_error();
+            VLOG(dht, INFO) << print_id << ": failed to store: " << R.move_as_error();
           }
         });
         send_store(it->second.clone(), std::move(P));
@@ -648,7 +650,7 @@ void DhtMemberImpl::check() {
   if (fill_att_.is_in_past()) {
     auto promise = td::PromiseCreator::lambda([](td::Result<DhtNodesList> R) {
       if (R.is_error()) {
-        VLOG(DHT_WARNING) << "failed find self query: " << R.move_as_error();
+        VLOG(dht, WARNING) << "failed find self query: " << R.move_as_error();
       }
     });
 

--- a/dht/dht.hpp
+++ b/dht/dht.hpp
@@ -27,19 +27,16 @@
 #include "td/actor/actor.h"
 #include "td/utils/List.h"
 #include "td/utils/int_types.h"
+#include "td/utils/logging.h"
 
 #include "dht-node.hpp"
 #include "dht.h"
 
+DECLARE_LOG_CATEGORY(dht)
+
 namespace ton {
 
 namespace dht {
-
-constexpr int VERBOSITY_NAME(DHT_WARNING) = verbosity_INFO;
-constexpr int VERBOSITY_NAME(DHT_NOTICE) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(DHT_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(DHT_DEBUG) = verbosity_DEBUG + 1;
-constexpr int VERBOSITY_NAME(DHT_EXTRA_DEBUG) = verbosity_DEBUG + 10;
 
 class DhtGlobalConfig {
  public:

--- a/overlay/broadcast-fec.cpp
+++ b/overlay/broadcast-fec.cpp
@@ -200,7 +200,7 @@ void BroadcastFec::broadcast_checked(OverlayImpl *overlay, td::Result<td::Unit> 
 td::Status BroadcastFec::distribute_part(OverlayImpl *overlay, td::uint32 seqno) {
   auto i = parts_.find(seqno);
   if (i == parts_.end()) {
-    VLOG(OVERLAY_WARNING) << "not distibuting empty part " << seqno;
+    VLOG(overlay, WARNING) << "not distibuting empty part " << seqno;
     // should not get here
     return td::Status::OK();
   }
@@ -223,7 +223,7 @@ td::Status BroadcastFec::distribute_part(OverlayImpl *overlay, td::uint32 seqno)
       limiter.register_out_traffic(data_short.size());
     } else {
       if (hash_.count_leading_zeroes() >= 12) {
-        VLOG(OVERLAY_INFO) << "broadcast " << hash_ << ": sending part " << seqno << " to " << n;
+        VLOG(overlay, INFO) << "broadcast " << hash_ << ": sending part " << seqno << " to " << n;
       }
       td::actor::send_closure(manager, &OverlayManager::send_message, n, overlay->local_id(), overlay->overlay_id(),
                               data.clone());

--- a/overlay/broadcast-simple.cpp
+++ b/overlay/broadcast-simple.cpp
@@ -211,13 +211,13 @@ void BroadcastsSimple::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay
                                      td::Promise<td::BufferSlice> promise) {
   auto it = broadcasts_.find(query.hash_);
   if (it == broadcasts_.end()) {
-    VLOG(OVERLAY_NOTICE) << this << ": received getBroadcastQuery(" << query.hash_ << ") from " << src
-                         << " but broadcast is unknown";
+    VLOG(overlay, INFO) << this << ": received getBroadcastQuery(" << query.hash_ << ") from " << src
+                        << " but broadcast is unknown";
     promise.set_value(create_serialize_tl_object<ton_api::overlay_broadcastNotFound>());
     return;
   }
-  VLOG(OVERLAY_DEBUG) << this << ": received getBroadcastQuery(" << query.hash_ << ") from " << src
-                      << " sending broadcast";
+  VLOG(overlay, DEBUG) << this << ": received getBroadcastQuery(" << query.hash_ << ") from " << src
+                       << " sending broadcast";
   promise.set_value(it->second->serialize());
 }
 

--- a/overlay/broadcast-twostep.cpp
+++ b/overlay/broadcast-twostep.cpp
@@ -40,13 +40,12 @@
 #include "broadcast-twostep.hpp"
 #include "overlay.hpp"
 
+DECLARE_LOG_CATEGORY(twostep)
+DEFINE_LOG_CATEGORY(twostep, VERBOSITY_NAME(WARNING))
+
 namespace ton {
 
 namespace overlay {
-
-constexpr int VERBOSITY_NAME(TWOSTEP_WARNING) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(TWOSTEP_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(TWOSTEP_DEBUG) = verbosity_DEBUG;
 
 static constexpr size_t FEC_MIN_BYTES = 513;
 static constexpr size_t FEC_MIN_OTHER_NODES = 5;
@@ -146,12 +145,12 @@ void BroadcastsTwostep::send(OverlayImpl *overlay, PublicKeyHash send_as, td::Bu
     broadcast_id = get_tl_object_sha_bits256(create_tl_object<ton_api::overlay_broadcastTwostep_id>(
         flags, date, send_as.bits256_value(), overlay->local_id().bits256_value(), data_hash,
         static_cast<td::int32>(data_size), static_cast<td::int32>(part_size), extra.clone()));
-    VLOG(TWOSTEP_INFO) << "twostep START sender broadcast_id=" << broadcast_id.to_hex()
-                       << " data_hash=" << data_hash.to_hex() << " data_size=" << data_size
-                       << " recipients=" << other_nodes.size() << " mode=FEC";
+    VLOG(twostep, INFO) << "twostep START sender broadcast_id=" << broadcast_id.to_hex()
+                        << " data_hash=" << data_hash.to_hex() << " data_size=" << data_size
+                        << " recipients=" << other_nodes.size() << " mode=FEC";
     auto R = td::raptorq::Encoder::create(part_size, data.clone());
     if (R.is_error()) {
-      VLOG(TWOSTEP_WARNING) << "cannot create FEC encoder: " << R.move_as_error();
+      VLOG(twostep, WARNING) << "cannot create FEC encoder: " << R.move_as_error();
       return;
     }
     auto encoder = R.move_as_ok();
@@ -161,7 +160,7 @@ void BroadcastsTwostep::send(OverlayImpl *overlay, PublicKeyHash send_as, td::Bu
       td::BufferSlice part(part_size);
       td::Status S = encoder->gen_symbol(seqno, part.as_slice());
       if (S.is_error()) {
-        VLOG(TWOSTEP_WARNING) << "cannot generate symbol: " << S;
+        VLOG(twostep, WARNING) << "cannot generate symbol: " << S;
         continue;
       }
       td::BufferSlice to_sign = create_serialize_tl_object<ton_api::overlay_broadcastTwostepFec_toSign>(
@@ -189,9 +188,9 @@ void BroadcastsTwostep::send(OverlayImpl *overlay, PublicKeyHash send_as, td::Bu
     broadcast_id = get_tl_object_sha_bits256(create_tl_object<ton_api::overlay_broadcastTwostep_id>(
         flags, date, send_as.bits256_value(), overlay->local_id().bits256_value(), data_hash,
         static_cast<std::int32_t>(data_size), static_cast<std::int32_t>(data_size), extra.clone()));
-    VLOG(TWOSTEP_INFO) << "twostep START sender broadcast_id=" << broadcast_id.to_hex()
-                       << " data_hash=" << data_hash.to_hex() << " data_size=" << data_size
-                       << " recipients=" << other_nodes.size() << " mode=simple";
+    VLOG(twostep, INFO) << "twostep START sender broadcast_id=" << broadcast_id.to_hex()
+                        << " data_hash=" << data_hash.to_hex() << " data_size=" << data_size
+                        << " recipients=" << other_nodes.size() << " mode=simple";
     td::BufferSlice to_sign =
         create_serialize_tl_object<ton_api::overlay_broadcastTwostepSimple_toSign>(broadcast_id, data.clone());
     BroadcastTwostepDataSimple passdata{
@@ -235,8 +234,8 @@ void BroadcastsTwostep::signed_simple(OverlayImpl *overlay, BroadcastTwostepData
     return;
   }
   auto V = R.move_as_ok();
-  VLOG(TWOSTEP_INFO) << "twostep SEND_SIMPLE sender broadcast_id=" << data.broadcast_id.to_hex()
-                     << " data_size=" << data.data.size() << " recipients=" << data.dsts.size();
+  VLOG(twostep, INFO) << "twostep SEND_SIMPLE sender broadcast_id=" << data.broadcast_id.to_hex()
+                      << " data_size=" << data.data.size() << " recipients=" << data.dsts.size();
   auto cert = overlay->get_certificate(data.src.pubkey_hash());
   td::BufferSlice broadcast = create_serialize_tl_object<ton_api::overlay_broadcastTwostepSimple>(
       data.flags, data.date, V.second.tl(), overlay->local_id().bits256_value(),
@@ -255,9 +254,9 @@ void BroadcastsTwostep::signed_fec(OverlayImpl *overlay, BroadcastTwostepDataFec
     return;
   }
   auto V = R.move_as_ok();
-  VLOG(TWOSTEP_INFO) << "twostep SEND_CHUNK sender broadcast_id=" << data.broadcast_id.to_hex()
-                     << " data_hash=" << data.data_hash.to_hex() << " data_size=" << data.data_size
-                     << " seqno=" << data.seqno << " part_size=" << data.part.size() << " to=" << data.dst;
+  VLOG(twostep, INFO) << "twostep SEND_CHUNK sender broadcast_id=" << data.broadcast_id.to_hex()
+                      << " data_hash=" << data.data_hash.to_hex() << " data_size=" << data.data_size
+                      << " seqno=" << data.seqno << " part_size=" << data.part.size() << " to=" << data.dst;
   auto cert = overlay->get_certificate(data.src.pubkey_hash());
   td::BufferSlice broadcast = create_serialize_tl_object<ton_api::overlay_broadcastTwostepFec>(
       data.flags, data.date, V.second.tl(), overlay->local_id().bits256_value(),
@@ -316,13 +315,13 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(
       static_cast<std::int32_t>(broadcast->data_.size()), static_cast<std::int32_t>(broadcast->data_.size()),
       broadcast->extra_.clone()));
   if (overlay->is_delivered(broadcast_id)) {
-    VLOG(TWOSTEP_DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex();
+    VLOG(twostep, DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex();
     co_return td::Status::Error(ErrorCode::notready, "duplicate broadcast");
   }
   bool will_rebroadcast = src_peer_id == bcast_src_adnl_id;
-  VLOG(TWOSTEP_INFO) << "twostep RECV_SIMPLE receiver broadcast_id=" << broadcast_id.to_hex()
-                     << " data_hash=" << data_hash.to_hex() << " data_size=" << broadcast->data_.size()
-                     << " from=" << src_peer_id << " will_rebroadcast=" << will_rebroadcast;
+  VLOG(twostep, INFO) << "twostep RECV_SIMPLE receiver broadcast_id=" << broadcast_id.to_hex()
+                      << " data_hash=" << data_hash.to_hex() << " data_size=" << broadcast->data_.size()
+                      << " from=" << src_peer_id << " will_rebroadcast=" << will_rebroadcast;
 
   td::BufferSlice to_sign = create_serialize_tl_object<ton_api::overlay_broadcastTwostepSimple_toSign>(
       broadcast_id, broadcast->data_.clone());
@@ -341,7 +340,7 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(
   // utime and is_delivered could change during precheck_broadcast
   CO_TRY(overlay->check_date(broadcast->date_));
   if (overlay->is_delivered(broadcast_id)) {
-    VLOG(TWOSTEP_DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex();
+    VLOG(twostep, DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex();
     co_return td::Status::Error(ErrorCode::notready, "duplicate broadcast");
   }
   CO_TRY(overlay->get_broadcasts_limiter(src_keyhash, cert.get()).try_register_broadcast(broadcast->data_.size()));
@@ -349,9 +348,9 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(
     td::uint64 total_size = rebroadcast(overlay, bcast_src_adnl_id, serialize_tl_object(broadcast, true));
     overlay->get_broadcasts_limiter(src_keyhash, cert.get()).register_out_traffic(total_size);
   }
-  VLOG(TWOSTEP_INFO) << "twostep FINISH receiver broadcast_id=" << broadcast_id.to_hex()
-                     << " data_hash=" << data_hash.to_hex() << " data_size=" << broadcast->data_.size()
-                     << " decoded=true";
+  VLOG(twostep, INFO) << "twostep FINISH receiver broadcast_id=" << broadcast_id.to_hex()
+                      << " data_hash=" << data_hash.to_hex() << " data_size=" << broadcast->data_.size()
+                      << " decoded=true";
   overlay->register_delivered_broadcast(broadcast_id);
   co_await check_and_deliver(overlay, src_keyhash, check_result, std::move(broadcast->data_),
                              std::move(broadcast->extra_));
@@ -380,7 +379,7 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(OverlayImpl *overlay, adn
       broadcast->data_hash_, broadcast->data_size_, static_cast<td::int32>(part_size), broadcast->extra_.clone()));
   auto it = broadcasts_.find(broadcast_id);
   if (overlay->is_delivered(broadcast_id) || (it != broadcasts_.end() && it->second->seen_parts.contains(seqno))) {
-    VLOG(TWOSTEP_DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex() << " seqno=" << seqno;
+    VLOG(twostep, DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex() << " seqno=" << seqno;
     co_return td::Status::Error(ErrorCode::notready, "duplicate broadcast");
   }
 
@@ -405,7 +404,7 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(OverlayImpl *overlay, adn
     it = broadcasts_.find(broadcast_id);
     CO_TRY(overlay->check_date(date));
     if (overlay->is_delivered(broadcast_id) || (it != broadcasts_.end() && it->second->seen_parts.contains(seqno))) {
-      VLOG(TWOSTEP_DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex() << " seqno=" << seqno;
+      VLOG(twostep, DEBUG) << "twostep DUPLICATE receiver broadcast_id=" << broadcast_id.to_hex() << " seqno=" << seqno;
       co_return td::Status::Error(ErrorCode::notready, "duplicate broadcast");
     }
   }
@@ -431,7 +430,7 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(OverlayImpl *overlay, adn
                                        .chunk_senders = {}}});
     lru_.put(bcast.get());
     it = broadcasts_.emplace(broadcast_id, std::move(bcast)).first;
-    VLOG(TWOSTEP_INFO) << "twostep START receiver " << *it->second << " from=" << src_peer_id;
+    VLOG(twostep, INFO) << "twostep START receiver " << *it->second << " from=" << src_peer_id;
   }
   auto bcast = it->second.get();
   bcast->seen_parts.insert(seqno);
@@ -447,11 +446,11 @@ td::actor::Task<> BroadcastsTwostep::process_broadcast(OverlayImpl *overlay, adn
   bcast->debug.chunk_senders.insert(src_peer_id);
   CO_TRY(bcast->decoder->add_symbol({seqno, std::move(broadcast->part_)}));
   bcast->debug.symbols_received++;
-  VLOG(TWOSTEP_INFO) << "twostep RECV_CHUNK receiver " << *bcast << " seqno=" << seqno << " from=" << src_peer_id
-                     << " will_rebroadcast=" << will_rebroadcast;
+  VLOG(twostep, INFO) << "twostep RECV_CHUNK receiver " << *bcast << " seqno=" << seqno << " from=" << src_peer_id
+                      << " will_rebroadcast=" << will_rebroadcast;
   if (bcast->decoder->may_try_decode()) {
     auto R = CO_TRY(bcast->decoder->try_decode(false));
-    VLOG(TWOSTEP_INFO) << "twostep FINISH receiver " << *bcast << " decoded=true elapsed=" << bcast->debug.elapsed();
+    VLOG(twostep, INFO) << "twostep FINISH receiver " << *bcast << " decoded=true elapsed=" << bcast->debug.elapsed();
     bcast->delivered = true;
     bcast->decoder = {};
     if (broadcast->data_hash_ != td::sha256_bits256(R.data)) {

--- a/overlay/overlay-manager.cpp
+++ b/overlay/overlay-manager.cpp
@@ -33,6 +33,8 @@
 #include "overlay-manager.h"
 #include "overlay.h"
 
+DEFINE_LOG_CATEGORY(overlay, VERBOSITY_NAME(WARNING))
+
 namespace ton {
 
 namespace overlay {
@@ -136,7 +138,7 @@ void OverlayManager::update_dht_node(td::actor::ActorId<dht::Dht> dht) {
 void OverlayManager::register_overlay(adnl::AdnlNodeIdShort local_id, OverlayIdShort overlay_id,
                                       OverlayMemberCertificate cert, td::actor::ActorOwn<Overlay> overlay) {
   auto it = overlays_.find(local_id);
-  VLOG(OVERLAY_INFO) << this << ": registering overlay " << overlay_id << "@" << local_id;
+  VLOG(overlay, INFO) << this << ": registering overlay " << overlay_id << "@" << local_id;
   if (it == overlays_.end()) {
     td::actor::send_closure(adnl_, &adnl::Adnl::subscribe, local_id,
                             adnl::Adnl::int_to_bytestring(ton_api::overlay_message::ID),
@@ -155,8 +157,8 @@ void OverlayManager::register_overlay(adnl::AdnlNodeIdShort local_id, OverlayIdS
 
   auto buffered = buffered_requests_.extract_for_overlay(local_id, overlay_id);
   if (!buffered.empty()) {
-    VLOG(OVERLAY_INFO) << this << ": flushing " << buffered.size() << " buffered requests for " << overlay_id << "@"
-                       << local_id;
+    VLOG(overlay, INFO) << this << ": flushing " << buffered.size() << " buffered requests for " << overlay_id << "@"
+                        << local_id;
     for (auto &req : buffered) {
       if (req.promise.has_value()) {
         receive_query(req.src, req.dst, std::move(req.data), std::move(req.promise.value()));
@@ -273,20 +275,20 @@ void OverlayManager::receive_message(adnl::AdnlNodeIdShort src, adnl::AdnlNodeId
     if (R2.is_ok()) {
       overlay_id = OverlayIdShort{R2.ok()->overlay_};
     } else {
-      VLOG(OVERLAY_WARNING) << this << ": can not parse overlay message [" << src << "->" << dst
-                            << "]: " << R2.move_as_error();
+      VLOG(overlay, WARNING) << this << ": can not parse overlay message [" << src << "->" << dst
+                             << "]: " << R2.move_as_error();
       return;
     }
   }
 
   auto it = overlays_.find(dst);
   if (it == overlays_.end()) {
-    VLOG(OVERLAY_NOTICE) << this << ": message to unknown overlay " << overlay_id << "@" << dst;
+    VLOG(overlay, INFO) << this << ": message to unknown overlay " << overlay_id << "@" << dst;
     return;
   }
   auto it2 = it->second.find(overlay_id);
   if (it2 == it->second.end()) {
-    VLOG(OVERLAY_NOTICE) << this << ": message to localid is not in overlay " << overlay_id << "@" << dst;
+    VLOG(overlay, INFO) << this << ": message to localid is not in overlay " << overlay_id << "@" << dst;
 
     if (buffer_limits_.max_packets != 0 && buffer_limits_.max_data_size >= data.size()) {
       while (buffered_requests_.total_packets >= buffer_limits_.max_packets ||
@@ -318,8 +320,8 @@ void OverlayManager::receive_query(adnl::AdnlNodeIdShort src, adnl::AdnlNodeIdSh
     if (R2.is_ok()) {
       overlay_id = OverlayIdShort{R2.ok()->overlay_};
     } else {
-      VLOG(OVERLAY_WARNING) << this << ": can not parse overlay query [" << src << "->" << dst
-                            << "]: " << R2.move_as_error();
+      VLOG(overlay, WARNING) << this << ": can not parse overlay query [" << src << "->" << dst
+                             << "]: " << R2.move_as_error();
       promise.set_error(td::Status::Error(ErrorCode::protoviolation, "bad overlay query header"));
       return;
     }
@@ -327,13 +329,13 @@ void OverlayManager::receive_query(adnl::AdnlNodeIdShort src, adnl::AdnlNodeIdSh
 
   auto it = overlays_.find(dst);
   if (it == overlays_.end()) {
-    VLOG(OVERLAY_NOTICE) << this << ": query to unknown overlay " << overlay_id << "@" << dst << " from " << src;
+    VLOG(overlay, INFO) << this << ": query to unknown overlay " << overlay_id << "@" << dst << " from " << src;
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, PSTRING() << "bad local_id " << dst));
     return;
   }
   auto it2 = it->second.find(overlay_id);
   if (it2 == it->second.end()) {
-    VLOG(OVERLAY_NOTICE) << this << ": query to localid not in overlay " << overlay_id << "@" << dst << " from " << src;
+    VLOG(overlay, INFO) << this << ": query to localid not in overlay " << overlay_id << "@" << dst << " from " << src;
 
     if (buffer_limits_.max_packets != 0 && buffer_limits_.max_data_size >= data.size()) {
       while (buffered_requests_.total_packets >= buffer_limits_.max_packets ||

--- a/overlay/overlay-manager.h
+++ b/overlay/overlay-manager.h
@@ -25,19 +25,16 @@
 #include "dht/dht.h"
 #include "td/actor/actor.h"
 #include "td/db/KeyValueAsync.h"
+#include "td/utils/logging.h"
 
 #include "overlay-id.hpp"
 #include "overlays.h"
 
+DECLARE_LOG_CATEGORY(overlay)
+
 namespace ton {
 
 namespace overlay {
-
-constexpr int VERBOSITY_NAME(OVERLAY_WARNING) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(OVERLAY_NOTICE) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(OVERLAY_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(OVERLAY_DEBUG) = verbosity_DEBUG + 1;
-constexpr int VERBOSITY_NAME(OVERLAY_EXTRA_DEBUG) = verbosity_DEBUG + 10;
 
 class Overlay;
 

--- a/overlay/overlay-peers.cpp
+++ b/overlay/overlay-peers.cpp
@@ -38,11 +38,11 @@ void OverlayImpl::del_peer(const adnl::AdnlNodeIdShort &id) {
     return;
   }
   if (P->is_permanent_member()) {
-    VLOG(OVERLAY_DEBUG) << this << ": not deleting peer " << id << ": a permanent member";
+    VLOG(overlay, DEBUG) << this << ": not deleting peer " << id << ": a permanent member";
     return;
   }
 
-  VLOG(OVERLAY_DEBUG) << this << ": deleting peer " << id;
+  VLOG(overlay, DEBUG) << this << ": deleting peer " << id;
 
   if (P->is_neighbour()) {
     del_from_neighbour_list(P);
@@ -179,23 +179,23 @@ td::Status OverlayImpl::validate_peer_certificate(const adnl::AdnlNodeIdShort &n
 void OverlayImpl::add_peer(OverlayNode node, bool verified, bool checked_signature) {
   td::Timestamp now = td::Timestamp::now();
   if (!verified && !receive_peers_rate_limiter_.check(now)) {
-    VLOG(OVERLAY_DEBUG) << this << ": dropping new peer: rate limit exceeded";
+    VLOG(overlay, DEBUG) << this << ": dropping new peer: rate limit exceeded";
     return;
   }
   CHECK(overlay_type_ != OverlayType::FixedMemberList);
   if (node.overlay_id() != overlay_id_) {
-    VLOG(OVERLAY_WARNING) << this << ": received node with bad overlay";
+    VLOG(overlay, WARNING) << this << ": received node with bad overlay";
     return;
   }
   auto t = td::Clocks::system();
   if (node.version() + Overlays::overlay_peer_ttl() < t || node.version() > t + 60) {
-    VLOG(OVERLAY_INFO) << this << ": ignoring node of too old version " << node.version();
+    VLOG(overlay, INFO) << this << ": ignoring node of too old version " << node.version();
     return;
   }
 
   auto pub_id = node.adnl_id_full();
   if (pub_id.compute_short_id() == local_id_) {
-    VLOG(OVERLAY_DEBUG) << this << ": ignoring self node";
+    VLOG(overlay, DEBUG) << this << ": ignoring self node";
     return;
   }
 
@@ -205,7 +205,7 @@ void OverlayImpl::add_peer(OverlayNode node, bool verified, bool checked_signatu
   if (!checked_signature) {
     auto S = node.check_signature();
     if (S.is_error()) {
-      VLOG(OVERLAY_WARNING) << this << ": bad signature: " << S;
+      VLOG(overlay, WARNING) << this << ": bad signature: " << S;
       return;
     }
   }
@@ -213,8 +213,8 @@ void OverlayImpl::add_peer(OverlayNode node, bool verified, bool checked_signatu
   if (overlay_type_ == OverlayType::CertificatedMembers) {
     auto R = validate_peer_certificate(node.adnl_id_short(), *node.certificate());
     if (R.is_error()) {
-      VLOG(OVERLAY_WARNING) << this << ": bad peer certificate node=" << node.adnl_id_short() << ": "
-                            << R.move_as_error();
+      VLOG(overlay, WARNING) << this << ": bad peer certificate node=" << node.adnl_id_short() << ": "
+                             << R.move_as_error();
       return;
     }
   }
@@ -223,10 +223,10 @@ void OverlayImpl::add_peer(OverlayNode node, bool verified, bool checked_signatu
 
   auto V = peer_list_.peers_.get(id);
   if (V) {
-    VLOG(OVERLAY_DEBUG) << this << ": updating peer " << id << " up to version " << node.version();
+    VLOG(overlay, DEBUG) << this << ": updating peer " << id << " up to version " << node.version();
     V->update(std::move(node));
   } else if (verified) {
-    VLOG(OVERLAY_DEBUG) << this << ": adding peer " << id << " of version " << node.version();
+    VLOG(overlay, DEBUG) << this << ": adding peer " << id << " of version " << node.version();
     CHECK(overlay_type_ != OverlayType::CertificatedMembers || (node.certificate() && !node.certificate()->empty()));
     peer_list_.peers_.insert(id, OverlayPeer(std::move(node)));
     peer_list_.pending_peers_.remove(id);
@@ -240,7 +240,7 @@ void OverlayImpl::add_peer(OverlayNode node, bool verified, bool checked_signatu
 
     update_neighbours(0);
   } else if (!processing_pending_peers_.contains(id)) {
-    VLOG(OVERLAY_DEBUG) << this << ": adding pending peer " << id << " of version " << node.version();
+    VLOG(overlay, DEBUG) << this << ": adding pending peer " << id << " of version " << node.version();
     auto pending = peer_list_.pending_peers_.get(id);
     if (pending) {
       pending->update(std::move(node));
@@ -261,8 +261,8 @@ void OverlayImpl::process_pending_peers() {
     OverlayNode node = std::move(*peer_list_.pending_peers_.get_random());
     peer_list_.pending_peers_.remove(node.adnl_id_short());
     if (node.version() + Overlays::overlay_peer_ttl() < td::Clocks::system()) {
-      VLOG(OVERLAY_INFO) << this << ": dropping pending node " << node.adnl_id_short() << " of too old version "
-                         << node.version();
+      VLOG(overlay, INFO) << this << ": dropping pending node " << node.adnl_id_short() << " of too old version "
+                          << node.version();
       continue;
     }
     process_pending_peers_rate_limiter_.insert(td::Timestamp::now());
@@ -272,7 +272,7 @@ void OverlayImpl::process_pending_peers() {
 }
 
 td::actor::Task<> OverlayImpl::process_pending_peer(OverlayNode node) {
-  VLOG(OVERLAY_INFO) << this << ": trying to ping pending peer " << node.adnl_id_short();
+  VLOG(overlay, INFO) << this << ": trying to ping pending peer " << node.adnl_id_short();
   for (size_t attempt = 0; attempt < 3; ++attempt) {
     auto [task, promise] = td::actor::StartedTask<td::BufferSlice>::make_bridge();
     td::actor::send_closure(manager_, &OverlayManager::send_query, node.adnl_id_short(), local_id_, overlay_id_,
@@ -280,13 +280,13 @@ td::actor::Task<> OverlayImpl::process_pending_peer(OverlayNode node) {
                             create_serialize_tl_object<ton_api::overlay_ping>());
     auto result = co_await std::move(task).wrap();
     if (result.is_ok() || peer_list_.peers_.exists(node.adnl_id_short())) {
-      VLOG(OVERLAY_INFO) << this << ": adding pending peer " << node.adnl_id_short();
+      VLOG(overlay, INFO) << this << ": adding pending peer " << node.adnl_id_short();
       processing_pending_peers_.erase(node.adnl_id_short());
       add_peer(std::move(node), /* verified = */ true, /* checked_signature = */ true);
       co_return {};
     }
   }
-  VLOG(OVERLAY_INFO) << this << ": dropping pending node " << node.adnl_id_short() << " - does not respond";
+  VLOG(overlay, INFO) << this << ": dropping pending node " << node.adnl_id_short() << " - does not respond";
   processing_pending_peers_.erase(node.adnl_id_short());
   co_return {};
 }
@@ -342,13 +342,13 @@ void OverlayImpl::receive_random_peers(adnl::AdnlNodeIdShort src, td::Result<td:
   CHECK(overlay_type_ != OverlayType::FixedMemberList);
   on_ping_result(src, R.is_ok(), elapsed);
   if (R.is_error()) {
-    VLOG(OVERLAY_NOTICE) << this << ": failed getRandomPeers query: " << R.move_as_error();
+    VLOG(overlay, INFO) << this << ": failed getRandomPeers query: " << R.move_as_error();
     return;
   }
   auto R2 = fetch_tl_object<ton_api::overlay_nodes>(R.move_as_ok(), true);
   if (R2.is_error()) {
-    VLOG(OVERLAY_WARNING) << this << ": dropping incorrect answer to overlay.getRandomPeers query from " << src << ": "
-                          << R2.move_as_error();
+    VLOG(overlay, WARNING) << this << ": dropping incorrect answer to overlay.getRandomPeers query from " << src << ": "
+                           << R2.move_as_error();
     return;
   }
 
@@ -359,13 +359,13 @@ void OverlayImpl::receive_random_peers_v2(adnl::AdnlNodeIdShort src, td::Result<
   CHECK(overlay_type_ != OverlayType::FixedMemberList);
   on_ping_result(src, R.is_ok(), elapsed);
   if (R.is_error()) {
-    VLOG(OVERLAY_NOTICE) << this << ": failed getRandomPeersV2 query: " << R.move_as_error();
+    VLOG(overlay, INFO) << this << ": failed getRandomPeersV2 query: " << R.move_as_error();
     return;
   }
   auto R2 = fetch_tl_object<ton_api::overlay_nodesV2>(R.move_as_ok(), true);
   if (R2.is_error()) {
-    VLOG(OVERLAY_WARNING) << this << ": dropping incorrect answer to overlay.getRandomPeers query from " << src << ": "
-                          << R2.move_as_error();
+    VLOG(overlay, WARNING) << this << ": dropping incorrect answer to overlay.getRandomPeers query from " << src << ": "
+                           << R2.move_as_error();
     return;
   }
 
@@ -476,7 +476,7 @@ void OverlayImpl::ping_random_peers() {
     auto P = td::PromiseCreator::lambda(
         [SelfId = actor_id(this), peer, timer = td::Timer(), oid = print_id()](td::Result<td::BufferSlice> R) {
           if (R.is_error()) {
-            VLOG(OVERLAY_INFO) << oid << " ping to " << peer << " failed : " << R.move_as_error();
+            VLOG(overlay, INFO) << oid << " ping to " << peer << " failed : " << R.move_as_error();
             return;
           }
           td::actor::send_closure(SelfId, &OverlayImpl::receive_pong, peer, timer.elapsed());
@@ -535,7 +535,7 @@ void OverlayImpl::update_neighbours(td::uint32 nodes_to_change, bool allow_delet
     }
 
     if (peer_list_.neighbours_.size() < max_neighbours()) {
-      VLOG(OVERLAY_INFO) << this << ": adding new neighbour " << X->get_id();
+      VLOG(overlay, INFO) << this << ": adding new neighbour " << X->get_id();
       peer_list_.neighbours_.push_back(X->get_id());
       X->set_neighbour(true);
     } else {
@@ -548,7 +548,7 @@ void OverlayImpl::update_neighbours(td::uint32 nodes_to_change, bool allow_delet
       peer_list_.neighbours_[i] = X->get_id();
       X->set_neighbour(true);
       nodes_to_change--;
-      VLOG(OVERLAY_INFO) << this << ": changing neighbour " << Y->get_id() << " -> " << X->get_id();
+      VLOG(overlay, INFO) << this << ": changing neighbour " << Y->get_id() << " -> " << X->get_id();
     }
   }
 }
@@ -560,7 +560,7 @@ OverlayPeer *OverlayImpl::get_random_peer(bool only_alive) {
     auto P = peer_list_.peers_.get_random();
     if (!P->is_permanent_member() &&
         (P->get_version() + 3600 < td::Clocks::system() || P->certificate()->is_expired())) {
-      VLOG(OVERLAY_INFO) << this << ": deleting outdated peer " << P->get_id();
+      VLOG(overlay, INFO) << this << ": deleting outdated peer " << P->get_id();
       del_peer(P->get_id());
       continue;
     }
@@ -586,7 +586,7 @@ void OverlayImpl::get_overlay_random_peers(td::uint32 max_peers,
   while (v.size() < max_peers && v.size() < peer_list_.peers_.size() - peer_list_.bad_peers_.size()) {
     auto P = peer_list_.peers_.get_random();
     if (!P->is_permanent_member() && (P->get_version() + 3600 < t || P->certificate()->is_expired(t))) {
-      VLOG(OVERLAY_INFO) << this << ": deleting outdated peer " << P->get_id();
+      VLOG(overlay, INFO) << this << ": deleting outdated peer " << P->get_id();
       del_peer(P->get_id());
     } else if (P->is_alive()) {
       bool dup = false;
@@ -650,7 +650,7 @@ bool OverlayImpl::check_src_peer(const adnl::AdnlNodeIdShort &src,
 
     auto S = validate_peer_certificate(src, cert, true);
     if (S.is_error()) {
-      VLOG(OVERLAY_WARNING) << "adnl=" << src << ": certificate is invalid: " << S;
+      VLOG(overlay, WARNING) << "adnl=" << src << ": certificate is invalid: " << S;
       return false;
     }
     auto P = peer_list_.peers_.get(src);

--- a/overlay/overlay.cpp
+++ b/overlay/overlay.cpp
@@ -106,7 +106,7 @@ OverlayImpl::OverlayImpl(td::actor::ActorId<keyring::Keyring> keyring, td::actor
   peer_list_.local_member_flags_ = opts_.local_overlay_member_flags_;
   opts_.broadcast_speed_multiplier_ = std::max(opts_.broadcast_speed_multiplier_, 1e-9);
 
-  VLOG(OVERLAY_INFO) << this << ": creating";
+  VLOG(overlay, INFO) << this << ": creating";
 
   auto nodes_size = static_cast<td::uint32>(nodes.size());
   OverlayImpl::update_root_member_list(std::move(nodes), std::move(root_public_keys), std::move(cert));
@@ -114,12 +114,12 @@ OverlayImpl::OverlayImpl(td::actor::ActorId<keyring::Keyring> keyring, td::actor
 
   if (overlay_type_ == OverlayType::Public &&
       (!opts_.twostep_broadcast_sender_.empty() || opts_.send_twostep_broadcast_)) {
-    VLOG(OVERLAY_WARNING) << "Cannot enable twostep broadcasts in public overlay";
+    VLOG(overlay, WARNING) << "Cannot enable twostep broadcasts in public overlay";
     opts_.twostep_broadcast_sender_ = {};
     opts_.send_twostep_broadcast_ = false;
   }
   if (opts_.send_twostep_broadcast_ && opts_.twostep_broadcast_sender_.empty()) {
-    VLOG(OVERLAY_WARNING) << "Twostep broadcast sender is not set";
+    VLOG(overlay, WARNING) << "Twostep broadcast sender is not set";
     opts_.send_twostep_broadcast_ = false;
   }
   if (!opts_.twostep_broadcast_sender_.empty()) {
@@ -135,12 +135,12 @@ OverlayImpl::OverlayImpl(td::actor::ActorId<keyring::Keyring> keyring, td::actor
 void OverlayImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay_getRandomPeers &query,
                                 td::Promise<td::BufferSlice> promise) {
   if (overlay_type_ != OverlayType::FixedMemberList) {
-    VLOG(OVERLAY_DEBUG) << this << ": received " << query.peers_->nodes_.size() << " nodes from " << src
-                        << " in getRandomPeers query";
+    VLOG(overlay, DEBUG) << this << ": received " << query.peers_->nodes_.size() << " nodes from " << src
+                         << " in getRandomPeers query";
     add_peers(query.peers_, /* verified = */ false);
     send_random_peers(src, std::move(promise));
   } else {
-    VLOG(OVERLAY_WARNING) << this << ": DROPPING getRandomPeers query from " << src << " in private overlay";
+    VLOG(overlay, WARNING) << this << ": DROPPING getRandomPeers query from " << src << " in private overlay";
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "overlay is private"));
   }
 }
@@ -148,12 +148,12 @@ void OverlayImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay_getR
 void OverlayImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay_getRandomPeersV2 &query,
                                 td::Promise<td::BufferSlice> promise) {
   if (overlay_type_ != OverlayType::FixedMemberList) {
-    VLOG(OVERLAY_DEBUG) << this << ": received " << query.peers_->nodes_.size() << " nodes from " << src
-                        << " in getRandomPeers query";
+    VLOG(overlay, DEBUG) << this << ": received " << query.peers_->nodes_.size() << " nodes from " << src
+                         << " in getRandomPeers query";
     add_peers(query.peers_, /* verified = */ false);
     send_random_peers_v2(src, std::move(promise));
   } else {
-    VLOG(OVERLAY_WARNING) << this << ": DROPPING getRandomPeers query from " << src << " in private overlay";
+    VLOG(overlay, WARNING) << this << ": DROPPING getRandomPeers query from " << src << " in private overlay";
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "overlay is private"));
   }
 }
@@ -170,7 +170,7 @@ void OverlayImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay_getB
 
 void OverlayImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay_getBroadcastList &query,
                                 td::Promise<td::BufferSlice> promise) {
-  VLOG(OVERLAY_WARNING) << this << ": DROPPING getBroadcastList query";
+  VLOG(overlay, WARNING) << this << ": DROPPING getBroadcastList query";
   promise.set_error(td::Status::Error(ErrorCode::protoviolation, "dropping get broadcast list query"));
 }
 
@@ -182,7 +182,7 @@ void OverlayImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::overlay_getB
 void OverlayImpl::receive_query(adnl::AdnlNodeIdShort src, tl_object_ptr<ton_api::overlay_messageExtra> extra,
                                 td::BufferSlice data, td::Promise<td::BufferSlice> promise) {
   if (!check_src_peer(src, extra ? extra->certificate_.get() : nullptr)) {
-    VLOG(OVERLAY_WARNING) << this << ": received query in private overlay from unknown source " << src;
+    VLOG(overlay, WARNING) << this << ": received query in private overlay from unknown source " << src;
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "overlay is not public"));
     return;
   }
@@ -197,7 +197,7 @@ void OverlayImpl::receive_query(adnl::AdnlNodeIdShort src, tl_object_ptr<ton_api
 
   auto Q = R.move_as_ok();
 
-  VLOG(OVERLAY_EXTRA_DEBUG) << this << "query from " << src << ": " << ton_api::to_string(Q);
+  VLOG(overlay, DEBUG) << this << "query from " << src << ": " << ton_api::to_string(Q);
 
   ton_api::downcast_call(*Q.get(), [&](auto &object) { this->process_query(src, object, std::move(promise)); });
 }
@@ -256,7 +256,7 @@ td::actor::Task<> OverlayImpl::process_broadcast(adnl::AdnlNodeIdShort message_f
 
 td::actor::Task<> OverlayImpl::process_broadcast(adnl::AdnlNodeIdShort message_from,
                                                  tl_object_ptr<ton_api::overlay_unicast> msg) {
-  VLOG(OVERLAY_DEBUG) << this << ": received unicast from " << message_from;
+  VLOG(overlay, DEBUG) << this << ": received unicast from " << message_from;
   callback_->receive_message(message_from, overlay_id_, std::move(msg->data_));
   co_return {};
 }
@@ -282,13 +282,13 @@ td::actor::Task<> OverlayImpl::process_broadcast(adnl::AdnlNodeIdShort message_f
 void OverlayImpl::receive_message(adnl::AdnlNodeIdShort src, tl_object_ptr<ton_api::overlay_messageExtra> extra,
                                   td::BufferSlice data) {
   if (!check_src_peer(src, extra ? extra->certificate_.get() : nullptr)) {
-    VLOG(OVERLAY_WARNING) << this << ": received message in private overlay from unknown source " << src;
+    VLOG(overlay, WARNING) << this << ": received message in private overlay from unknown source " << src;
     return;
   }
 
   auto X = fetch_tl_object<ton_api::overlay_Broadcast>(data.clone(), true);
   if (X.is_error()) {
-    VLOG(OVERLAY_DEBUG) << this << ": received custom message";
+    VLOG(overlay, DEBUG) << this << ": received custom message";
     callback_->receive_message(src, overlay_id_, std::move(data));
     return;
   }
@@ -350,8 +350,8 @@ void OverlayImpl::alarm() {
         }
       }
     } else {
-      VLOG(OVERLAY_WARNING) << "member certificate ist invalid, valid_until="
-                            << peer_list_.local_cert_is_valid_until_.at_unix();
+      VLOG(overlay, WARNING) << "member certificate ist invalid, valid_until="
+                             << peer_list_.local_cert_is_valid_until_.at_unix();
     }
     if (next_dht_query_ && next_dht_query_.is_in_past() && overlay_type_ == OverlayType::Public) {
       next_dht_query_ = td::Timestamp::never();
@@ -437,8 +437,8 @@ void OverlayImpl::receive_dht_nodes(dht::DhtValue v) {
   auto R = fetch_tl_object<ton_api::overlay_nodes>(v.value().clone(), true);
   if (R.is_ok()) {
     auto r = R.move_as_ok();
-    VLOG(OVERLAY_INFO) << this << ": received " << r->nodes_.size() << " nodes from overlay";
-    VLOG(OVERLAY_EXTRA_DEBUG) << this << ": nodes: " << ton_api::to_string(r);
+    VLOG(overlay, INFO) << this << ": received " << r->nodes_.size() << " nodes from overlay";
+    VLOG(overlay, DEBUG) << this << ": nodes: " << ton_api::to_string(r);
     std::vector<OverlayNode> nodes;
     for (auto &n : r->nodes_) {
       auto N = OverlayNode::create(n);
@@ -448,13 +448,13 @@ void OverlayImpl::receive_dht_nodes(dht::DhtValue v) {
     }
     add_peers(std::move(nodes), /* verified = */ false);
   } else {
-    VLOG(OVERLAY_WARNING) << this << ": incorrect value in DHT for overlay nodes: " << R.move_as_error();
+    VLOG(overlay, WARNING) << this << ": incorrect value in DHT for overlay nodes: " << R.move_as_error();
   }
 }
 
 void OverlayImpl::dht_lookup_finished(td::Status S) {
   if (S.is_error()) {
-    VLOG(OVERLAY_NOTICE) << this << ": can not get value from DHT: " << S;
+    VLOG(overlay, INFO) << this << ": can not get value from DHT: " << S;
   }
   if (!(next_dht_store_query_ && next_dht_store_query_.is_in_past())) {
     finish_dht_query();
@@ -466,7 +466,7 @@ void OverlayImpl::dht_lookup_finished(td::Status S) {
     return;
   }
 
-  VLOG(OVERLAY_INFO) << this << ": adding self node to DHT overlay's nodes";
+  VLOG(overlay, INFO) << this << ": adding self node to DHT overlay's nodes";
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), oid = print_id()](td::Result<OverlayNode> R) {
     if (R.is_error()) {
       LOG(ERROR) << oid << "cannot get self node";
@@ -497,7 +497,7 @@ void OverlayImpl::update_dht_nodes(OverlayNode node) {
 
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), oid = print_id()](td::Result<td::Unit> res) {
     if (res.is_error()) {
-      VLOG(OVERLAY_NOTICE) << oid << ": error storing to DHT: " << res.move_as_error();
+      VLOG(overlay, INFO) << oid << ": error storing to DHT: " << res.move_as_error();
     }
     td::actor::send_closure(SelfId, &OverlayImpl::finish_dht_query);
   });
@@ -519,13 +519,13 @@ void OverlayImpl::bcast_gc() {
 
 void OverlayImpl::send_broadcast(PublicKeyHash send_as, td::uint32 flags, td::BufferSlice data) {
   if (!has_valid_membership_certificate()) {
-    VLOG(OVERLAY_WARNING) << "member certificate is invalid, valid_until="
-                          << peer_list_.local_cert_is_valid_until_.at_unix();
+    VLOG(overlay, WARNING) << "member certificate is invalid, valid_until="
+                           << peer_list_.local_cert_is_valid_until_.at_unix();
     return;
   }
   if (!has_valid_broadcast_certificate(send_as, data.size(), /* is_fec = */ false,
                                        /* is_any_sender = */ flags & Overlays::BroadcastFlagAnySender())) {
-    VLOG(OVERLAY_WARNING) << "broadcast source certificate is invalid";
+    VLOG(overlay, WARNING) << "broadcast source certificate is invalid";
     return;
   }
   flags &= ~Overlays::BroadcastFlagNoTwostep();
@@ -535,8 +535,8 @@ void OverlayImpl::send_broadcast(PublicKeyHash send_as, td::uint32 flags, td::Bu
 void OverlayImpl::send_broadcast_fec(PublicKeyHash send_as, td::uint32 flags, td::BufferSlice data,
                                      td::BufferSlice extra) {
   if (!has_valid_membership_certificate()) {
-    VLOG(OVERLAY_WARNING) << "member certificate is invalid, valid_until="
-                          << peer_list_.local_cert_is_valid_until_.at_unix();
+    VLOG(overlay, WARNING) << "member certificate is invalid, valid_until="
+                           << peer_list_.local_cert_is_valid_until_.at_unix();
     return;
   }
   bool twostep = opts_.send_twostep_broadcast_ && !(flags & Overlays::BroadcastFlagNoTwostep());
@@ -544,7 +544,7 @@ void OverlayImpl::send_broadcast_fec(PublicKeyHash send_as, td::uint32 flags, td
   if (!has_valid_broadcast_certificate(
           send_as, data.size(), /* is_fec = */ true,
           /* is_any_sender = */ (flags & Overlays::BroadcastFlagAnySender()) && !twostep)) {
-    VLOG(OVERLAY_WARNING) << "broadcast source certificate is invalid";
+    VLOG(overlay, WARNING) << "broadcast source certificate is invalid";
     return;
   }
   if (twostep) {
@@ -595,7 +595,7 @@ BroadcastCheckResult OverlayImpl::check_source_eligible(const PublicKeyHash &sou
   if (r2 != BroadcastCheckResult::Forbidden && !cached) {
     td::Timestamp now = td::Timestamp::now();
     if (!limiter.certificate_check_rate_limiter_.check(now)) {
-      VLOG(OVERLAY_NOTICE) << "dropping certificate from " << cert->issuer_hash() << " : rate limit exceeded";
+      VLOG(overlay, INFO) << "dropping certificate from " << cert->issuer_hash() << " : rate limit exceeded";
       r2 = BroadcastCheckResult::Forbidden;
     } else {
       td::Status check_result;
@@ -606,7 +606,7 @@ BroadcastCheckResult OverlayImpl::check_source_eligible(const PublicKeyHash &sou
       }
       if (check_result.is_error()) {
         r2 = BroadcastCheckResult::Forbidden;
-        VLOG(OVERLAY_NOTICE) << "dropping certificate from " << cert->issuer_hash() << " : " << check_result;
+        VLOG(overlay, INFO) << "dropping certificate from " << cert->issuer_hash() << " : " << check_result;
       } else {
         limiter.certificate_check_rate_limiter_.insert(now);
         limiter.checked_certificates_lru_.put(cache_key, td::Unit{});

--- a/rldp2/BdwStats.cpp
+++ b/rldp2/BdwStats.cpp
@@ -56,7 +56,7 @@ void BdwStats::on_packet_ack(const PacketInfo &info, td::Timestamp sent_at, td::
   auto ack_passed = now.at() - effective_delivered_at.at();
   auto passed = td::max(sent_passed, ack_passed);
   if (passed < 0.01) {
-    VLOG(RLDP_INFO) << "Invalid passed " << passed;
+    VLOG(rldp2, INFO) << "Invalid passed " << passed;
   }
   auto delivered = delivered_count - info.delivered_count;
   on_rate_sample((double)delivered / passed, now, info.is_paused);

--- a/rldp2/RldpConnection.cpp
+++ b/rldp2/RldpConnection.cpp
@@ -82,7 +82,7 @@ td::Timestamp RldpConnection::loop_limits(td::Timestamp now) {
         outbound_transfers_.erase(it);
         to_on_sent_.emplace_back(limit->transfer_id, std::move(error));
       } else {
-        VLOG(RLDP_WARNING) << "Timeout on unknown transfer " << limit->transfer_id.to_hex();
+        VLOG(rldp2, WARNING) << "Timeout on unknown transfer " << limit->transfer_id.to_hex();
       }
     }
     limits_set_.erase(*limit);
@@ -113,7 +113,7 @@ void RldpConnection::send(TransferId transfer_id, td::BufferSlice data, td::Time
     td::Random::secure_bytes(transfer_id.as_slice());
   } else {
     if (outbound_transfers_.find(transfer_id) != outbound_transfers_.end()) {
-      VLOG(RLDP_WARNING) << "Skip resend of " << transfer_id.to_hex();
+      VLOG(rldp2, WARNING) << "Skip resend of " << transfer_id.to_hex();
       return;
     }
   }
@@ -124,7 +124,7 @@ void RldpConnection::send(TransferId transfer_id, td::BufferSlice data, td::Time
     limit.max_size = 0;
     limit.is_inbound = false;
     if (limits_set_.contains(limit)) {
-      VLOG(RLDP_WARNING) << "Dropping outbound transfer: duplicate transfer_id";
+      VLOG(rldp2, WARNING) << "Dropping outbound transfer: duplicate transfer_id";
       return;
     }
     add_limit(timeout, limit);
@@ -276,12 +276,12 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
 
   auto r_total_size = td::narrow_cast_safe<std::size_t>(part.total_size_);
   if (r_total_size.is_error()) {
-    VLOG(RLDP_INFO) << "Drop bad rldp message: " << r_total_size.move_as_error();
+    VLOG(rldp2, INFO) << "Drop bad rldp message: " << r_total_size.move_as_error();
     return;
   }
   auto r_fec_type = ton::fec::FecType::create(std::move(part.fec_type_));
   if (r_fec_type.is_error()) {
-    VLOG(RLDP_INFO) << "Drop bad rldp message: " << r_fec_type.move_as_error();
+    VLOG(rldp2, INFO) << "Drop bad rldp message: " << r_fec_type.move_as_error();
     return;
   }
   if (r_fec_type.ok().symbol_size() != OutboundTransfer::symbol_size()) {
@@ -290,7 +290,7 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
   }
   auto r_seqno = td::narrow_cast_safe<td::uint32>(part.seqno_);
   if (r_seqno.is_error()) {
-    VLOG(RLDP_INFO) << "Drop bad rldp message: " << r_seqno.move_as_error();
+    VLOG(rldp2, INFO) << "Drop bad rldp message: " << r_seqno.move_as_error();
     return;
   }
   td::uint32 seqno = r_seqno.move_as_ok();
@@ -310,7 +310,7 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
     max_size = limit_it->max_size;
   }
   if (total_size > max_size) {
-    VLOG(RLDP_INFO) << "Drop too big rldp message: " << part.total_size_ << " > " << max_size;
+    VLOG(rldp2, INFO) << "Drop too big rldp message: " << part.total_size_ << " > " << max_size;
     return;
   }
   size_t n_parts = (total_size + OutboundTransfer::part_size() - 1) / OutboundTransfer::part_size();

--- a/rldp2/RldpConnection.cpp
+++ b/rldp2/RldpConnection.cpp
@@ -285,7 +285,7 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
     return;
   }
   if (r_fec_type.ok().symbol_size() != OutboundTransfer::symbol_size()) {
-    VLOG(RLDP_INFO) << "Drop bad rldp message: bad symbol size " << r_fec_type.ok().symbol_size();
+    VLOG(rldp2, INFO) << "Drop bad rldp message: bad symbol size " << r_fec_type.ok().symbol_size();
     return;
   }
   auto r_seqno = td::narrow_cast_safe<td::uint32>(part.seqno_);
@@ -316,8 +316,8 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
   size_t n_parts = (total_size + OutboundTransfer::part_size() - 1) / OutboundTransfer::part_size();
   td::uint32 part_idx = part.part_;
   if (part_idx >= n_parts) {
-    VLOG(RLDP_INFO) << "Drop rldp message: part_idx=" << part_idx << " >= n_parts=" << n_parts
-                    << " (total_size=" << total_size << ")";
+    VLOG(rldp2, INFO) << "Drop rldp message: part_idx=" << part_idx << " >= n_parts=" << n_parts
+                      << " (total_size=" << total_size << ")";
     return;
   }
   size_t part_size = r_fec_type.ok().size();
@@ -325,8 +325,8 @@ void RldpConnection::receive_raw_obj(ton::ton_api::rldp2_messagePart &part) {
                                   ? total_size % OutboundTransfer::part_size()
                                   : OutboundTransfer::part_size();
   if (part_size != expected_part_size) {
-    VLOG(RLDP_INFO) << "Drop rldp message: part_size=" << part_size << " != " << expected_part_size
-                    << " (total_size=" << total_size << ", part_idx=" << part_idx << ")";
+    VLOG(rldp2, INFO) << "Drop rldp message: part_size=" << part_size << " != " << expected_part_size
+                      << " (total_size=" << total_size << ", part_idx=" << part_idx << ")";
     return;
   }
 

--- a/rldp2/RttStats.cpp
+++ b/rldp2/RttStats.cpp
@@ -27,11 +27,11 @@ namespace rldp2 {
 void RttStats::on_rtt_sample(double rtt_sample, double ack_delay, td::Timestamp now) {
   // Accept RTT samples from 1ms to 10s
   if (rtt_sample < 0.001 || rtt_sample > 10) {
-    VLOG(RLDP_INFO) << "Suspicious rtt sample " << rtt_sample;
+    VLOG(rldp2, INFO) << "Suspicious rtt sample " << rtt_sample;
     return;
   }
   if (ack_delay < -1e-9 || ack_delay > 10) {
-    VLOG(RLDP_INFO) << "Suspicious ack_delay " << ack_delay;
+    VLOG(rldp2, INFO) << "Suspicious ack_delay " << ack_delay;
     return;
   }
   // Floor at 1ms - prevents issues with near-zero RTT

--- a/rldp2/rldp.cpp
+++ b/rldp2/rldp.cpp
@@ -24,6 +24,8 @@
 #include "RldpConnection.h"
 #include "rldp-in.hpp"
 
+DEFINE_LOG_CATEGORY(rldp2, VERBOSITY_NAME(WARNING))
+
 namespace ton {
 
 namespace rldp2 {
@@ -154,7 +156,7 @@ td::actor::ActorId<RldpConnectionActor> RldpIn::get_or_create_connection(adnl::A
   }
   td::uint64 mtu = get_peer_mtu(local_id, peer_id);
   if (mtu == 0 && incoming) {
-    VLOG(RLDP_INFO) << "dropping incoming packet " << local_id << " <- " << peer_id << " : peer not allowed";
+    VLOG(rldp2, INFO) << "dropping incoming packet " << local_id << " <- " << peer_id << " : peer not allowed";
     return {};
   }
   auto connection =
@@ -164,8 +166,8 @@ td::actor::ActorId<RldpConnectionActor> RldpIn::get_or_create_connection(adnl::A
   connections_[std::make_pair(local_id, peer_id)] = {std::move(connection), timeout};
   timeout_set_.emplace(timeout, local_id, peer_id);
   alarm_timestamp().relax(timeout);
-  VLOG(RLDP_INFO) << "creating connection " << local_id << " , " << peer_id << " ("
-                  << (incoming ? "inbound" : "outbound") << ")";
+  VLOG(rldp2, INFO) << "creating connection " << local_id << " , " << peer_id << " ("
+                    << (incoming ? "inbound" : "outbound") << ")";
   return res;
 }
 
@@ -176,7 +178,7 @@ void RldpIn::receive_message(adnl::AdnlNodeIdShort source, adnl::AdnlNodeIdShort
       it->second.set_error(r_data.move_as_error());
       queries_.erase(it);
     } else {
-      VLOG(RLDP_INFO) << "received error to unknown transfer_id " << transfer_id << " " << r_data.error();
+      VLOG(rldp2, INFO) << "received error to unknown transfer_id " << transfer_id << " " << r_data.error();
     }
     return;
   }
@@ -184,7 +186,7 @@ void RldpIn::receive_message(adnl::AdnlNodeIdShort source, adnl::AdnlNodeIdShort
   auto data = r_data.move_as_ok();
   auto F = fetch_tl_object<ton_api::rldp_Message>(std::move(data), true);
   if (F.is_error()) {
-    VLOG(RLDP_INFO) << "failed to parse rldp packet [" << source << "->" << local_id << "]: " << F.error();
+    VLOG(rldp2, INFO) << "failed to parse rldp packet [" << source << "->" << local_id << "]: " << F.error();
     if (auto it = queries_.find(transfer_id); it != queries_.end()) {
       it->second.set_error(F.move_as_error_prefix("received invalid rldp query answer: "));
       queries_.erase(it);
@@ -215,7 +217,7 @@ void RldpIn::process_message(adnl::AdnlNodeIdShort source, adnl::AdnlNodeIdShort
     if (R.is_ok()) {
       auto data = R.move_as_ok();
       if (data.size() > max_answer_size) {
-        VLOG(RLDP_NOTICE) << "rldp query failed: answer too big";
+        VLOG(rldp2, INFO) << "rldp query failed: answer too big";
       } else {
         if (!timeout || td::Timestamp::in(60.0) < timeout) {
           timeout = td::Timestamp::in(60.0);
@@ -224,10 +226,10 @@ void RldpIn::process_message(adnl::AdnlNodeIdShort source, adnl::AdnlNodeIdShort
                                 transfer_id ^ TransferId::ones(), std::move(data));
       }
     } else {
-      VLOG(RLDP_NOTICE) << "rldp query failed: " << R.move_as_error();
+      VLOG(rldp2, INFO) << "rldp query failed: " << R.move_as_error();
     }
   });
-  VLOG(RLDP_DEBUG) << "delivering rldp query";
+  VLOG(rldp2, DEBUG) << "delivering rldp query";
   td::actor::send_closure(adnl_, &adnl::AdnlPeerTable::deliver_query, source, local_id, std::move(message.data_),
                           std::move(P));
 }
@@ -239,7 +241,7 @@ void RldpIn::process_message(adnl::AdnlNodeIdShort source, adnl::AdnlNodeIdShort
     it->second.set_value(std::move(message.data_));
     queries_.erase(it);
   } else {
-    VLOG(RLDP_INFO) << "received answer to unknown query " << message.query_id_;
+    VLOG(rldp2, INFO) << "received answer to unknown query " << message.query_id_;
   }
 }
 
@@ -293,7 +295,7 @@ void RldpIn::alarm() {
   for (auto it = timeout_set_.begin(); it != timeout_set_.end();) {
     auto &[timeout, local_id, peer_id] = *it;
     if (timeout.is_in_past()) {
-      VLOG(RLDP_INFO) << "removing old connection " << local_id << " , " << peer_id;
+      VLOG(rldp2, INFO) << "removing old connection " << local_id << " , " << peer_id;
       connections_.erase({local_id, peer_id});
       it = timeout_set_.erase(it);
     } else {

--- a/rldp2/rldp.hpp
+++ b/rldp2/rldp.hpp
@@ -21,19 +21,16 @@
 #include <map>
 
 #include "adnl/adnl-query.h"
+#include "td/utils/logging.h"
 #include "tl-utils/tl-utils.hpp"
 
 #include "rldp.h"
 
+DECLARE_LOG_CATEGORY(rldp2)
+
 namespace ton {
 
 namespace rldp2 {
-
-constexpr int VERBOSITY_NAME(RLDP_WARNING) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(RLDP_NOTICE) = verbosity_INFO;
-constexpr int VERBOSITY_NAME(RLDP_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(RLDP_DEBUG) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(RLDP_EXTRA_DEBUG) = verbosity_DEBUG + 1;
 
 using TransferId = td::Bits256;
 

--- a/tdutils/td/utils/logging.cpp
+++ b/tdutils/td/utils/logging.cpp
@@ -54,6 +54,7 @@ int VERBOSITY_NAME(actor) = VERBOSITY_NAME(DEBUG) + 10;
 int VERBOSITY_NAME(sqlite) = VERBOSITY_NAME(DEBUG) + 10;
 
 LogOptions log_options;
+std::atomic<int> log_disable_count{0};
 
 TD_THREAD_LOCAL const char *Logger::tag_ = nullptr;
 TD_THREAD_LOCAL const char *Logger::tag2_ = nullptr;
@@ -299,6 +300,41 @@ void set_log_fatal_error_callback(OnFatalErrorCallback callback) {
   on_fatal_error_callback = callback;
 }
 
+namespace {
+std::mutex log_category_mutex;
+LogCategory *log_category_head = nullptr;
+}  // namespace
+
+LogCategory::LogCategory(const char *name, int default_level) : name_(name), default_level_(default_level) {
+  std::lock_guard<std::mutex> guard(log_category_mutex);
+  next_ = log_category_head;
+  log_category_head = this;
+}
+
+const LogCategory *first_log_category() {
+  std::lock_guard<std::mutex> guard(log_category_mutex);
+  return log_category_head;
+}
+
+LogCategory *find_log_category(Slice name) {
+  std::lock_guard<std::mutex> guard(log_category_mutex);
+  for (auto *c = log_category_head; c != nullptr; c = const_cast<LogCategory *>(c->next())) {
+    if (c->name() == name) {
+      return c;
+    }
+  }
+  return nullptr;
+}
+
+bool set_log_category_level(Slice name, int level) {
+  auto *c = find_log_category(name);
+  if (c == nullptr) {
+    return false;
+  }
+  c->set_level(level);
+  return true;
+}
+
 void process_fatal_error(CSlice message) {
   auto callback = on_fatal_error_callback;
   if (callback) {
@@ -307,25 +343,12 @@ void process_fatal_error(CSlice message) {
   std::abort();
 }
 
-namespace {
-std::mutex sdl_mutex;
-int sdl_cnt = 0;
-int sdl_verbosity = 0;
-
-}  // namespace
 ScopedDisableLog::ScopedDisableLog() {
-  std::unique_lock<std::mutex> guard(sdl_mutex);
-  if (sdl_cnt == 0) {
-    sdl_verbosity = set_verbosity_level(std::numeric_limits<int>::min());
-  }
-  sdl_cnt++;
+  log_disable_count.fetch_add(1, std::memory_order_relaxed);
 }
 
 ScopedDisableLog::~ScopedDisableLog() {
-  std::unique_lock<std::mutex> guard(sdl_mutex);
-  sdl_cnt--;
-  if (sdl_cnt == 0) {
-    set_verbosity_level(sdl_verbosity);
-  }
+  auto old_count = log_disable_count.fetch_sub(1, std::memory_order_relaxed);
+  CHECK(old_count > 0);
 }
 }  // namespace td

--- a/tdutils/td/utils/logging.cpp
+++ b/tdutils/td/utils/logging.cpp
@@ -318,7 +318,7 @@ const LogCategory *first_log_category() {
 
 LogCategory *find_log_category(Slice name) {
   std::lock_guard<std::mutex> guard(log_category_mutex);
-  for (auto *c = log_category_head; c != nullptr; c = const_cast<LogCategory *>(c->next())) {
+  for (auto *c = log_category_head; c != nullptr; c = c->next()) {
     if (c->name() == name) {
       return c;
     }

--- a/tdutils/td/utils/logging.h
+++ b/tdutils/td/utils/logging.h
@@ -207,6 +207,8 @@ class LogCategory {
   LogCategory(const LogCategory &) = delete;
   LogCategory &operator=(const LogCategory &) = delete;
 
+  // Effective level: the override if set; otherwise the category follows the global level but never
+  // exceeds its default — raising the global verbosity alone does not raise a category above its default.
   int get_level() const {
     if (is_log_disabled()) {
       return VERBOSITY_DISABLED;
@@ -231,6 +233,9 @@ class LogCategory {
     return Slice(name_);
   }
   const LogCategory *next() const {
+    return next_;
+  }
+  LogCategory *next() {
     return next_;
   }
 

--- a/tdutils/td/utils/logging.h
+++ b/tdutils/td/utils/logging.h
@@ -221,6 +221,9 @@ class LogCategory {
   int default_level() const {
     return default_level_;
   }
+  int override_level() const {
+    return override_level_.load(std::memory_order_relaxed);
+  }
   void set_level(int level) {
     override_level_.store(level, std::memory_order_relaxed);
   }

--- a/tdutils/td/utils/logging.h
+++ b/tdutils/td/utils/logging.h
@@ -64,20 +64,37 @@
 
 #define LOGGER(interface, options, level, comment) ::td::Logger(interface, options, level, __FILE__, __LINE__, comment)
 
-#define LOG_IMPL_FULL(interface, options, strip_level, runtime_level, condition, comment) \
-  LOG_IS_STRIPPED(strip_level) || runtime_level > options.get_level() || !(condition)     \
-      ? (void)0                                                                           \
+#define LOG_IMPL_FULL(interface, options, strip_level, runtime_level, condition, comment)                        \
+  LOG_IS_STRIPPED(strip_level) || ::td::is_log_disabled() || runtime_level > options.get_level() || !(condition) \
+      ? (void)0                                                                                                  \
       : ::td::detail::Voidify() & LOGGER(interface, options, runtime_level, comment)
 
 #define LOG_IMPL(strip_level, level, condition, comment) \
   LOG_IMPL_FULL(*::td::log_interface, ::td::log_options, strip_level, VERBOSITY_NAME(level), condition, comment)
 
+#define LOG_IMPL_FULL_CAT(interface, options, strip_level, runtime_level, category, condition, comment) \
+  LOG_IS_STRIPPED(strip_level) || runtime_level > (category).get_level() || !(condition)                \
+      ? (void)0                                                                                         \
+      : ::td::detail::Voidify() & LOGGER(interface, options, runtime_level, comment)
+
+#define LOG_IMPL_CAT(category, strip_level, level, condition, comment)                           \
+  LOG_IMPL_FULL_CAT(*::td::log_interface, ::td::log_options, strip_level, VERBOSITY_NAME(level), \
+                    ::td::log_category_##category, condition, comment)
+
 #define LOG(level) LOG_IMPL(level, level, true, ::td::Slice())
 #define LOG_IF(level, condition) LOG_IMPL(level, level, condition, #condition)
 #define FLOG(level) LOG_IMPL(level, level, true, ::td::Slice()) << td::LambdaPrint{} << [&](auto &sb)
 
-#define VLOG(level) LOG_IMPL(DEBUG, level, true, TD_DEFINE_STR(level))
-#define VLOG_IF(level, condition) LOG_IMPL(DEBUG, level, condition, TD_DEFINE_STR(level) " " #condition)
+#define VLOG_GLOBAL_(level) LOG_IMPL(DEBUG, level, true, TD_DEFINE_STR(level))
+#define VLOG_CAT_(category, level) LOG_IMPL_CAT(category, DEBUG, level, true, TD_DEFINE_STR(level))
+#define VLOG_PICK_(_1, _2, NAME, ...) NAME
+#define VLOG(...) VLOG_PICK_(__VA_ARGS__, VLOG_CAT_, VLOG_GLOBAL_)(__VA_ARGS__)
+
+#define VLOG_IF_GLOBAL_(level, condition) LOG_IMPL(DEBUG, level, condition, TD_DEFINE_STR(level) " " #condition)
+#define VLOG_IF_CAT_(category, level, condition) \
+  LOG_IMPL_CAT(category, DEBUG, level, condition, TD_DEFINE_STR(level) " " #condition)
+#define VLOG_IF_PICK_(_1, _2, _3, NAME, ...) NAME
+#define VLOG_IF(...) VLOG_IF_PICK_(__VA_ARGS__, VLOG_IF_CAT_, VLOG_IF_GLOBAL_)(__VA_ARGS__)
 
 #define LOG_ROTATE() ::td::log_interface->rotate()
 
@@ -134,8 +151,10 @@ extern int VERBOSITY_NAME(actor);
 extern int VERBOSITY_NAME(files);
 extern int VERBOSITY_NAME(sqlite);
 
+constexpr int DEFAULT_VERBOSITY_LEVEL = VERBOSITY_NAME(DEBUG) + 1;
+
 struct LogOptions {
-  std::atomic<int> level{VERBOSITY_NAME(DEBUG) + 1};
+  std::atomic<int> level{DEFAULT_VERBOSITY_LEVEL};
   bool fix_newlines{true};
   bool add_info{true};
 
@@ -167,12 +186,79 @@ struct LogOptions {
 };
 
 extern LogOptions log_options;
+extern std::atomic<int> log_disable_count;
+
+constexpr int VERBOSITY_DISABLED = VERBOSITY_NAME(PLAIN) - 1;
+
+inline bool is_log_disabled() {
+  return log_disable_count.load(std::memory_order_relaxed) != 0;
+}
+
 inline int set_verbosity_level(int level) {
   return log_options.set_level(level);
 }
 inline int get_verbosity_level() {
   return log_options.get_level();
 }
+
+class LogCategory {
+ public:
+  explicit LogCategory(const char *name, int default_level = DEFAULT_VERBOSITY_LEVEL);
+  LogCategory(const LogCategory &) = delete;
+  LogCategory &operator=(const LogCategory &) = delete;
+
+  int get_level() const {
+    if (is_log_disabled()) {
+      return VERBOSITY_DISABLED;
+    }
+    auto override_level = override_level_.load(std::memory_order_relaxed);
+    if (override_level >= 0) {
+      return override_level;
+    }
+    auto global_level = log_options.get_level();
+    return global_level < default_level_ ? global_level : default_level_;
+  }
+  int default_level() const {
+    return default_level_;
+  }
+  void set_level(int level) {
+    override_level_.store(level, std::memory_order_relaxed);
+  }
+  Slice name() const {
+    return Slice(name_);
+  }
+  const LogCategory *next() const {
+    return next_;
+  }
+
+ private:
+  const char *name_;
+  int default_level_;
+  std::atomic<int> override_level_{-1};
+  LogCategory *next_;
+};
+
+// Cold-path category registry helpers (never touched by the logging hot path).
+const LogCategory *first_log_category();
+LogCategory *find_log_category(Slice name);
+// Sets one category override (level < 0 clears override). Returns false if no such category exists.
+bool set_log_category_level(Slice name, int level);
+
+#define DECLARE_LOG_CATEGORY(name)        \
+  namespace td {                          \
+  extern LogCategory log_category_##name; \
+  }
+#define DEFINE_LOG_CATEGORY_DEFAULT_(name) \
+  namespace td {                           \
+  LogCategory log_category_##name{#name};  \
+  }
+#define DEFINE_LOG_CATEGORY_WITH_LEVEL_(name, default_level) \
+  namespace td {                                             \
+  LogCategory log_category_##name{#name, default_level};     \
+  }
+#define DEFINE_LOG_CATEGORY_PICK_(_1, _2, NAME, ...) NAME
+#define DEFINE_LOG_CATEGORY(...) \
+  DEFINE_LOG_CATEGORY_PICK_(__VA_ARGS__, DEFINE_LOG_CATEGORY_WITH_LEVEL_, DEFINE_LOG_CATEGORY_DEFAULT_)(__VA_ARGS__)
 
 class ScopedDisableLog {
  public:

--- a/tdutils/test/log.cpp
+++ b/tdutils/test/log.cpp
@@ -42,6 +42,37 @@
 
 char disable_linker_warning_about_empty_file_tdutils_test_log_cpp TD_UNUSED;
 
+DEFINE_LOG_CATEGORY(test_xyz, VERBOSITY_NAME(INFO))
+DEFINE_LOG_CATEGORY(test_default)
+
+TEST(Log, LogCategory) {
+  auto &cat = td::log_category_test_xyz;
+  auto &default_cat = td::log_category_test_default;
+  auto old_level = td::set_verbosity_level(td::DEFAULT_VERBOSITY_LEVEL);
+  ASSERT_EQ(td::DEFAULT_VERBOSITY_LEVEL, default_cat.default_level());
+  ASSERT_EQ(td::DEFAULT_VERBOSITY_LEVEL, default_cat.get_level());
+  ASSERT_EQ(VERBOSITY_NAME(INFO), cat.default_level());
+  ASSERT_EQ(VERBOSITY_NAME(INFO), cat.get_level());
+  td::set_verbosity_level(VERBOSITY_NAME(WARNING));
+  ASSERT_EQ(VERBOSITY_NAME(WARNING), default_cat.get_level());
+  ASSERT_EQ(VERBOSITY_NAME(WARNING), cat.get_level());
+  td::set_verbosity_level(td::DEFAULT_VERBOSITY_LEVEL + 1);
+  ASSERT_EQ(td::DEFAULT_VERBOSITY_LEVEL, default_cat.get_level());
+  ASSERT_EQ(VERBOSITY_NAME(INFO), cat.get_level());
+  ASSERT_TRUE(td::find_log_category("test_xyz") == &cat);
+  ASSERT_TRUE(td::find_log_category("does_not_exist") == nullptr);
+  ASSERT_TRUE(td::set_log_category_level("test_xyz", VERBOSITY_NAME(DEBUG) + 2));
+  ASSERT_EQ(VERBOSITY_NAME(DEBUG) + 2, cat.get_level());
+  {
+    td::ScopedDisableLog disable_log;
+    ASSERT_TRUE(cat.get_level() < VERBOSITY_NAME(FATAL));
+  }
+  ASSERT_TRUE(!td::set_log_category_level("does_not_exist", 1));
+  cat.set_level(-1);
+  ASSERT_EQ(VERBOSITY_NAME(INFO), cat.get_level());
+  td::set_verbosity_level(old_level);
+}
+
 #if !TD_THREAD_UNSUPPORTED
 template <class Log>
 class LogBenchmark : public td::Benchmark {

--- a/tl/generate/scheme/ton_api.tl
+++ b/tl/generate/scheme/ton_api.tl
@@ -807,6 +807,8 @@ engine.validator.getStats = engine.validator.Stats;
 engine.validator.getConfig = engine.validator.JsonConfig;
 
 engine.validator.setVerbosity verbosity:int = engine.validator.Success;
+engine.validator.setLogCategoryVerbosity name:string verbosity:int = engine.validator.Success;
+engine.validator.getLogCategories = engine.validator.TextStats;
 
 engine.validator.createElectionBid election_date:int election_addr:string wallet:string = engine.validator.ElectionBid;
 engine.validator.createProposalVote vote:bytes = engine.validator.ProposalVote;

--- a/validator-engine-console/validator-engine-console-query.cpp
+++ b/validator-engine-console/validator-engine-console-query.cpp
@@ -630,6 +630,53 @@ td::Status SetVerbosityQuery::receive(td::BufferSlice data) {
   return td::Status::OK();
 }
 
+td::Status SetLogCategoryVerbosityQuery::run() {
+  TRY_RESULT_ASSIGN(category_, tokenizer_.get_token<std::string>());
+  TRY_RESULT(level, tokenizer_.get_token<std::string>());
+  TRY_STATUS(tokenizer_.check_endl());
+  if (level == "default" || level == "reset") {
+    verbosity_ = -1;
+    return td::Status::OK();
+  }
+  TRY_RESULT_ASSIGN(verbosity_, td::to_integer_safe<td::int32>(level));
+  if (verbosity_ < -1 || verbosity_ > 10) {
+    return td::Status::Error("verbosity must be -1, default or in range [0..10]");
+  }
+  return td::Status::OK();
+}
+
+td::Status SetLogCategoryVerbosityQuery::send() {
+  auto b =
+      ton::create_serialize_tl_object<ton::ton_api::engine_validator_setLogCategoryVerbosity>(category_, verbosity_);
+  td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
+  return td::Status::OK();
+}
+
+td::Status SetLogCategoryVerbosityQuery::receive(td::BufferSlice data) {
+  TRY_RESULT_PREFIX(f, ton::fetch_tl_object<ton::ton_api::engine_validator_success>(data.as_slice(), true),
+                    "received incorrect answer: ");
+  td::TerminalIO::out() << "success\n";
+  return td::Status::OK();
+}
+
+td::Status GetLogCategoriesQuery::run() {
+  TRY_STATUS(tokenizer_.check_endl());
+  return td::Status::OK();
+}
+
+td::Status GetLogCategoriesQuery::send() {
+  auto b = ton::create_serialize_tl_object<ton::ton_api::engine_validator_getLogCategories>();
+  td::actor::send_closure(console_, &ValidatorEngineConsole::envelope_send_query, std::move(b), create_promise());
+  return td::Status::OK();
+}
+
+td::Status GetLogCategoriesQuery::receive(td::BufferSlice data) {
+  TRY_RESULT_PREFIX(f, ton::fetch_tl_object<ton::ton_api::engine_validator_textStats>(data.as_slice(), true),
+                    "received incorrect answer: ");
+  td::TerminalIO::out() << f->data_;
+  return td::Status::OK();
+}
+
 td::Status GetStatsQuery::run() {
   TRY_STATUS(tokenizer_.check_endl());
   return td::Status::OK();

--- a/validator-engine-console/validator-engine-console-query.h
+++ b/validator-engine-console/validator-engine-console-query.h
@@ -764,6 +764,48 @@ class SetVerbosityQuery : public Query {
   td::uint32 verbosity_;
 };
 
+class SetLogCategoryVerbosityQuery : public Query {
+ public:
+  SetLogCategoryVerbosityQuery(td::actor::ActorId<ValidatorEngineConsole> console, Tokenizer tokenizer)
+      : Query(console, std::move(tokenizer)) {
+  }
+  td::Status run() override;
+  td::Status send() override;
+  td::Status receive(td::BufferSlice data) override;
+  static std::string get_name() {
+    return "set-vcategory";
+  }
+  static std::string get_help() {
+    return "set-vcategory <name> <value|default>\tchanges category verbosity level";
+  }
+  std::string name() const override {
+    return get_name();
+  }
+
+ private:
+  std::string category_;
+  td::int32 verbosity_;
+};
+
+class GetLogCategoriesQuery : public Query {
+ public:
+  GetLogCategoriesQuery(td::actor::ActorId<ValidatorEngineConsole> console, Tokenizer tokenizer)
+      : Query(console, std::move(tokenizer)) {
+  }
+  td::Status run() override;
+  td::Status send() override;
+  td::Status receive(td::BufferSlice data) override;
+  static std::string get_name() {
+    return "get-vcategories";
+  }
+  static std::string get_help() {
+    return "get-vcategories\tprints log categories and levels";
+  }
+  std::string name() const override {
+    return get_name();
+  }
+};
+
 class GetStatsQuery : public Query {
  public:
   GetStatsQuery(td::actor::ActorId<ValidatorEngineConsole> console, Tokenizer tokenizer)

--- a/validator-engine-console/validator-engine-console.cpp
+++ b/validator-engine-console/validator-engine-console.cpp
@@ -129,6 +129,8 @@ void ValidatorEngineConsole::run() {
   add_query_runner(std::make_unique<QueryRunnerImpl<DelValidatorAdnlAddrQuery>>());
   add_query_runner(std::make_unique<QueryRunnerImpl<GetConfigQuery>>());
   add_query_runner(std::make_unique<QueryRunnerImpl<SetVerbosityQuery>>());
+  add_query_runner(std::make_unique<QueryRunnerImpl<SetLogCategoryVerbosityQuery>>());
+  add_query_runner(std::make_unique<QueryRunnerImpl<GetLogCategoriesQuery>>());
   add_query_runner(std::make_unique<QueryRunnerImpl<GetStatsQuery>>());
   add_query_runner(std::make_unique<QueryRunnerImpl<QuitQuery>>());
   add_query_runner(std::make_unique<QueryRunnerImpl<AddNetworkAddressQuery>>());

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -49,6 +49,7 @@
 #include "td/utils/TsFileLog.h"
 #include "td/utils/buffer.h"
 #include "td/utils/filesystem.h"
+#include "td/utils/logging.h"
 #include "td/utils/misc.h"
 #include "td/utils/overloaded.h"
 #include "td/utils/port/path.h"
@@ -4188,6 +4189,59 @@ void ValidatorEngine::run_control_query(ton::ton_api::engine_validator_setVerbos
   SET_VERBOSITY_LEVEL(VERBOSITY_NAME(ERROR) + query.verbosity_);
 
   promise.set_value(ton::serialize_tl_object(ton::create_tl_object<ton::ton_api::engine_validator_success>(), true));
+}
+
+void ValidatorEngine::run_control_query(ton::ton_api::engine_validator_setLogCategoryVerbosity &query,
+                                        td::BufferSlice data, ton::PublicKeyHash src, td::uint32 perm,
+                                        td::Promise<td::BufferSlice> promise) {
+  if (!(perm & ValidatorEnginePermissions::vep_default)) {
+    promise.set_value(create_control_query_error(td::Status::Error(ton::ErrorCode::error, "not authorized")));
+    return;
+  }
+
+  if (query.verbosity_ < -1 || query.verbosity_ > 10) {
+    promise.set_value(create_control_query_error(
+        td::Status::Error(ton::ErrorCode::error, "verbosity should be -1 or in range [0..10]")));
+    return;
+  }
+
+  auto level = query.verbosity_ < 0 ? -1 : VERBOSITY_NAME(FATAL) + query.verbosity_;
+  if (!td::set_log_category_level(query.name_, level)) {
+    promise.set_value(create_control_query_error(
+        td::Status::Error(ton::ErrorCode::error, PSTRING() << "unknown log category: " << query.name_)));
+    return;
+  }
+
+  promise.set_value(ton::serialize_tl_object(ton::create_tl_object<ton::ton_api::engine_validator_success>(), true));
+}
+
+void ValidatorEngine::run_control_query(ton::ton_api::engine_validator_getLogCategories &query, td::BufferSlice data,
+                                        ton::PublicKeyHash src, td::uint32 perm, td::Promise<td::BufferSlice> promise) {
+  if (!(perm & ValidatorEnginePermissions::vep_default)) {
+    promise.set_value(create_control_query_error(td::Status::Error(ton::ErrorCode::error, "not authorized")));
+    return;
+  }
+
+  std::vector<const td::LogCategory *> categories;
+  for (auto *category = td::first_log_category(); category != nullptr; category = category->next()) {
+    categories.push_back(category);
+  }
+  std::sort(categories.begin(), categories.end(),
+            [](const auto *lhs, const auto *rhs) { return lhs->name() < rhs->name(); });
+
+  std::string text;
+  for (auto *category : categories) {
+    auto override_level = category->override_level();
+    text += PSTRING() << category->name() << "=" << category->get_level() << " default=" << category->default_level()
+                      << " override=";
+    if (override_level < 0) {
+      text += "default";
+    } else {
+      text += PSTRING() << override_level;
+    }
+    text += "\n";
+  }
+  promise.set_value(ton::create_serialize_tl_object<ton::ton_api::engine_validator_textStats>(std::move(text)));
 }
 
 void ValidatorEngine::run_control_query(ton::ton_api::engine_validator_getStats &query, td::BufferSlice data,

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -5713,6 +5713,9 @@ int main(int argc, char *argv[]) {
             return td::Status::Error(PSTRING() << "bad --vcategory token (want name=level): " << token);
           }
           TRY_RESULT(level, td::to_integer_safe<int>(kv[1]));
+          if (level < 0 || level > 10) {
+            return td::Status::Error(PSTRING() << "--vcategory level should be in range [0..10]: " << token);
+          }
           if (!td::set_log_category_level(kv[0], VERBOSITY_NAME(FATAL) + level)) {
             return td::Status::Error(PSTRING() << "unknown log category: " << kv[0]);
           }

--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -5644,6 +5644,27 @@ int main(int argc, char *argv[]) {
     int v = VERBOSITY_NAME(FATAL) + (td::to_integer<int>(arg));
     SET_VERBOSITY_LEVEL(v);
   });
+  p.add_checked_option(
+      '\0', "vcategory", "per-category verbosity, e.g. adnl=5,overlay=2 ('--vcategory list' prints categories)",
+      [&](td::Slice arg) -> td::Status {
+        if (arg == "list") {
+          for (auto *c = td::first_log_category(); c != nullptr; c = c->next()) {
+            std::cout << c->name().str() << "=" << c->get_level() << "\n";
+          }
+          std::exit(0);
+        }
+        for (auto token : td::full_split(arg, ',')) {
+          auto kv = td::full_split(token, '=');
+          if (kv.size() != 2) {
+            return td::Status::Error(PSTRING() << "bad --vcategory token (want name=level): " << token);
+          }
+          TRY_RESULT(level, td::to_integer_safe<int>(kv[1]));
+          if (!td::set_log_category_level(kv[0], VERBOSITY_NAME(FATAL) + level)) {
+            return td::Status::Error(PSTRING() << "unknown log category: " << kv[0]);
+          }
+        }
+        return td::Status::OK();
+      });
   p.add_option('V', "version", "shows validator-engine build information", [&]() {
     std::cout << "validator-engine build information: [ Commit: " << GitMetadata::CommitSHA1()
               << ", Date: " << GitMetadata::CommitDate() << "]\n";

--- a/validator-engine/validator-engine.hpp
+++ b/validator-engine/validator-engine.hpp
@@ -628,6 +628,10 @@ class ValidatorEngine : public td::actor::Actor {
                          ton::PublicKeyHash src, td::uint32 perm, td::Promise<td::BufferSlice> promise);
   void run_control_query(ton::ton_api::engine_validator_setVerbosity &query, td::BufferSlice data,
                          ton::PublicKeyHash src, td::uint32 perm, td::Promise<td::BufferSlice> promise);
+  void run_control_query(ton::ton_api::engine_validator_setLogCategoryVerbosity &query, td::BufferSlice data,
+                         ton::PublicKeyHash src, td::uint32 perm, td::Promise<td::BufferSlice> promise);
+  void run_control_query(ton::ton_api::engine_validator_getLogCategories &query, td::BufferSlice data,
+                         ton::PublicKeyHash src, td::uint32 perm, td::Promise<td::BufferSlice> promise);
   void run_control_query(ton::ton_api::engine_validator_getStats &query, td::BufferSlice data, ton::PublicKeyHash src,
                          td::uint32 perm, td::Promise<td::BufferSlice> promise);
   void run_control_query(ton::ton_api::engine_validator_createElectionBid &query, td::BufferSlice data,

--- a/validator/apply-block.cpp
+++ b/validator/apply-block.cpp
@@ -30,14 +30,14 @@ namespace validator {
 
 void ApplyBlock::abort_query(td::Status reason) {
   if (promise_) {
-    VLOG(VALIDATOR_WARNING) << "aborting apply block query for " << id_ << ": " << reason;
+    VLOG(validator, WARNING) << "aborting apply block query for " << id_ << ": " << reason;
     promise_.set_error(std::move(reason));
   }
   stop();
 }
 
 void ApplyBlock::finish_query() {
-  VLOG(VALIDATOR_DEBUG) << "successfully finishing apply block query in " << perf_timer_.elapsed() << " s";
+  VLOG(validator, DEBUG) << "successfully finishing apply block query in " << perf_timer_.elapsed() << " s";
   handle_->set_processed();
   ValidatorInvariants::check_post_apply(handle_);
 
@@ -52,7 +52,7 @@ void ApplyBlock::alarm() {
 }
 
 void ApplyBlock::start_up() {
-  VLOG(VALIDATOR_DEBUG) << "running apply_block for " << id_ << ", mc_seqno=" << masterchain_block_id_.seqno();
+  VLOG(validator, DEBUG) << "running apply_block for " << id_ << ", mc_seqno=" << masterchain_block_id_.seqno();
 
   if (id_.is_masterchain()) {
     masterchain_block_id_ = id_;
@@ -72,7 +72,7 @@ void ApplyBlock::start_up() {
 }
 
 void ApplyBlock::got_block_handle(BlockHandle handle) {
-  VLOG(VALIDATOR_DEBUG) << "got_block_handle";
+  VLOG(validator, DEBUG) << "got_block_handle";
   handle_ = std::move(handle);
 
   if (handle_->is_applied() && (!handle_->id().is_masterchain() || handle_->processed())) {
@@ -81,7 +81,7 @@ void ApplyBlock::got_block_handle(BlockHandle handle) {
   }
 
   if (handle_->is_applied()) {
-    VLOG(VALIDATOR_DEBUG) << "already applied";
+    VLOG(validator, DEBUG) << "already applied";
     auto P =
         td::PromiseCreator::lambda([SelfId = actor_id(this), seqno = handle_->id().id.seqno](td::Result<BlockIdExt> R) {
           R.ensure();
@@ -97,19 +97,19 @@ void ApplyBlock::got_block_handle(BlockHandle handle) {
   }
 
   if (handle_->id().id.seqno == 0) {
-    VLOG(VALIDATOR_DEBUG) << "seqno == 0";
+    VLOG(validator, DEBUG) << "seqno == 0";
     written_block_data();
     return;
   }
 
   if (handle_->is_archived()) {
-    VLOG(VALIDATOR_DEBUG) << "already archived";
+    VLOG(validator, DEBUG) << "already archived";
     finish_query();
     return;
   }
 
   if (handle_->received()) {
-    VLOG(VALIDATOR_DEBUG) << "already received";
+    VLOG(validator, DEBUG) << "already received";
     written_block_data();
     return;
   }
@@ -123,7 +123,7 @@ void ApplyBlock::got_block_handle(BlockHandle handle) {
       }
     });
 
-    VLOG(VALIDATOR_DEBUG) << "storing block data";
+    VLOG(validator, DEBUG) << "storing block data";
     td::actor::send_closure(manager_, &ValidatorManager::set_block_data, handle_, block_, std::move(P));
   } else {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), handle = handle_](td::Result<td::Ref<BlockData>> R) {
@@ -135,7 +135,7 @@ void ApplyBlock::got_block_handle(BlockHandle handle) {
       }
     });
 
-    VLOG(VALIDATOR_DEBUG) << "wait for block data";
+    VLOG(validator, DEBUG) << "wait for block data";
     td::actor::send_closure(manager_, &ValidatorManager::wait_block_data, handle_, apply_block_priority(), timeout_,
                             std::move(P));
   }
@@ -147,7 +147,7 @@ void ApplyBlock::got_block_data(td::Ref<BlockData> block) {
 }
 
 void ApplyBlock::written_block_data() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_data";
+  VLOG(validator, DEBUG) << "written_block_data";
   if (!handle_->id().seqno()) {
     CHECK(handle_->inited_split_after());
     CHECK(handle_->inited_state_root_hash());
@@ -178,26 +178,26 @@ void ApplyBlock::written_block_data() {
       }
     });
 
-    VLOG(VALIDATOR_DEBUG) << "wait_block_state";
+    VLOG(validator, DEBUG) << "wait_block_state";
     td::actor::send_closure(manager_, &ValidatorManager::wait_block_state, handle_, apply_block_priority(), timeout_,
                             true, std::move(P));
   }
 }
 
 void ApplyBlock::got_cur_state(td::Ref<ShardState> state) {
-  VLOG(VALIDATOR_DEBUG) << "got_cur_state";
+  VLOG(validator, DEBUG) << "got_cur_state";
   state_ = std::move(state);
   CHECK(handle_->received_state());
   written_state();
 }
 
 void ApplyBlock::written_state() {
-  VLOG(VALIDATOR_DEBUG) << "written_state";
+  VLOG(validator, DEBUG) << "written_state";
   if (handle_->is_applied() && handle_->processed()) {
     finish_query();
     return;
   }
-  VLOG(VALIDATOR_DEBUG) << "setting next for parents";
+  VLOG(validator, DEBUG) << "setting next for parents";
 
   if (handle_->id().id.seqno != 0 && !handle_->is_applied()) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Unit> R) {
@@ -223,13 +223,13 @@ void ApplyBlock::written_state() {
 }
 
 void ApplyBlock::written_next() {
-  VLOG(VALIDATOR_DEBUG) << "written_next";
+  VLOG(validator, DEBUG) << "written_next";
   if (handle_->is_applied() && handle_->processed()) {
     finish_query();
     return;
   }
 
-  VLOG(VALIDATOR_DEBUG) << "applying parents";
+  VLOG(validator, DEBUG) << "applying parents";
 
   if (handle_->id().id.seqno != 0 && !handle_->is_applied()) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Unit> R) {
@@ -257,8 +257,8 @@ void ApplyBlock::written_next() {
 }
 
 void ApplyBlock::applied_prev() {
-  VLOG(VALIDATOR_DEBUG) << "applying parents";
-  VLOG(VALIDATOR_DEBUG) << "applied_prev, waiting manager's confirm";
+  VLOG(validator, DEBUG) << "applying parents";
+  VLOG(validator, DEBUG) << "applied_prev, waiting manager's confirm";
   if (!id_.is_masterchain()) {
     handle_->set_masterchain_ref_block(masterchain_block_id_.seqno());
   }
@@ -273,7 +273,7 @@ void ApplyBlock::applied_prev() {
 }
 
 void ApplyBlock::applied_set() {
-  VLOG(VALIDATOR_DEBUG) << "applied_set";
+  VLOG(validator, DEBUG) << "applied_set";
   handle_->set_applied();
   if (handle_->id().seqno() > 0) {
     CHECK(handle_->handle_moved_to_archive());
@@ -287,7 +287,7 @@ void ApplyBlock::applied_set() {
         td::actor::send_closure(SelfId, &ApplyBlock::cleanup_and_finish);
       }
     });
-    VLOG(VALIDATOR_DEBUG) << "flush handle";
+    VLOG(validator, DEBUG) << "flush handle";
     handle_->flush(manager_, handle_, std::move(P));
   } else {
     cleanup_and_finish();

--- a/validator/collator-node/collator-node.cpp
+++ b/validator/collator-node/collator-node.cpp
@@ -27,6 +27,8 @@
 #include "fabric.h"
 #include "utils.hpp"
 
+DEFINE_LOG_CATEGORY(collator_node, VERBOSITY_NAME(WARNING))
+
 namespace ton::validator {
 
 CollatorNode::CollatorNode(adnl::AdnlNodeIdShort local_id, td::Ref<ValidatorManagerOptions> opts,

--- a/validator/collator-node/utils.cpp
+++ b/validator/collator-node/utils.cpp
@@ -31,12 +31,11 @@ tl_object_ptr<ton_api::collatorNode_Candidate> serialize_candidate(const BlockCa
     auto res = create_tl_object<ton_api::collatorNode_candidate>(
         PublicKey{pubkeys::Ed25519{block.pubkey.as_bits256()}}.tl(), create_tl_block_id(block.id), block.data.clone(),
         block.collated_data.clone());
-    VLOG(COLLATOR_NODE_BENCHMARK) << "Broadcast_benchmark serialize_candidate block_id=" << block.id.root_hash.to_hex()
-                                  << " called_from=" << k_called_from_collator_node
-                                  << " time_sec=" << (td::Time::now() - t_compression_start)
-                                  << " compression=" << "none"
-                                  << " original_size=" << block.data.size() + block.collated_data.size()
-                                  << " compressed_size=" << block.data.size() + block.collated_data.size();
+    VLOG(collator_node, WARNING) << "Broadcast_benchmark serialize_candidate block_id=" << block.id.root_hash.to_hex()
+                                 << " called_from=" << k_called_from_collator_node
+                                 << " time_sec=" << (td::Time::now() - t_compression_start) << " compression=" << "none"
+                                 << " original_size=" << block.data.size() + block.collated_data.size()
+                                 << " compressed_size=" << block.data.size() + block.collated_data.size();
     return res;
   }
   size_t decompressed_size;
@@ -65,7 +64,7 @@ td::Result<BlockCandidate> deserialize_candidate(tl_object_ptr<ton_api::collator
                   auto e_key = Ed25519_PublicKey{key.ed25519_value().raw()};
                   auto block_id = create_block_id(c.id_);
                   BlockCandidate res{e_key, block_id, hash, std::move(c.data_), std::move(c.collated_data_)};
-                  VLOG(COLLATOR_NODE_BENCHMARK)
+                  VLOG(collator_node, WARNING)
                       << "Broadcast_benchmark deserialize_candidate block_id=" << block_id.root_hash.to_hex()
                       << " called_from=" << k_called_from_collator_node
                       << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"

--- a/validator/collator-node/utils.hpp
+++ b/validator/collator-node/utils.hpp
@@ -16,12 +16,13 @@
 */
 #pragma once
 
+#include "td/utils/logging.h"
 #include "tl/generate/auto/tl/ton_api.h"
 #include "ton/ton-types.h"
 
-namespace ton::validator {
+DECLARE_LOG_CATEGORY(collator_node)
 
-constexpr int VERBOSITY_NAME(COLLATOR_NODE_BENCHMARK) = verbosity_WARNING;
+namespace ton::validator {
 
 tl_object_ptr<ton_api::collatorNode_Candidate> serialize_candidate(const BlockCandidate& block, bool compress);
 td::Result<BlockCandidate> deserialize_candidate(tl_object_ptr<ton_api::collatorNode_Candidate> f,

--- a/validator/db/archiver.cpp
+++ b/validator/db/archiver.cpp
@@ -37,9 +37,9 @@ void BlockArchiver::start_up() {
 td::actor::Task<> BlockArchiver::run() {
   auto result = co_await run_inner().wrap();
   if (result.is_error()) {
-    VLOG(VALIDATOR_WARNING) << "failed to archive block " << handle_->id() << ": " << result.error();
+    VLOG(validator, WARNING) << "failed to archive block " << handle_->id() << ": " << result.error();
   } else {
-    VLOG(VALIDATOR_DEBUG) << "finished archiving block in " << timer_.elapsed() << " s";
+    VLOG(validator, DEBUG) << "finished archiving block in " << timer_.elapsed() << " s";
   }
   promise_.set_result(std::move(result));
   stop();
@@ -47,9 +47,9 @@ td::actor::Task<> BlockArchiver::run() {
 }
 
 td::actor::Task<> BlockArchiver::run_inner() {
-  VLOG(VALIDATOR_DEBUG) << "started block archiver for " << handle_->id();
+  VLOG(validator, DEBUG) << "started block archiver for " << handle_->id();
   if (handle_->moved_to_archive()) {
-    VLOG(VALIDATOR_DEBUG) << "already moved";
+    VLOG(validator, DEBUG) << "already moved";
     co_return {};
   }
   if (handle_->id().is_masterchain()) {
@@ -73,9 +73,9 @@ td::actor::Task<> BlockArchiver::run_inner() {
                         .then([ref](td::BufferSlice data) { return std::make_pair(ref, std::move(data)); })
                         .start());
   }
-  VLOG(VALIDATOR_DEBUG) << "loading data";
+  VLOG(validator, DEBUG) << "loading data";
   std::vector<std::pair<FileReference, td::BufferSlice>> files = co_await td::actor::all(std::move(tasks));
-  VLOG(VALIDATOR_DEBUG) << "loaded data";
+  VLOG(validator, DEBUG) << "loaded data";
   co_await td::actor::ask(archive_, &ArchiveManager::move_block_to_archive, handle_, std::move(files));
   co_return {};
 }

--- a/validator/db/rootdb.cpp
+++ b/validator/db/rootdb.cpp
@@ -431,7 +431,7 @@ void RootDb::archive(BlockHandle handle, td::Promise<td::Unit> promise) {
   auto [it, inserted] = archive_block_waiters_.emplace(handle->id(), std::vector<td::Promise<td::Unit>>{});
   it->second.push_back(std::move(promise));
   if (!inserted) {
-    VLOG(VALIDATOR_DEBUG) << "archive block " << handle->id().id << " : already in progress";
+    VLOG(validator, DEBUG) << "archive block " << handle->id().id << " : already in progress";
     return;
   }
   td::actor::create_actor<BlockArchiver>(

--- a/validator/db/rootdb.cpp
+++ b/validator/db/rootdb.cpp
@@ -27,6 +27,9 @@
 #include "archiver.hpp"
 #include "rootdb.hpp"
 
+// Defined here (validator-db) so every flavour of the validator library gets it.
+DEFINE_LOG_CATEGORY(validator, VERBOSITY_NAME(INFO))
+
 namespace ton {
 
 namespace validator {

--- a/validator/full-node-custom-overlays.cpp
+++ b/validator/full-node-custom-overlays.cpp
@@ -43,8 +43,8 @@ void FullNodeCustomOverlay::process_broadcast(PublicKeyHash src, ton_api::tonNod
 
 void FullNodeCustomOverlay::process_broadcast(PublicKeyHash src, ton_api::tonNode_blockBroadcastCompressedV2 &query) {
   if (!block_senders_.count(adnl::AdnlNodeIdShort(src))) {
-    VLOG(FULL_NODE_DEBUG) << "Dropping block broadcast in private overlay \"" << name_ << "\" from unauthorized sender "
-                          << src;
+    VLOG(full_node, DEBUG) << "Dropping block broadcast in private overlay \"" << name_
+                           << "\" from unauthorized sender " << src;
     return;
   }
 
@@ -75,8 +75,8 @@ void FullNodeCustomOverlay::process_broadcast(PublicKeyHash src, ton_api::tonNod
 
 void FullNodeCustomOverlay::process_block_broadcast(PublicKeyHash src, ton_api::tonNode_Broadcast &query) {
   if (!block_senders_.count(adnl::AdnlNodeIdShort(src))) {
-    VLOG(FULL_NODE_DEBUG) << "Dropping block broadcast in private overlay \"" << name_ << "\" from unauthorized sender "
-                          << src;
+    VLOG(full_node, DEBUG) << "Dropping block broadcast in private overlay \"" << name_
+                           << "\" from unauthorized sender " << src;
     return;
   }
   auto B = deserialize_block_broadcast(query, overlay::Overlays::max_fec_broadcast_size(), k_called_from_custom);
@@ -84,8 +84,8 @@ void FullNodeCustomOverlay::process_block_broadcast(PublicKeyHash src, ton_api::
     LOG(DEBUG) << "dropped broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received block broadcast " << (B.ok().sig_set->is_final() ? "" : "(approve signatures) ")
-                        << "in custom overlay \"" << name_ << "\" from " << src << ": " << B.ok().block_id;
+  VLOG(full_node, DEBUG) << "Received block broadcast " << (B.ok().sig_set->is_final() ? "" : "(approve signatures) ")
+                         << "in custom overlay \"" << name_ << "\" from " << src << ": " << B.ok().block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_broadcast, B.move_as_ok(), false,
                           BroadcastSource::custom_overlay);
 }
@@ -122,8 +122,8 @@ void FullNodeCustomOverlay::process_block_broadcast_with_state(PublicKeyHash src
     LOG(DEBUG) << "Failed to deserialize block broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received block broadcast in custom overlay \"" << name_ << "\" from " << src << ": "
-                        << B.ok().block_id;
+  VLOG(full_node, DEBUG) << "Received block broadcast in custom overlay \"" << name_ << "\" from " << src << ": "
+                         << B.ok().block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_broadcast, B.move_as_ok(), true,
                           BroadcastSource::custom_overlay);
 }
@@ -131,12 +131,12 @@ void FullNodeCustomOverlay::process_block_broadcast_with_state(PublicKeyHash src
 void FullNodeCustomOverlay::process_broadcast(PublicKeyHash src, ton_api::tonNode_externalMessageBroadcast &query) {
   auto it = msg_senders_.find(adnl::AdnlNodeIdShort{src});
   if (it == msg_senders_.end()) {
-    VLOG(FULL_NODE_DEBUG) << "Dropping external message broadcast in custom overlay \"" << name_
-                          << "\" from unauthorized sender " << src;
+    VLOG(full_node, DEBUG) << "Dropping external message broadcast in custom overlay \"" << name_
+                           << "\" from unauthorized sender " << src;
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Got external message in custom overlay \"" << name_ << "\" from " << src
-                        << " (priority=" << it->second << ")";
+  VLOG(full_node, DEBUG) << "Got external message in custom overlay \"" << name_ << "\" from " << src
+                         << " (priority=" << it->second << ")";
   td::actor::ask(validator_manager_, &ValidatorManagerInterface::new_external_message_broadcast,
                  std::move(query.message_->data_), it->second)
       .detach();
@@ -158,8 +158,8 @@ void FullNodeCustomOverlay::process_broadcast(PublicKeyHash src,
 
 void FullNodeCustomOverlay::process_block_candidate_broadcast(PublicKeyHash src, ton_api::tonNode_Broadcast &query) {
   if (!block_senders_.count(adnl::AdnlNodeIdShort(src))) {
-    VLOG(FULL_NODE_DEBUG) << "Dropping block candidate broadcast in private overlay \"" << name_
-                          << "\" from unauthorized sender " << src;
+    VLOG(full_node, DEBUG) << "Dropping block candidate broadcast in private overlay \"" << name_
+                           << "\" from unauthorized sender " << src;
     return;
   }
   BlockIdExt block_id;
@@ -173,28 +173,28 @@ void FullNodeCustomOverlay::process_block_candidate_broadcast(PublicKeyHash src,
     return;
   }
   if (data.size() > FullNode::max_block_size()) {
-    VLOG(FULL_NODE_WARNING) << "received block candidate with too big size from " << src;
+    VLOG(full_node, WARNING) << "received block candidate with too big size from " << src;
     return;
   }
   if (td::sha256_bits256(data.as_slice()) != block_id.file_hash) {
-    VLOG(FULL_NODE_WARNING) << "received block candidate with incorrect file hash from " << src;
+    VLOG(full_node, WARNING) << "received block candidate with incorrect file hash from " << src;
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received newBlockCandidate in custom overlay \"" << name_ << "\" from " << src << ": "
-                        << block_id;
+  VLOG(full_node, DEBUG) << "Received newBlockCandidate in custom overlay \"" << name_ << "\" from " << src << ": "
+                         << block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_candidate_broadcast, block_id, cc_seqno,
                           validator_set_hash, std::move(data), BroadcastSource::custom_overlay);
 }
 
 void FullNodeCustomOverlay::process_broadcast(PublicKeyHash src, ton_api::tonNode_newShardBlockBroadcast &query) {
   if (!block_senders_.count(adnl::AdnlNodeIdShort(src))) {
-    VLOG(FULL_NODE_DEBUG) << "Dropping shard block description broadcast in private overlay \"" << name_
-                          << "\" from unauthorized sender " << src;
+    VLOG(full_node, DEBUG) << "Dropping shard block description broadcast in private overlay \"" << name_
+                           << "\" from unauthorized sender " << src;
     return;
   }
   BlockIdExt block_id = create_block_id(query.block_->block_);
-  VLOG(FULL_NODE_DEBUG) << "Received newShardBlockBroadcast in custom overlay \"" << name_ << "\" from " << src << ": "
-                        << block_id;
+  VLOG(full_node, DEBUG) << "Received newShardBlockBroadcast in custom overlay \"" << name_ << "\" from " << src << ": "
+                         << block_id;
   td::actor::send_closure(full_node_, &FullNode::process_shard_block_info_broadcast, block_id, query.block_->cc_seqno_,
                           std::move(query.block_->data_));
 }
@@ -214,7 +214,7 @@ void FullNodeCustomOverlay::send_external_message(td::BufferSlice data) {
   if (!inited_ || opts_.config_.ext_messages_broadcast_disabled_) {
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending external message to custom overlay \"" << name_ << "\"";
+  VLOG(full_node, DEBUG) << "Sending external message to custom overlay \"" << name_ << "\"";
   auto B = create_serialize_tl_object<ton_api::tonNode_externalMessageBroadcast>(
       create_tl_object<ton_api::tonNode_externalMessage>(std::move(data)));
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,
@@ -225,10 +225,10 @@ void FullNodeCustomOverlay::send_broadcast(BlockBroadcast broadcast) {
   if (!inited_) {
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending block broadcast to custom overlay \"" << name_ << "\": " << broadcast.block_id;
+  VLOG(full_node, DEBUG) << "Sending block broadcast to custom overlay \"" << name_ << "\": " << broadcast.block_id;
   auto B = serialize_block_broadcast(broadcast, k_called_from_custom);
   if (B.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "failed to serialize block broadcast: " << B.move_as_error();
+    VLOG(full_node, WARNING) << "failed to serialize block broadcast: " << B.move_as_error();
     return;
   }
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,
@@ -243,16 +243,16 @@ void FullNodeCustomOverlay::send_block_candidate(BlockIdExt block_id, CatchainSe
   auto B = serialize_block_candidate_broadcast(block_id, cc_seqno, validator_set_hash, data, true,
                                                k_called_from_custom);  // compression enabled
   if (B.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "failed to serialize block candidate broadcast: " << B.move_as_error();
+    VLOG(full_node, WARNING) << "failed to serialize block candidate broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending newBlockCandidate in custom overlay \"" << name_ << "\": " << block_id;
+  VLOG(full_node, DEBUG) << "Sending newBlockCandidate in custom overlay \"" << name_ << "\": " << block_id;
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,
                           local_id_.pubkey_hash(), overlay::Overlays::BroadcastFlagAnySender(), B.move_as_ok());
 }
 
 void FullNodeCustomOverlay::send_shard_block_info(BlockIdExt block_id, CatchainSeqno cc_seqno, td::BufferSlice data) {
-  VLOG(FULL_NODE_DEBUG) << "Sending newShardBlockBroadcast in custom overlay \"" << name_ << "\": " << block_id;
+  VLOG(full_node, DEBUG) << "Sending newShardBlockBroadcast in custom overlay \"" << name_ << "\": " << block_id;
   auto B = create_serialize_tl_object<ton_api::tonNode_newShardBlockBroadcast>(
       create_tl_object<ton_api::tonNode_newShardBlock>(create_tl_block_id(block_id), cc_seqno, std::move(data)));
   if (B.size() <= overlay::Overlays::max_simple_broadcast_size()) {
@@ -295,9 +295,9 @@ void FullNodeCustomOverlay::try_init() {
 void FullNodeCustomOverlay::init() {
   td::actor::send_closure(adnl_sender_, &adnl::AdnlSenderEx::add_id, local_id_);
 
-  LOG(FULL_NODE_WARNING) << "Creating custom overlay \"" << name_ << "\" for adnl id " << local_id_ << " : "
-                         << nodes_.size() << " nodes, " << msg_senders_.size() << " msg senders, "
-                         << block_senders_.size() << " block senders, overlay_id=" << overlay_id_;
+  VLOG(full_node, WARNING) << "Creating custom overlay \"" << name_ << "\" for adnl id " << local_id_ << " : "
+                           << nodes_.size() << " nodes, " << msg_senders_.size() << " msg senders, "
+                           << block_senders_.size() << " block senders, overlay_id=" << overlay_id_;
   class Callback : public overlay::Overlays::Callback {
    public:
     void receive_message(adnl::AdnlNodeIdShort src, overlay::OverlayIdShort overlay_id, td::BufferSlice data) override {
@@ -341,7 +341,7 @@ void FullNodeCustomOverlay::init() {
 }
 
 void FullNodeCustomOverlay::tear_down() {
-  LOG(FULL_NODE_WARNING) << "Destroying custom overlay \"" << name_ << "\" for adnl id " << local_id_;
+  VLOG(full_node, WARNING) << "Destroying custom overlay \"" << name_ << "\" for adnl id " << local_id_;
   td::actor::send_closure(overlays_, &ton::overlay::Overlays::delete_overlay, local_id_, overlay_id_);
 }
 

--- a/validator/full-node-custom-overlays.hpp
+++ b/validator/full-node-custom-overlays.hpp
@@ -44,7 +44,7 @@ class FullNodeCustomOverlay : public td::actor::Actor {
 
   template <class T>
   void process_broadcast(PublicKeyHash, T &) {
-    VLOG(FULL_NODE_WARNING) << "dropping unknown broadcast";
+    VLOG(full_node, WARNING) << "dropping unknown broadcast";
   }
   void receive_broadcast(PublicKeyHash src, td::BufferSlice query);
 

--- a/validator/full-node-fast-sync-overlays.cpp
+++ b/validator/full-node-fast-sync-overlays.cpp
@@ -75,8 +75,8 @@ void FullNodeFastSyncOverlay::process_block_broadcast(PublicKeyHash src, ton_api
     LOG(DEBUG) << "dropped broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received block broadcast " << (B.ok().sig_set->is_final() ? "" : "(approve signatures) ")
-                        << "in fast sync overlay from " << src << ": " << B.ok().block_id;
+  VLOG(full_node, DEBUG) << "Received block broadcast " << (B.ok().sig_set->is_final() ? "" : "(approve signatures) ")
+                         << "in fast sync overlay from " << src << ": " << B.ok().block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_broadcast, B.move_as_ok(), false,
                           BroadcastSource::fast_sync_overlay);
 }
@@ -113,7 +113,7 @@ void FullNodeFastSyncOverlay::process_block_broadcast_with_state(PublicKeyHash s
     return;
   }
 
-  VLOG(FULL_NODE_DEBUG) << "Received V2 block broadcast in fast sync overlay from " << src << ": " << B.ok().block_id;
+  VLOG(full_node, DEBUG) << "Received V2 block broadcast in fast sync overlay from " << src << ": " << B.ok().block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_broadcast, B.move_as_ok(), true,
                           BroadcastSource::fast_sync_overlay);
 }
@@ -152,7 +152,7 @@ void FullNodeFastSyncOverlay::process_broadcast(PublicKeyHash src, ton_api::tonN
 
 void FullNodeFastSyncOverlay::process_broadcast(PublicKeyHash src, ton_api::tonNode_newShardBlockBroadcast &query) {
   BlockIdExt block_id = create_block_id(query.block_->block_);
-  VLOG(FULL_NODE_DEBUG) << "Received newShardBlockBroadcast in fast sync overlay from " << src << ": " << block_id;
+  VLOG(full_node, DEBUG) << "Received newShardBlockBroadcast in fast sync overlay from " << src << ": " << block_id;
   td::actor::send_closure(full_node_, &FullNode::process_shard_block_info_broadcast, block_id, query.block_->cc_seqno_,
                           std::move(query.block_->data_));
 }
@@ -183,14 +183,14 @@ void FullNodeFastSyncOverlay::process_block_candidate_broadcast(PublicKeyHash sr
     return;
   }
   if (data.size() > FullNode::max_block_size()) {
-    VLOG(FULL_NODE_WARNING) << "received block candidate with too big size from " << src;
+    VLOG(full_node, WARNING) << "received block candidate with too big size from " << src;
     return;
   }
   if (td::sha256_bits256(data.as_slice()) != block_id.file_hash) {
-    VLOG(FULL_NODE_WARNING) << "received block candidate with incorrect file hash from " << src;
+    VLOG(full_node, WARNING) << "received block candidate with incorrect file hash from " << src;
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received newBlockCandidate in fast sync overlay from " << src << ": " << block_id;
+  VLOG(full_node, DEBUG) << "Received newBlockCandidate in fast sync overlay from " << src << ": " << block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_candidate_broadcast, block_id, cc_seqno,
                           validator_set_hash, std::move(data), BroadcastSource::fast_sync_overlay);
 }
@@ -198,27 +198,27 @@ void FullNodeFastSyncOverlay::process_block_candidate_broadcast(PublicKeyHash sr
 void FullNodeFastSyncOverlay::process_telemetry_broadcast(
     adnl::AdnlNodeIdShort src, const tl_object_ptr<ton_api::validator_telemetry> &telemetry) {
   if (telemetry->adnl_id_ != src.bits256_value()) {
-    VLOG(FULL_NODE_WARNING) << "Invalid telemetry broadcast from " << src << ": adnl_id mismatch";
+    VLOG(full_node, WARNING) << "Invalid telemetry broadcast from " << src << ": adnl_id mismatch";
     return;
   }
   auto now = (td::int32)td::Clocks::system();
   if (telemetry->timestamp_ < now - 60) {
-    VLOG(FULL_NODE_WARNING) << "Invalid telemetry broadcast from " << src << ": too old ("
-                            << now - telemetry->timestamp_ << "s ago)";
+    VLOG(full_node, WARNING) << "Invalid telemetry broadcast from " << src << ": too old ("
+                             << now - telemetry->timestamp_ << "s ago)";
     return;
   }
   if (telemetry->timestamp_ > now + 60) {
-    VLOG(FULL_NODE_WARNING) << "Invalid telemetry broadcast from " << src << ": too new ("
-                            << telemetry->timestamp_ - now << "s in the future)";
+    VLOG(full_node, WARNING) << "Invalid telemetry broadcast from " << src << ": too new ("
+                             << telemetry->timestamp_ - now << "s in the future)";
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Got telemetry broadcast from " << src;
+  VLOG(full_node, DEBUG) << "Got telemetry broadcast from " << src;
   auto s = td::json_encode<std::string>(td::ToJson(*telemetry), false);
   std::erase_if(s, [](char c) { return c == '\n' || c == '\r'; });
   telemetry_file_ << s << "\n";
   telemetry_file_.flush();
   if (telemetry_file_.fail()) {
-    VLOG(FULL_NODE_WARNING) << "Failed to write telemetry to file";
+    VLOG(full_node, WARNING) << "Failed to write telemetry to file";
   }
 }
 
@@ -241,7 +241,7 @@ void FullNodeFastSyncOverlay::send_shard_block_info(BlockIdExt block_id, Catchai
   if (!inited_) {
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending newShardBlockBroadcast in fast sync overlay: " << block_id;
+  VLOG(full_node, DEBUG) << "Sending newShardBlockBroadcast in fast sync overlay: " << block_id;
   auto B = create_serialize_tl_object<ton_api::tonNode_newShardBlockBroadcast>(
       create_tl_object<ton_api::tonNode_newShardBlock>(create_tl_block_id(block_id), cc_seqno, std::move(data)));
   if (B.size() <= overlay::Overlays::max_simple_broadcast_size()) {
@@ -258,10 +258,10 @@ void FullNodeFastSyncOverlay::send_broadcast(BlockBroadcast broadcast) {
   if (!inited_) {
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending block broadcast in fast sync overlay (with compression): " << broadcast.block_id;
+  VLOG(full_node, DEBUG) << "Sending block broadcast in fast sync overlay (with compression): " << broadcast.block_id;
   auto B = serialize_block_broadcast(broadcast, k_called_from_fast_sync);
   if (B.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "failed to serialize block broadcast: " << B.move_as_error();
+    VLOG(full_node, WARNING) << "failed to serialize block broadcast: " << B.move_as_error();
     return;
   }
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,
@@ -276,10 +276,10 @@ void FullNodeFastSyncOverlay::send_block_candidate(BlockIdExt block_id, Catchain
   auto B = serialize_block_candidate_broadcast(block_id, cc_seqno, validator_set_hash, data, true,
                                                k_called_from_fast_sync);  // compression enabled
   if (B.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "failed to serialize block candidate broadcast: " << B.move_as_error();
+    VLOG(full_node, WARNING) << "failed to serialize block candidate broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending newBlockCandidate in fast sync overlay (with compression): " << block_id;
+  VLOG(full_node, DEBUG) << "Sending newBlockCandidate in fast sync overlay (with compression): " << block_id;
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,
                           local_id_.pubkey_hash(), overlay::Overlays::BroadcastFlagAnySender(), B.move_as_ok());
 }
@@ -303,7 +303,7 @@ void FullNodeFastSyncOverlay::collect_validator_telemetry(std::string filename) 
     telemetry_file_.close();
   }
   collect_telemetry_ = true;
-  LOG(FULL_NODE_WARNING) << "Collecting validator telemetry to " << filename << " (local id: " << local_id_ << ")";
+  VLOG(full_node, WARNING) << "Collecting validator telemetry to " << filename << " (local id: " << local_id_ << ")";
   telemetry_file_.open(filename, std::ios_base::app);
   if (!telemetry_file_.is_open()) {
     LOG(WARNING) << "Cannot open file " << filename << " for validator telemetry";
@@ -321,7 +321,7 @@ void FullNodeFastSyncOverlay::send_out_msg_queue_proof_broadcast(td::Ref<OutMsgQ
       create_tl_object<ton_api::tonNode_outMsgQueueProof>(broadcast->queue_proofs.clone(),
                                                           broadcast->block_state_proofs.clone(),
                                                           std::vector<td::int32>(1, broadcast->msg_count)));
-  VLOG(FULL_NODE_DEBUG) << "Sending outMsgQueueProof in fast sync overlay to " << broadcast->dst_shard.to_str()
+  VLOG(full_node, DEBUG) << "Sending outMsgQueueProof in fast sync overlay to " << broadcast->dst_shard.to_str()
                         << " from " << broadcast->block_id.to_str() << ", msgs=" << broadcast->msg_count
                         << " bytes=" << broadcast->queue_proofs.size();
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,

--- a/validator/full-node-fast-sync-overlays.hpp
+++ b/validator/full-node-fast-sync-overlays.hpp
@@ -46,7 +46,7 @@ class FullNodeFastSyncOverlay : public td::actor::Actor {
 
   template <class T>
   void process_broadcast(PublicKeyHash, T&) {
-    VLOG(FULL_NODE_WARNING) << "dropping unknown broadcast";
+    VLOG(full_node, WARNING) << "dropping unknown broadcast";
   }
   void receive_broadcast(PublicKeyHash src, td::BufferSlice query);
 

--- a/validator/full-node-serializer.cpp
+++ b/validator/full-node-serializer.cpp
@@ -45,17 +45,17 @@ static td::Result<td::BufferSlice> serialize_block_broadcast_v2(const BlockBroad
   TRY_RESULT_ASSIGN(compressed_data, vm::boc_compress({data_root}, algorithm));
   size_t compressed_size = compressed_data.size();
   TRY_RESULT(algorithm_name, vm::boc_get_algorithm_name(compressed_data));
-  VLOG(FULL_NODE_DEBUG) << "Compressing block broadcast V2: "
-                        << broadcast.data.size() + broadcast.proof.size() + total_signatures_size << " -> "
-                        << compressed_data.size() + broadcast.proof.size() + total_signatures_size;
+  VLOG(full_node, DEBUG) << "Compressing block broadcast V2: "
+                         << broadcast.data.size() + broadcast.proof.size() + total_signatures_size << " -> "
+                         << compressed_data.size() + broadcast.proof.size() + total_signatures_size;
   auto res = create_serialize_tl_object<ton_api::tonNode_blockBroadcastCompressedV2>(
       create_tl_block_id(broadcast.block_id), broadcast.sig_set->tl(), 0, broadcast.proof.clone(),
       std::move(compressed_data));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark serialize_block_broadcast block_id=" << broadcast.block_id
-                            << " called_from=" << called_from << " time_sec=" << (td::Time::now() - t_compression_start)
-                            << " compression=" << "compressedV2" << algorithm_name << " original_size="
-                            << broadcast.data.size() + broadcast.proof.size() + total_signatures_size
-                            << " compressed_size=" << compressed_size + broadcast.proof.size() + total_signatures_size;
+  VLOG(full_node, WARNING) << "Broadcast_benchmark serialize_block_broadcast block_id=" << broadcast.block_id
+                           << " called_from=" << called_from << " time_sec=" << (td::Time::now() - t_compression_start)
+                           << " compression=" << "compressedV2" << algorithm_name << " original_size="
+                           << broadcast.data.size() + broadcast.proof.size() + total_signatures_size
+                           << " compressed_size=" << compressed_size + broadcast.proof.size() + total_signatures_size;
   return res;
 }
 
@@ -75,18 +75,18 @@ td::Result<td::BufferSlice> serialize_block_broadcast(const BlockBroadcast& broa
       create_serialize_tl_object<ton_api::tonNode_blockBroadcastCompressed_data>(std::move(sigs), std::move(boc));
   td::BufferSlice compressed = td::lz4_compress(data);
   size_t compressed_size = compressed.size();
-  VLOG(FULL_NODE_DEBUG) << "Compressing block broadcast: "
-                        << broadcast.data.size() + broadcast.proof.size() + total_signatures_size << " -> "
-                        << compressed.size();
+  VLOG(full_node, DEBUG) << "Compressing block broadcast: "
+                         << broadcast.data.size() + broadcast.proof.size() + total_signatures_size << " -> "
+                         << compressed.size();
   auto res = create_serialize_tl_object<ton_api::tonNode_blockBroadcastCompressed>(
       create_tl_block_id(broadcast.block_id), broadcast.sig_set->get_catchain_seqno(),
       broadcast.sig_set->get_validator_set_hash(), 0, std::move(compressed));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark serialize_block_broadcast block_id=" << broadcast.block_id
-                            << " called_from=" << called_from << " time_sec=" << (td::Time::now() - t_compression_start)
-                            << " compression=" << "compressed"
-                            << " original_size="
-                            << broadcast.data.size() + broadcast.proof.size() + total_signatures_size
-                            << " compressed_size=" << compressed_size;
+  VLOG(full_node, WARNING) << "Broadcast_benchmark serialize_block_broadcast block_id=" << broadcast.block_id
+                           << " called_from=" << called_from << " time_sec=" << (td::Time::now() - t_compression_start)
+                           << " compression=" << "compressed"
+                           << " original_size="
+                           << broadcast.data.size() + broadcast.proof.size() + total_signatures_size
+                           << " compressed_size=" << compressed_size;
   return res;
 }
 
@@ -98,11 +98,11 @@ static td::Result<BlockBroadcast> deserialize_block_broadcast(ton_api::tonNode_b
   td::Ref<block::BlockSignatureSet> sig_set =
       block::BlockSignatureSet::fetch(f.signatures_, f.catchain_seqno_, f.validator_set_hash_);
   auto result = BlockBroadcast{block_id, std::move(sig_set), std::move(f.data_), std::move(f.proof_)};
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_broadcast block_id=" << block_id
-                            << " called_from=" << called_from
-                            << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"
-                            << " compressed_size="
-                            << result.data.size() + result.proof.size() + f.signatures_.size() * 96;
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_broadcast block_id=" << block_id
+                           << " called_from=" << called_from
+                           << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"
+                           << " compressed_size="
+                           << result.data.size() + result.proof.size() + f.signatures_.size() * 96;
   return result;
 }
 
@@ -119,15 +119,15 @@ static td::Result<BlockBroadcast> deserialize_block_broadcast(ton_api::tonNode_b
   if (roots.size() != 2) {
     return td::Status::Error("expected 2 roots in boc");
   }
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_broadcast block_id=" << block_id
-                            << " called_from=" << called_from
-                            << " time_sec=" << (td::Time::now() - t_decompression_start)
-                            << " compression=" << "compressed"
-                            << " compressed_size=" << f.compressed_.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_broadcast block_id=" << block_id
+                           << " called_from=" << called_from
+                           << " time_sec=" << (td::Time::now() - t_decompression_start)
+                           << " compression=" << "compressed"
+                           << " compressed_size=" << f.compressed_.size();
   TRY_RESULT(proof, vm::std_boc_serialize(roots[0], 0));
   TRY_RESULT(data, vm::std_boc_serialize(roots[1], 31));
-  VLOG(FULL_NODE_DEBUG) << "Decompressing block broadcast: " << f.compressed_.size() << " -> "
-                        << data.size() + proof.size() + f2->signatures_.size() * 96;
+  VLOG(full_node, DEBUG) << "Decompressing block broadcast: " << f.compressed_.size() << " -> "
+                         << data.size() + proof.size() + f2->signatures_.size() * 96;
   return BlockBroadcast{block_id, std::move(sig_set), std::move(data), std::move(proof)};
 }
 
@@ -195,11 +195,11 @@ static td::Result<BlockBroadcast> deserialize_block_broadcast(ton_api::tonNode_b
     return td::Status::Error("expected 1 root in boc");
   }
   TRY_RESULT(algorithm_name, vm::boc_get_algorithm_name(f.data_compressed_));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_broadcast block_id=" << block_id
-                            << " called_from=" << called_from
-                            << " time_sec=" << (td::Time::now() - t_decompression_start)
-                            << " compression=" << "compressedV2_" << algorithm_name << " compressed_size="
-                            << f.data_compressed_.size() + f.proof_.size() + total_signatures_size;
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_broadcast block_id=" << block_id
+                           << " called_from=" << called_from
+                           << " time_sec=" << (td::Time::now() - t_decompression_start)
+                           << " compression=" << "compressedV2_" << algorithm_name << " compressed_size="
+                           << f.data_compressed_.size() + f.proof_.size() + total_signatures_size;
   TRY_RESULT(data, vm::std_boc_serialize(roots[0], 31));
   return BlockBroadcast{create_block_id(f.id_), sig_set, std::move(data), std::move(f.proof_)};
 }
@@ -225,10 +225,10 @@ td::Result<td::BufferSlice> serialize_block_full(const BlockIdExt& id, td::Slice
     auto t_compression_start = td::Time::now();
     auto res = create_serialize_tl_object<ton_api::tonNode_dataFull>(create_tl_block_id(id), td::BufferSlice(proof),
                                                                      td::BufferSlice(data), is_proof_link);
-    VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark serialize_block_full block_id=" << id
-                              << " time_sec=" << (td::Time::now() - t_compression_start) << " compression=" << "none"
-                              << " original_size=" << data.size() + proof.size()
-                              << " compressed_size=" << data.size() + proof.size();
+    VLOG(full_node, WARNING) << "Broadcast_benchmark serialize_block_full block_id=" << id
+                             << " time_sec=" << (td::Time::now() - t_compression_start) << " compression=" << "none"
+                             << " original_size=" << data.size() + proof.size()
+                             << " compressed_size=" << data.size() + proof.size();
     return res;
   }
   TRY_RESULT(proof_root, vm::std_boc_deserialize(proof));
@@ -237,14 +237,12 @@ td::Result<td::BufferSlice> serialize_block_full(const BlockIdExt& id, td::Slice
   TRY_RESULT(boc, vm::std_boc_serialize_multi({proof_root, data_root}, 2));
   td::BufferSlice compressed = td::lz4_compress(boc);
   size_t compressed_size = compressed.size();
-  VLOG(FULL_NODE_DEBUG) << "Compressing block full: " << data.size() + proof.size() << " -> " << compressed.size();
+  VLOG(full_node, DEBUG) << "Compressing block full: " << data.size() + proof.size() << " -> " << compressed.size();
   auto res = create_serialize_tl_object<ton_api::tonNode_dataFullCompressed>(create_tl_block_id(id), 0,
                                                                              std::move(compressed), is_proof_link);
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark serialize_block_full block_id=" << id
-                            << " time_sec=" << (td::Time::now() - t_compression_start)
-                            << " compression=" << "compressed"
-                            << " original_size=" << data.size() + proof.size()
-                            << " compressed_size=" << compressed_size;
+  VLOG(full_node, WARNING) << "Broadcast_benchmark serialize_block_full block_id=" << id
+                           << " time_sec=" << (td::Time::now() - t_compression_start) << " compression=" << "compressed"
+                           << " original_size=" << data.size() + proof.size() << " compressed_size=" << compressed_size;
   return res;
 }
 
@@ -255,9 +253,9 @@ static td::Status deserialize_block_full(ton_api::tonNode_dataFull& f, BlockIdEx
   proof = std::move(f.proof_);
   data = std::move(f.block_);
   is_proof_link = f.is_link_;
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_full block_id=" << id
-                            << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"
-                            << " compressed_size=" << proof.size() + data.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_full block_id=" << id
+                           << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"
+                           << " compressed_size=" << proof.size() + data.size();
   return td::Status::OK();
 }
 
@@ -271,13 +269,14 @@ static td::Status deserialize_block_full(ton_api::tonNode_dataFullCompressed& f,
   if (roots.size() != 2) {
     return td::Status::Error("expected 2 roots in boc");
   }
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_full block_id=" << id
-                            << " time_sec=" << (td::Time::now() - t_decompression_start)
-                            << " compression=" << "compressed"
-                            << " compressed_size=" << f.compressed_.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_full block_id=" << id
+                           << " time_sec=" << (td::Time::now() - t_decompression_start)
+                           << " compression=" << "compressed"
+                           << " compressed_size=" << f.compressed_.size();
   TRY_RESULT_ASSIGN(proof, vm::std_boc_serialize(roots[0], 0));
   TRY_RESULT_ASSIGN(data, vm::std_boc_serialize(roots[1], 31));
-  VLOG(FULL_NODE_DEBUG) << "Decompressing block full: " << f.compressed_.size() << " -> " << data.size() + proof.size();
+  VLOG(full_node, DEBUG) << "Decompressing block full: " << f.compressed_.size() << " -> "
+                         << data.size() + proof.size();
   is_proof_link = f.is_link_;
   return td::Status::OK();
 }
@@ -293,14 +292,14 @@ static td::Status deserialize_block_full(ton_api::tonNode_dataFullCompressedV2& 
     return td::Status::Error("expected 1 root in boc");
   }
   TRY_RESULT(algorithm_name, vm::boc_get_algorithm_name(f.block_compressed_));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_full block_id=" << id
-                            << " time_sec=" << (td::Time::now() - t_decompression_start)
-                            << " compression=" << "compressedV2_" << algorithm_name
-                            << " compressed_size=" << f.block_compressed_.size() + f.proof_.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_full block_id=" << id
+                           << " time_sec=" << (td::Time::now() - t_decompression_start)
+                           << " compression=" << "compressedV2_" << algorithm_name
+                           << " compressed_size=" << f.block_compressed_.size() + f.proof_.size();
   TRY_RESULT_ASSIGN(data, vm::std_boc_serialize(roots[0], 31));
   proof = std::move(f.proof_);
-  VLOG(FULL_NODE_DEBUG) << "Decompressing block full V2: " << f.block_compressed_.size() + f.proof_.size() << " -> "
-                        << data.size() + proof.size();
+  VLOG(full_node, DEBUG) << "Decompressing block full V2: " << f.block_compressed_.size() + f.proof_.size() << " -> "
+                         << data.size() + proof.size();
   is_proof_link = f.is_link_;
   return td::Status::OK();
 }
@@ -330,10 +329,10 @@ td::Result<td::BufferSlice> serialize_block_candidate_broadcast(BlockIdExt block
     auto res = create_serialize_tl_object<ton_api::tonNode_newBlockCandidateBroadcast>(
         create_tl_block_id(block_id), cc_seqno, validator_set_hash,
         create_tl_object<ton_api::tonNode_blockSignature>(Bits256::zero(), td::BufferSlice()), td::BufferSlice(data));
-    VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark serialize_block_candidate_broadcast block_id=" << block_id
-                              << " called_from=" << called_from
-                              << " time_sec=" << (td::Time::now() - t_compression_start) << " compression=" << "none"
-                              << " original_size=" << data.size() << " compressed_size=" << data.size();
+    VLOG(full_node, WARNING) << "Broadcast_benchmark serialize_block_candidate_broadcast block_id=" << block_id
+                             << " called_from=" << called_from
+                             << " time_sec=" << (td::Time::now() - t_compression_start) << " compression=" << "none"
+                             << " original_size=" << data.size() << " compressed_size=" << data.size();
     return res;
   }
   TRY_RESULT(root, vm::std_boc_deserialize(data));
@@ -341,14 +340,14 @@ td::Result<td::BufferSlice> serialize_block_candidate_broadcast(BlockIdExt block
   TRY_RESULT(data_new, vm::std_boc_serialize(root, 2));
   td::BufferSlice compressed = td::lz4_compress(data_new);
   auto compressed_size = compressed.size();
-  VLOG(FULL_NODE_DEBUG) << "Compressing block candidate broadcast: " << data.size() << " -> " << compressed_size;
+  VLOG(full_node, DEBUG) << "Compressing block candidate broadcast: " << data.size() << " -> " << compressed_size;
   auto res = create_serialize_tl_object<ton_api::tonNode_newBlockCandidateBroadcastCompressed>(
       create_tl_block_id(block_id), cc_seqno, validator_set_hash,
       create_tl_object<ton_api::tonNode_blockSignature>(Bits256::zero(), td::BufferSlice()), 0, std::move(compressed));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark serialize_block_candidate_broadcast block_id=" << block_id
-                            << " called_from=" << called_from << " time_sec=" << (td::Time::now() - t_compression_start)
-                            << " compression=" << "compressed"
-                            << " original_size=" << data.size() << " compressed_size=" << compressed_size;
+  VLOG(full_node, WARNING) << "Broadcast_benchmark serialize_block_candidate_broadcast block_id=" << block_id
+                           << " called_from=" << called_from << " time_sec=" << (td::Time::now() - t_compression_start)
+                           << " compression=" << "compressed"
+                           << " original_size=" << data.size() << " compressed_size=" << compressed_size;
   return res;
 }
 
@@ -361,10 +360,10 @@ static td::Status deserialize_block_candidate_broadcast(ton_api::tonNode_newBloc
   cc_seqno = obj.catchain_seqno_;
   validator_set_hash = obj.validator_set_hash_;
   data = std::move(obj.data_);
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_candidate_broadcast block_id=" << block_id
-                            << " called_from=" << called_from
-                            << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"
-                            << " compressed_size=" << data.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_candidate_broadcast block_id=" << block_id
+                           << " called_from=" << called_from
+                           << " time_sec=" << (td::Time::now() - t_decompression_start) << " compression=" << "none"
+                           << " compressed_size=" << data.size();
   return td::Status::OK();
 }
 
@@ -378,14 +377,14 @@ static td::Status deserialize_block_candidate_broadcast(ton_api::tonNode_newBloc
   validator_set_hash = obj.validator_set_hash_;
   TRY_RESULT(decompressed, td::lz4_decompress(obj.compressed_, max_decompressed_data_size));
   TRY_RESULT(root, vm::std_boc_deserialize(decompressed));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_candidate_broadcast block_id=" << block_id
-                            << " called_from=" << called_from
-                            << " time_sec=" << (td::Time::now() - t_decompression_start)
-                            << " compression=" << "compressed"
-                            << " compressed_size=" << obj.compressed_.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_candidate_broadcast block_id=" << block_id
+                           << " called_from=" << called_from
+                           << " time_sec=" << (td::Time::now() - t_decompression_start)
+                           << " compression=" << "compressed"
+                           << " compressed_size=" << obj.compressed_.size();
   TRY_RESULT_ASSIGN(data, vm::std_boc_serialize(root, 31));
-  VLOG(FULL_NODE_DEBUG) << "Decompressing block candidate broadcast: " << obj.compressed_.size() << " -> "
-                        << data.size();
+  VLOG(full_node, DEBUG) << "Decompressing block candidate broadcast: " << obj.compressed_.size() << " -> "
+                         << data.size();
   return td::Status::OK();
 }
 
@@ -402,15 +401,15 @@ static td::Status deserialize_block_candidate_broadcast(ton_api::tonNode_newBloc
     return td::Status::Error("expected 1 root in boc");
   }
   TRY_RESULT(algorithm_name, vm::boc_get_algorithm_name(obj.compressed_));
-  VLOG(FULL_NODE_BENCHMARK) << "Broadcast_benchmark deserialize_block_candidate_broadcast block_id=" << block_id
-                            << " called_from=" << called_from
-                            << " time_sec=" << (td::Time::now() - t_decompression_start)
-                            << " compression=" << "compressedV2_" << algorithm_name
-                            << " compressed_size=" << obj.compressed_.size();
+  VLOG(full_node, WARNING) << "Broadcast_benchmark deserialize_block_candidate_broadcast block_id=" << block_id
+                           << " called_from=" << called_from
+                           << " time_sec=" << (td::Time::now() - t_decompression_start)
+                           << " compression=" << "compressedV2_" << algorithm_name
+                           << " compressed_size=" << obj.compressed_.size();
   auto root = std::move(roots[0]);
   TRY_RESULT_ASSIGN(data, vm::std_boc_serialize(root, 31));
-  VLOG(FULL_NODE_DEBUG) << "Decompressing block candidate broadcast V2: " << obj.compressed_.size() << " -> "
-                        << data.size();
+  VLOG(full_node, DEBUG) << "Decompressing block candidate broadcast V2: " << obj.compressed_.size() << " -> "
+                         << data.size();
   return td::Status::OK();
 }
 

--- a/validator/full-node-shard.cpp
+++ b/validator/full-node-shard.cpp
@@ -254,12 +254,12 @@ void FullNodeShardImpl::get_next_block() {
     } else {
       auto S = R.move_as_error();
       if (S.code() != ErrorCode::notready && S.code() != ErrorCode::timeout) {
-        VLOG(FULL_NODE_WARNING) << "failed to download next block after " << block_id << ": " << S;
+        VLOG(full_node, WARNING) << "failed to download next block after " << block_id << ": " << S;
       } else {
         if ((attempt % 128) == 0) {
-          VLOG(FULL_NODE_INFO) << "failed to download next block after " << block_id << ": " << S;
+          VLOG(full_node, INFO) << "failed to download next block after " << block_id << ": " << S;
         } else {
-          VLOG(FULL_NODE_DEBUG) << "failed to download next block after " << block_id << ": " << S;
+          VLOG(full_node, DEBUG) << "failed to download next block after " << block_id << ": " << S;
         }
       }
       delay_action([SelfId]() mutable { td::actor::send_closure(SelfId, &FullNodeShardImpl::get_next_block); },
@@ -291,7 +291,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
     }
   });
   BlockIdExt block_id = create_block_id(query.prev_block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query getNextBlockDescription " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query getNextBlockDescription " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_next_block, block_id, std::move(P));
 }
 
@@ -313,7 +313,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
     }
   });
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query prepareBlock " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query prepareBlock " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
                           std::move(P));
 }
@@ -334,7 +334,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
     }
   });
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadBlock " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadBlock " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
                           std::move(P));
 }
@@ -342,14 +342,14 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
 void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockFull &query,
                                       td::Promise<td::BufferSlice> promise) {
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadBlockFull " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadBlockFull " << block_id << " from " << src;
   td::actor::create_actor<BlockFullSender>("sender", block_id, false, validator_manager_, std::move(promise)).release();
 }
 
 void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadNextBlockFull &query,
                                       td::Promise<td::BufferSlice> promise) {
   BlockIdExt block_id = create_block_id(query.prev_block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadNextBlockFull " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadNextBlockFull " << block_id << " from " << src;
   td::actor::create_actor<BlockFullSender>("sender", block_id, true, validator_manager_, std::move(promise)).release();
 }
 
@@ -383,7 +383,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
   });
 
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query prepareBlockProof " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query prepareBlockProof " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
                           std::move(P));
 }
@@ -409,8 +409,8 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
       });
 
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query prepareKeyBlockProof " << block_id << " " << query.allow_partial_ << " from "
-                        << src;
+  VLOG(full_node, DEBUG) << "Got query prepareKeyBlockProof " << block_id << " " << query.allow_partial_ << " from "
+                         << src;
   if (query.allow_partial_) {
     td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_key_block_proof_link, block_id,
                             std::move(P));
@@ -440,7 +440,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
       });
 
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadBlockProof " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadBlockProof " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
                           std::move(P));
 }
@@ -465,7 +465,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
       });
 
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadBlockProofLink " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadBlockProofLink " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
                           std::move(P));
 }
@@ -485,7 +485,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
   });
 
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadKeyBlockProof " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadKeyBlockProof " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_key_block_proof, block_id, std::move(P));
 }
 
@@ -504,7 +504,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
   });
 
   BlockIdExt block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadKeyBlockProofLink " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadKeyBlockProofLink " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_key_block_proof_link, block_id,
                           std::move(P));
 }
@@ -523,7 +523,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
         promise.set_value(std::move(x));
       });
   auto block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query prepareZeroState " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query prepareZeroState " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::check_zero_state_exists, block_id,
                           std::move(P));
 }
@@ -542,8 +542,8 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
       });
   auto block_id = create_block_id(query.block_);
   auto masterchain_block_id = create_block_id(query.masterchain_block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query preparePersistentState " << block_id << " " << masterchain_block_id << " from "
-                        << src;
+  VLOG(full_node, DEBUG) << "Got query preparePersistentState " << block_id << " " << masterchain_block_id << " from "
+                         << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_persistent_state_size, block_id,
                           masterchain_block_id, UnsplitStateType{}, std::move(P));
 }
@@ -576,7 +576,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
         promise.set_value(std::move(x));
       });
   auto block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query getNextKeyBlockIds " << block_id << " " << cnt << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query getNextKeyBlockIds " << block_id << " " << cnt << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_next_key_blocks, block_id, cnt,
                           std::move(P));
 }
@@ -593,13 +593,13 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
         promise.set_value(R.move_as_ok());
       });
   auto block_id = create_block_id(query.block_);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadZeroState " << block_id << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadZeroState " << block_id << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_zero_state, block_id, std::move(P));
 }
 
 void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getCapabilities &query,
                                       td::Promise<td::BufferSlice> promise) {
-  VLOG(FULL_NODE_DEBUG) << "Got query getCapabilities from " << src;
+  VLOG(full_node, DEBUG) << "Got query getCapabilities from " << src;
   promise.set_value(
       create_serialize_tl_object<ton_api::tonNode_capabilities>(proto_version_major(), proto_version_minor(), 0));
 }
@@ -614,7 +614,7 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
           promise.set_value(create_serialize_tl_object<ton_api::tonNode_archiveInfo>(R.move_as_ok()));
         }
       });
-  VLOG(FULL_NODE_DEBUG) << "Got query getArchiveInfo " << query.masterchain_seqno_ << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query getArchiveInfo " << query.masterchain_seqno_ << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_archive_id, query.masterchain_seqno_,
                           ShardIdFull{masterchainId}, std::move(P));
 }
@@ -630,16 +630,16 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
         }
       });
   ShardIdFull shard_prefix = create_shard_id(query.shard_prefix_);
-  VLOG(FULL_NODE_DEBUG) << "Got query getShardArchiveInfo " << query.masterchain_seqno_ << " " << shard_prefix
-                        << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query getShardArchiveInfo " << query.masterchain_seqno_ << " " << shard_prefix
+                         << " from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_archive_id, query.masterchain_seqno_,
                           shard_prefix, std::move(P));
 }
 
 void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getArchiveSlice &query,
                                       td::Promise<td::BufferSlice> promise) {
-  VLOG(FULL_NODE_DEBUG) << "Got query getArchiveSlice " << query.archive_id_ << " " << query.offset_ << " "
-                        << query.max_size_ << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query getArchiveSlice " << query.archive_id_ << " " << query.offset_ << " "
+                         << query.max_size_ << " from " << src;
   if (query.max_size_ < 0 || query.max_size_ > (1 << 24)) {
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "invalid max_size"));
     return;
@@ -700,9 +700,9 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
 void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadPersistentStateSliceV2 &query,
                                       td::Promise<td::BufferSlice> promise) {
   auto [block_id, mc_block_id, state_type] = persistent_state_from_v2_query(query);
-  VLOG(FULL_NODE_DEBUG) << "Got query downloadPersistentStateSlice " << block_id << " " << mc_block_id << " ("
-                        << persistent_state_type_to_string(block_id.shard_full(), state_type) << ") " << query.offset_
-                        << " " << query.max_size_ << " from " << src;
+  VLOG(full_node, DEBUG) << "Got query downloadPersistentStateSlice " << block_id << " " << mc_block_id << " ("
+                         << persistent_state_type_to_string(block_id.shard_full(), state_type) << ") " << query.offset_
+                         << " " << query.max_size_ << " from " << src;
   if (query.max_size_ < 0 || query.max_size_ > (1 << 24)) {
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "invalid max_size"));
     return;
@@ -731,8 +731,8 @@ void FullNodeShardImpl::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNod
         }
       });
   auto [block_id, mc_block_id, state_type] = persistent_state_from_v2_query(query);
-  VLOG(FULL_NODE_DEBUG) << "Got query getPersistentStateSize " << block_id << " " << mc_block_id << " ("
-                        << persistent_state_type_to_string(block_id.shard_full(), state_type) << ") from " << src;
+  VLOG(full_node, DEBUG) << "Got query getPersistentStateSize " << block_id << " " << mc_block_id << " ("
+                         << persistent_state_type_to_string(block_id.shard_full(), state_type) << ") from " << src;
   td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_persistent_state_size, block_id,
                           mc_block_id, state_type, std::move(P));
 }
@@ -763,7 +763,7 @@ void FullNodeShardImpl::receive_message(adnl::AdnlNodeIdShort src, td::BufferSli
   if (B.is_error()) {
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Got tonNode.forgetPeer from " << src;
+  VLOG(full_node, DEBUG) << "Got tonNode.forgetPeer from " << src;
   neighbours_.erase(src);
   td::actor::send_closure(overlays_, &overlay::Overlays::forget_peer, adnl_id_, overlay_id_, src);
 }
@@ -779,7 +779,7 @@ void FullNodeShardImpl::process_broadcast(PublicKeyHash src, ton_api::tonNode_ex
 
 void FullNodeShardImpl::process_broadcast(PublicKeyHash src, ton_api::tonNode_newShardBlockBroadcast &query) {
   BlockIdExt block_id = create_block_id(query.block_->block_);
-  VLOG(FULL_NODE_DEBUG) << "Received newShardBlockBroadcast from " << src << ": " << block_id;
+  VLOG(full_node, DEBUG) << "Received newShardBlockBroadcast from " << src << ": " << block_id;
   td::actor::send_closure(full_node_, &FullNode::process_shard_block_info_broadcast, block_id, query.block_->cc_seqno_,
                           std::move(query.block_->data_));
 }
@@ -806,18 +806,18 @@ void FullNodeShardImpl::process_block_candidate_broadcast(PublicKeyHash src, ton
   auto S = deserialize_block_candidate_broadcast(query, block_id, cc_seqno, validator_set_hash, data,
                                                  overlay::Overlays::max_fec_broadcast_size(), k_called_from_public);
   if (S.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "received bad block candidate from " << src << " : " << S;
+    VLOG(full_node, WARNING) << "received bad block candidate from " << src << " : " << S;
     return;
   }
   if (data.size() > FullNode::max_block_size()) {
-    VLOG(FULL_NODE_WARNING) << "received block candidate with too big size from " << src;
+    VLOG(full_node, WARNING) << "received block candidate with too big size from " << src;
     return;
   }
   if (td::sha256_bits256(data.as_slice()) != block_id.file_hash) {
-    VLOG(FULL_NODE_WARNING) << "received block candidate with incorrect file hash from " << src;
+    VLOG(full_node, WARNING) << "received block candidate with incorrect file hash from " << src;
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received newBlockCandidate from " << src << ": " << block_id;
+  VLOG(full_node, DEBUG) << "Received newBlockCandidate from " << src << ": " << block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_candidate_broadcast, block_id, cc_seqno,
                           validator_set_hash, std::move(data), BroadcastSource::public_overlay);
 }
@@ -863,12 +863,12 @@ void FullNodeShardImpl::process_block_broadcast(PublicKeyHash src, ton_api::tonN
     return;
   }
   //if (!shard_is_ancestor(shard_, block_id.shard_full())) {
-  //  LOG(FULL_NODE_WARNING) << "dropping block broadcast: shard mismatch. overlay=" << shard_.to_str()
+  //  VLOG(full_node, WARNING) << "dropping block broadcast: shard mismatch. overlay=" << shard_.to_str()
   //                         << " block=" << block_id.to_str();
   //  return;
   //}
-  VLOG(FULL_NODE_DEBUG) << "Received block broadcast " << (B.ok().sig_set->is_final() ? "" : "(approve signatures) ")
-                        << "from " << src << ": " << B.ok().block_id;
+  VLOG(full_node, DEBUG) << "Received block broadcast " << (B.ok().sig_set->is_final() ? "" : "(approve signatures) ")
+                         << "from " << src << ": " << B.ok().block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_broadcast, B.move_as_ok(), false,
                           BroadcastSource::public_overlay);
 }
@@ -905,7 +905,7 @@ void FullNodeShardImpl::process_block_broadcast_with_state(PublicKeyHash src,
     LOG(DEBUG) << "Failed to deserialize block broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Received block broadcast from " << src << ": " << B.ok().block_id;
+  VLOG(full_node, DEBUG) << "Received block broadcast from " << src << ": " << B.ok().block_id;
   td::actor::send_closure(full_node_, &FullNode::process_block_broadcast, B.move_as_ok(), true,
                           BroadcastSource::public_overlay);
 }
@@ -951,7 +951,7 @@ void FullNodeShardImpl::send_external_message(td::BufferSlice data) {
                                     create_tl_object<ton_api::tonNode_externalMessage>(std::move(data)))),
                             td::Timestamp::in(1.0), [](td::Result<td::BufferSlice> R) {
                               if (R.is_error()) {
-                                VLOG(FULL_NODE_WARNING) << "failed to send ext message: " << R.move_as_error();
+                                VLOG(full_node, WARNING) << "failed to send ext message: " << R.move_as_error();
                               }
                             });
     return;
@@ -979,7 +979,7 @@ void FullNodeShardImpl::send_shard_block_info(BlockIdExt block_id, CatchainSeqno
     UNREACHABLE();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending newShardBlockBroadcast: " << block_id;
+  VLOG(full_node, DEBUG) << "Sending newShardBlockBroadcast: " << block_id;
   auto B = create_serialize_tl_object<ton_api::tonNode_newShardBlockBroadcast>(
       create_tl_object<ton_api::tonNode_newShardBlock>(create_tl_block_id(block_id), cc_seqno, std::move(data)));
   auto source = choose_outbound_source(static_cast<td::uint32>(B.size()),
@@ -1002,10 +1002,10 @@ void FullNodeShardImpl::send_block_candidate(BlockIdExt block_id, CatchainSeqno 
   auto B = serialize_block_candidate_broadcast(block_id, cc_seqno, validator_set_hash, data, true,
                                                k_called_from_public);  // compression enabled
   if (B.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "failed to serialize block candidate broadcast: " << B.move_as_error();
+    VLOG(full_node, WARNING) << "failed to serialize block candidate broadcast: " << B.move_as_error();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending newBlockCandidate: " << block_id;
+  VLOG(full_node, DEBUG) << "Sending newBlockCandidate: " << block_id;
   auto payload = B.move_as_ok();
   auto source = choose_outbound_source(static_cast<td::uint32>(payload.size()), true);
   td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, adnl_id_, overlay_id_, source,
@@ -1017,10 +1017,10 @@ void FullNodeShardImpl::send_broadcast(BlockBroadcast broadcast) {
     UNREACHABLE();
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Sending block broadcast in private overlay: " << broadcast.block_id;
+  VLOG(full_node, DEBUG) << "Sending block broadcast in private overlay: " << broadcast.block_id;
   auto B = serialize_block_broadcast(broadcast, k_called_from_public);
   if (B.is_error()) {
-    VLOG(FULL_NODE_WARNING) << "failed to serialize block broadcast: " << B.move_as_error();
+    VLOG(full_node, WARNING) << "failed to serialize block broadcast: " << B.move_as_error();
     return;
   }
   auto payload = B.move_as_ok();
@@ -1215,7 +1215,7 @@ void FullNodeShardImpl::sign_new_certificate(PublicKeyHash sign_by) {
                                           td::Result<std::pair<td::BufferSlice, PublicKey>> R) mutable {
     if (R.is_error()) {
       // ignore
-      VLOG(FULL_NODE_WARNING) << "failed to create certificate: failed to sign: " << R.move_as_error();
+      VLOG(full_node, WARNING) << "failed to create certificate: failed to sign: " << R.move_as_error();
     } else {
       auto p = R.move_as_ok();
       cert.set_signature(std::move(p.first));

--- a/validator/full-node.cpp
+++ b/validator/full-node.cpp
@@ -28,6 +28,8 @@
 #include "full-node.h"
 #include "full-node.hpp"
 
+DEFINE_LOG_CATEGORY(full_node, VERBOSITY_NAME(INFO))
+
 namespace ton {
 
 namespace validator {
@@ -172,7 +174,7 @@ void FullNodeImpl::add_custom_overlay(CustomOverlayParams params, td::Promise<td
     promise.set_error(td::Status::Error(PSTRING() << "duplicate custom overlay name \"" << name << "\""));
     return;
   }
-  VLOG(FULL_NODE_WARNING) << "Adding custom overlay \"" << name << "\", " << params.nodes_.size() << " nodes";
+  VLOG(full_node, WARNING) << "Adding custom overlay \"" << name << "\", " << params.nodes_.size() << " nodes";
   auto &p = custom_overlays_[name];
   p.params_ = std::move(params);
   update_custom_overlay(p);
@@ -302,7 +304,7 @@ void FullNodeImpl::sync_completed() {
 void FullNodeImpl::send_ihr_message(AccountIdPrefixFull dst, td::BufferSlice data) {
   auto shard = get_shard(dst);
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping OUT ihr message to unknown shard";
+    VLOG(full_node, WARNING) << "dropping OUT ihr message to unknown shard";
     return;
   }
   td::actor::send_closure(shard, &FullNodeShard::send_ihr_message, std::move(data));
@@ -326,7 +328,7 @@ void FullNodeImpl::send_ext_message(AccountIdPrefixFull dst, td::BufferSlice dat
   if (!skip_public) {
     auto shard = get_shard(dst);
     if (shard.empty()) {
-      VLOG(FULL_NODE_WARNING) << "dropping OUT ext message to unknown shard";
+      VLOG(full_node, WARNING) << "dropping OUT ext message to unknown shard";
       return;
     }
     td::actor::send_closure(shard, &FullNodeShard::send_external_message, std::move(data));
@@ -337,7 +339,7 @@ void FullNodeImpl::send_shard_block_info(BlockIdExt block_id, CatchainSeqno cc_s
   send_shard_block_info_to_custom_overlays(block_id, cc_seqno, data);
   auto shard = get_shard(ShardIdFull{masterchainId});
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping OUT shard block info message to unknown shard";
+    VLOG(full_node, WARNING) << "dropping OUT shard block info message to unknown shard";
     return;
   }
   auto fast_sync_overlay = fast_sync_overlays_.choose_overlay(ShardIdFull(masterchainId)).first;
@@ -363,7 +365,7 @@ void FullNodeImpl::send_block_candidate(BlockIdExt block_id, CatchainSeqno cc_se
   if (mode & broadcast_mode_public) {
     auto shard = get_shard(ShardIdFull{masterchainId, shardIdAll});
     if (shard.empty()) {
-      VLOG(FULL_NODE_WARNING) << "dropping OUT shard block info message to unknown shard";
+      VLOG(full_node, WARNING) << "dropping OUT shard block info message to unknown shard";
       return;
     }
     td::actor::send_closure(shard, &FullNodeShard::send_block_candidate, block_id, cc_seqno, validator_set_hash,
@@ -392,7 +394,7 @@ void FullNodeImpl::send_broadcast(BlockBroadcast broadcast, int mode) {
   if (mode & broadcast_mode_public) {
     auto shard = get_shard(broadcast.block_id.shard_full());
     if (shard.empty()) {
-      VLOG(FULL_NODE_WARNING) << "dropping OUT broadcast to unknown shard";
+      VLOG(full_node, WARNING) << "dropping OUT broadcast to unknown shard";
       return;
     }
     td::actor::send_closure(shard, &FullNodeShard::send_broadcast, std::move(broadcast));
@@ -403,7 +405,7 @@ void FullNodeImpl::download_block(BlockIdExt id, td::uint32 priority, td::Timest
                                   td::Promise<ReceivedBlock> promise) {
   auto shard = get_shard(id.shard_full());
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download block query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download block query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -414,7 +416,7 @@ void FullNodeImpl::download_zero_state(BlockIdExt id, td::uint32 priority, td::T
                                        td::Promise<td::BufferSlice> promise) {
   auto shard = get_shard(id.shard_full());
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download state query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download state query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -426,7 +428,7 @@ void FullNodeImpl::download_persistent_state(BlockIdExt id, BlockIdExt mastercha
                                              td::Promise<td::BufferSlice> promise) {
   auto shard = get_shard(id.shard_full(), /* historical = */ true);
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download state diff query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download state diff query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -438,7 +440,7 @@ void FullNodeImpl::download_block_proof(BlockIdExt block_id, td::uint32 priority
                                         td::Promise<td::BufferSlice> promise) {
   auto shard = get_shard(block_id.shard_full());
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download proof query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download proof query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -449,7 +451,7 @@ void FullNodeImpl::download_block_proof_link(BlockIdExt block_id, td::uint32 pri
                                              td::Promise<td::BufferSlice> promise) {
   auto shard = get_shard(block_id.shard_full(), /* historical = */ true);
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download proof link query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download proof link query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -461,7 +463,7 @@ void FullNodeImpl::get_next_key_blocks(BlockIdExt block_id, td::Timestamp timeou
                                        td::Promise<std::vector<BlockIdExt>> promise) {
   auto shard = get_shard(block_id.shard_full());
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download proof link query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download proof link query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -472,7 +474,7 @@ void FullNodeImpl::download_archive(BlockSeqno masterchain_seqno, ShardIdFull sh
                                     td::Timestamp timeout, td::Promise<std::string> promise) {
   auto shard = get_shard(shard_prefix, /* historical = */ true);
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download archive query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download archive query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -491,7 +493,7 @@ void FullNodeImpl::download_out_msg_queue_proof(ShardIdFull dst_shard, std::vect
   // All blocks are expected to have the same minsplit shard prefix
   auto shard = get_shard(blocks[0].shard_full());
   if (shard.empty()) {
-    VLOG(FULL_NODE_WARNING) << "dropping download msg queue query to unknown shard";
+    VLOG(full_node, WARNING) << "dropping download msg queue query to unknown shard";
     promise.set_error(td::Status::Error(ErrorCode::notready, "shard not ready"));
     return;
   }
@@ -581,7 +583,7 @@ void FullNodeImpl::new_key_block(BlockHandle handle) {
   if (handle->id().seqno() == 0) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Ref<ShardState>> R) {
       if (R.is_error()) {
-        VLOG(FULL_NODE_WARNING) << "failed to get zero state: " << R.move_as_error();
+        VLOG(full_node, WARNING) << "failed to get zero state: " << R.move_as_error();
       } else {
         auto s = td::Ref<MasterchainState>{R.move_as_ok()};
         CHECK(s.not_null());
@@ -594,7 +596,7 @@ void FullNodeImpl::new_key_block(BlockHandle handle) {
     CHECK(handle->is_key_block());
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Ref<ProofLink>> R) {
       if (R.is_error()) {
-        VLOG(FULL_NODE_WARNING) << "failed to get key block proof: " << R.move_as_error();
+        VLOG(full_node, WARNING) << "failed to get key block proof: " << R.move_as_error();
       } else {
         td::actor::send_closure(SelfId, &FullNodeImpl::got_key_block_config,
                                 R.ok()->get_key_block_config().move_as_ok());

--- a/validator/full-node.h
+++ b/validator/full-node.h
@@ -28,23 +28,19 @@
 #include "quic/quic-sender.h"
 #include "rldp2/rldp.h"
 #include "td/actor/actor.h"
+#include "td/utils/logging.h"
 #include "ton/ton-types.h"
 #include "validator/validator.h"
 
 #include "types.h"
+
+DECLARE_LOG_CATEGORY(full_node)
 
 namespace ton {
 
 namespace validator {
 
 namespace fullnode {
-
-constexpr int VERBOSITY_NAME(FULL_NODE_WARNING) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(FULL_NODE_BENCHMARK) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(FULL_NODE_NOTICE) = verbosity_INFO;
-constexpr int VERBOSITY_NAME(FULL_NODE_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(FULL_NODE_DEBUG) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(FULL_NODE_EXTRA_DEBUG) = verbosity_DEBUG + 1;
 
 struct FullNodeConfig {
   FullNodeConfig() = default;

--- a/validator/full-node.hpp
+++ b/validator/full-node.hpp
@@ -104,9 +104,9 @@ class FullNodeImpl : public FullNode {
 
   void import_fast_sync_member_certificate(adnl::AdnlNodeIdShort local_id,
                                            overlay::OverlayMemberCertificate cert) override {
-    VLOG(FULL_NODE_DEBUG) << "Importing fast sync overlay certificate for " << local_id << " issued by "
-                          << cert.issued_by().compute_short_id() << " expires in "
-                          << (double)cert.expire_at() - td::Clocks::system();
+    VLOG(full_node, DEBUG) << "Importing fast sync overlay certificate for " << local_id << " issued by "
+                           << cert.issued_by().compute_short_id() << " expires in "
+                           << (double)cert.expire_at() - td::Clocks::system();
     fast_sync_overlays_.add_member_certificate(local_id, std::move(cert));
   }
 

--- a/validator/impl/accept-block.cpp
+++ b/validator/impl/accept-block.cpp
@@ -561,7 +561,7 @@ void AcceptBlockQuery::got_last_mc_block(std::pair<td::Ref<MasterchainState>, Bl
   CHECK(last_mc_state_.not_null());
   if (last_mc_id_.id.seqno < mc_blkid_.id.seqno) {
     VLOG(validator, DEBUG) << "shardchain block refers to newer masterchain block " << mc_blkid_
-                          << ", trying to obtain it";
+                           << ", trying to obtain it";
     td::actor::send_closure_later(manager_, &ValidatorManager::wait_block_state_short, mc_blkid_, priority(), timeout_,
                                   false, [SelfId = actor_id(this)](td::Result<Ref<ShardState>> R) {
                                     check_send_error(SelfId, R) ||
@@ -609,8 +609,8 @@ void AcceptBlockQuery::find_known_ancestors() {
     auto ancestor2 = config->get_shard_hash(ton::shard_child(shard, false));
     if (ancestor.is_null() || ancestor2.is_null()) {
       VLOG(validator, WARNING) << " cannot retrieve information about shard " + shard.to_str() +
-                                     " from masterchain block " + last_mc_id_.to_str() +
-                                     ", skipping ShardTopBlockDescr creation";
+                                      " from masterchain block " + last_mc_id_.to_str() +
+                                      ", skipping ShardTopBlockDescr creation";
       if (last_mc_id_.id.seqno <= mc_blkid_.id.seqno) {
         fatal_error(" cannot retrieve information about shard "s + shard.to_str() + " from masterchain block " +
                     last_mc_id_.to_str());
@@ -634,8 +634,8 @@ void AcceptBlockQuery::find_known_ancestors() {
     ancestors_split_ = true;
   } else {
     VLOG(validator, WARNING) << " cannot retrieve information about shard " + shard.to_str() +
-                                   " from masterchain block " + last_mc_id_.to_str() +
-                                   ", skipping ShardTopBlockDescr creation";
+                                    " from masterchain block " + last_mc_id_.to_str() +
+                                    ", skipping ShardTopBlockDescr creation";
     if (last_mc_id_.id.seqno <= mc_blkid_.id.seqno || ancestor->seqno() <= id_.id.seqno) {
       fatal_error(" cannot retrieve information about shard "s + shard.to_str() + " from masterchain block " +
                   last_mc_id_.to_str());
@@ -646,7 +646,7 @@ void AcceptBlockQuery::find_known_ancestors() {
   }
   if (ancestors_seqno_ >= id_.id.seqno) {
     VLOG(validator, WARNING) << "skipping ShardTopBlockDescr creation for " << id_ << " because a newer block "
-                            << ancestors_.at(0)->blk_ << " is already present in masterchain block " << last_mc_id_;
+                             << ancestors_.at(0)->blk_ << " is already present in masterchain block " << last_mc_id_;
     written_block_next();
     return;
   }
@@ -839,7 +839,7 @@ void AcceptBlockQuery::top_block_descr_validated(td::Result<Ref<ShardTopBlockDes
   VLOG(validator, DEBUG) << "top_block_descr_validated()";
   if (R.is_error()) {
     VLOG(validator, WARNING) << "error validating newly-created ShardTopBlockDescr for " << id_ << ": "
-                            << R.move_as_error().to_string();
+                             << R.move_as_error().to_string();
   } else {
     top_block_descr_ = R.move_as_ok();
     CHECK(top_block_descr_.not_null());

--- a/validator/impl/accept-block.cpp
+++ b/validator/impl/accept-block.cpp
@@ -100,7 +100,7 @@ AcceptBlockQuery::AcceptBlockQuery(ForceFork ffork, BlockIdExt id, td::Ref<Block
 }
 
 bool AcceptBlockQuery::precheck_header() {
-  VLOG(VALIDATOR_DEBUG) << "precheck_header()";
+  VLOG(validator, DEBUG) << "precheck_header()";
   // 0. sanity check
   block_root_ = data_->root_cell();
   if (data_->block_id() != id_) {
@@ -155,7 +155,7 @@ bool AcceptBlockQuery::precheck_header() {
 
 bool AcceptBlockQuery::create_new_proof() {
   // 0. check block's root hash
-  VLOG(VALIDATOR_DEBUG) << "create_new_proof() : start";
+  VLOG(validator, DEBUG) << "create_new_proof() : start";
   RootHash blk_rhash{block_root_->get_hash().bits()};
   if (blk_rhash != id_.root_hash) {
     return fatal_error("block root hash mismatch: expected "s + id_.root_hash.to_hex() + ", found " +
@@ -255,7 +255,7 @@ bool AcceptBlockQuery::create_new_proof() {
     }
     if (sign_chk.is_error()) {
       auto err = sign_chk.move_as_error();
-      VLOG(VALIDATOR_WARNING) << "signature check failed : " << err.to_string();
+      VLOG(validator, WARNING) << "signature check failed : " << err.to_string();
       abort_query(std::move(err));
       return false;
     }
@@ -324,13 +324,13 @@ bool AcceptBlockQuery::create_new_proof() {
   } else {
     proof_link_ = create_proof_link(id_, vm::std_boc_serialize(bs_cell, 0).move_as_ok()).move_as_ok();
   }
-  VLOG(VALIDATOR_DEBUG) << "create_new_proof() : end";
+  VLOG(validator, DEBUG) << "create_new_proof() : end";
   return true;
 }
 
 void AcceptBlockQuery::abort_query(td::Status reason) {
   if (promise_) {
-    VLOG(VALIDATOR_WARNING) << "aborting accept block query: " << reason;
+    VLOG(validator, WARNING) << "aborting accept block query: " << reason;
     promise_.set_error(std::move(reason));
   }
   stop();
@@ -351,7 +351,7 @@ bool AcceptBlockQuery::check_send_error(td::actor::ActorId<AcceptBlockQuery> Sel
 }
 
 void AcceptBlockQuery::finish_query() {
-  VLOG(VALIDATOR_DEBUG) << "finish_query()";
+  VLOG(validator, DEBUG) << "finish_query()";
   if (apply_) {
     ValidatorInvariants::check_post_accept(handle_);
   }
@@ -371,7 +371,7 @@ void AcceptBlockQuery::alarm() {
 }
 
 void AcceptBlockQuery::start_up() {
-  VLOG(VALIDATOR_DEBUG) << "start_up()";
+  VLOG(validator, DEBUG) << "start_up()";
   alarm_timestamp() = timeout_;
 
   if (!is_fork_ && validator_set_.is_null()) {
@@ -407,7 +407,7 @@ void AcceptBlockQuery::start_up() {
 }
 
 void AcceptBlockQuery::got_block_handle(BlockHandle handle) {
-  VLOG(VALIDATOR_DEBUG) << "got_block_handle()";
+  VLOG(validator, DEBUG) << "got_block_handle()";
   handle_ = std::move(handle);
   if (handle_->received() && handle_->received_state() &&
       (handle_->inited_signatures() || !signatures_->is_final() || is_fork_) && handle_->inited_split_after() &&
@@ -423,7 +423,7 @@ void AcceptBlockQuery::got_block_handle(BlockHandle handle) {
 }
 
 void AcceptBlockQuery::got_block_handle_cont() {
-  VLOG(VALIDATOR_DEBUG) << "got_block_handle_cont()";
+  VLOG(validator, DEBUG) << "got_block_handle_cont()";
   if (!handle_->received()) {
     td::actor::send_closure(
         manager_, &ValidatorManager::set_block_data, handle_, data_, [SelfId = actor_id(this)](td::Result<td::Unit> R) {
@@ -435,7 +435,7 @@ void AcceptBlockQuery::got_block_handle_cont() {
 }
 
 void AcceptBlockQuery::written_block_data() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_data()";
+  VLOG(validator, DEBUG) << "written_block_data()";
   if (handle_->inited_signatures() || !signatures_->is_final() || is_fork_) {
     written_block_signatures();
     return;
@@ -448,7 +448,7 @@ void AcceptBlockQuery::written_block_data() {
 }
 
 void AcceptBlockQuery::written_block_signatures() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_signatures()";
+  VLOG(validator, DEBUG) << "written_block_signatures()";
   handle_->set_merge(prev_.size() == 2);
 
   for (auto& p : prev_) {
@@ -465,7 +465,7 @@ void AcceptBlockQuery::written_block_signatures() {
 }
 
 void AcceptBlockQuery::written_block_info() {
-  VLOG(VALIDATOR_DEBUG) << "written block info";
+  VLOG(validator, DEBUG) << "written block info";
   block_root_ = data_->root_cell();
   if (block_root_.is_null()) {
     fatal_error("block data does not contain a root cell");
@@ -486,13 +486,13 @@ void AcceptBlockQuery::written_block_info() {
         td::actor::send_closure_bool(SelfId, &AcceptBlockQuery::got_prev_state, R.move_as_ok());
   });
 
-  VLOG(VALIDATOR_DEBUG) << "wait_prev_block_state";
+  VLOG(validator, DEBUG) << "wait_prev_block_state";
   td::actor::send_closure(manager_, &ValidatorManager::wait_prev_block_state, handle_, priority(), timeout_,
                           std::move(P));
 }
 
 void AcceptBlockQuery::got_prev_state(td::Ref<ShardState> state) {
-  VLOG(VALIDATOR_DEBUG) << "got prev state";
+  VLOG(validator, DEBUG) << "got prev state";
   state_ = std::move(state);
 
   state_keep_old_hash_ = state_->root_hash();
@@ -504,7 +504,7 @@ void AcceptBlockQuery::got_prev_state(td::Ref<ShardState> state) {
 }
 
 void AcceptBlockQuery::written_state(td::Ref<ShardState> upd_state) {
-  VLOG(VALIDATOR_DEBUG) << "written state";
+  VLOG(validator, DEBUG) << "written state";
   state_ = std::move(upd_state);
 
   if (apply_ && state_keep_old_hash_ != state_old_hash_) {
@@ -532,7 +532,7 @@ void AcceptBlockQuery::written_state(td::Ref<ShardState> upd_state) {
 }
 
 void AcceptBlockQuery::written_block_proof() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_proof()";
+  VLOG(validator, DEBUG) << "written_block_proof()";
   if (!signatures_->is_final()) {
     written_block_next();
     return;
@@ -555,12 +555,12 @@ void AcceptBlockQuery::written_block_proof() {
 }
 
 void AcceptBlockQuery::got_last_mc_block(std::pair<td::Ref<MasterchainState>, BlockIdExt> last) {
-  VLOG(VALIDATOR_DEBUG) << "got_last_mc_block(): " << last.second;
+  VLOG(validator, DEBUG) << "got_last_mc_block(): " << last.second;
   last_mc_state_ = Ref<MasterchainStateQ>(std::move(last.first));
   last_mc_id_ = std::move(last.second);
   CHECK(last_mc_state_.not_null());
   if (last_mc_id_.id.seqno < mc_blkid_.id.seqno) {
-    VLOG(VALIDATOR_DEBUG) << "shardchain block refers to newer masterchain block " << mc_blkid_
+    VLOG(validator, DEBUG) << "shardchain block refers to newer masterchain block " << mc_blkid_
                           << ", trying to obtain it";
     td::actor::send_closure_later(manager_, &ValidatorManager::wait_block_state_short, mc_blkid_, priority(), timeout_,
                                   false, [SelfId = actor_id(this)](td::Result<Ref<ShardState>> R) {
@@ -584,7 +584,7 @@ void AcceptBlockQuery::got_last_mc_block(std::pair<td::Ref<MasterchainState>, Bl
 }
 
 void AcceptBlockQuery::got_mc_state(Ref<ShardState> res) {
-  VLOG(VALIDATOR_DEBUG) << "got_mc_state()";
+  VLOG(validator, DEBUG) << "got_mc_state()";
   auto new_state = Ref<MasterchainStateQ>(std::move(res));
   CHECK(new_state.not_null());
   if (!new_state->check_old_mc_block_id(last_mc_id_)) {
@@ -598,7 +598,7 @@ void AcceptBlockQuery::got_mc_state(Ref<ShardState> res) {
 }
 
 void AcceptBlockQuery::find_known_ancestors() {
-  VLOG(VALIDATOR_DEBUG) << "find_known_ancestors()";
+  VLOG(validator, DEBUG) << "find_known_ancestors()";
   prev_mc_blkid_ = mc_blkid_;
   auto config = last_mc_state_->get_config();
   CHECK(config);
@@ -608,7 +608,7 @@ void AcceptBlockQuery::find_known_ancestors() {
     ancestor = config->get_shard_hash(ton::shard_child(shard, true));
     auto ancestor2 = config->get_shard_hash(ton::shard_child(shard, false));
     if (ancestor.is_null() || ancestor2.is_null()) {
-      VLOG(VALIDATOR_WARNING) << " cannot retrieve information about shard " + shard.to_str() +
+      VLOG(validator, WARNING) << " cannot retrieve information about shard " + shard.to_str() +
                                      " from masterchain block " + last_mc_id_.to_str() +
                                      ", skipping ShardTopBlockDescr creation";
       if (last_mc_id_.id.seqno <= mc_blkid_.id.seqno) {
@@ -619,21 +619,21 @@ void AcceptBlockQuery::find_known_ancestors() {
       written_block_next();
       return;
     }
-    VLOG(VALIDATOR_DEBUG) << "found two ancestors: " << ancestor->blk_ << " and " << ancestor2->blk_;
+    VLOG(validator, DEBUG) << "found two ancestors: " << ancestor->blk_ << " and " << ancestor2->blk_;
     ancestors_seqno_ = std::max(ancestor->blk_.id.seqno, ancestor2->blk_.id.seqno);
     ancestors_.emplace_back(std::move(ancestor));
     ancestors_.emplace_back(std::move(ancestor2));
   } else if (ancestor->shard() == shard) {
-    VLOG(VALIDATOR_DEBUG) << "found one regular ancestor " << ancestor->blk_;
+    VLOG(validator, DEBUG) << "found one regular ancestor " << ancestor->blk_;
     ancestors_seqno_ = ancestor->seqno();
     ancestors_.emplace_back(std::move(ancestor));
   } else if (ton::shard_is_parent(ancestor->shard(), shard)) {
-    VLOG(VALIDATOR_DEBUG) << "found one parent ancestor " << ancestor->blk_;
+    VLOG(validator, DEBUG) << "found one parent ancestor " << ancestor->blk_;
     ancestors_seqno_ = ancestor->seqno();
     ancestors_.emplace_back(std::move(ancestor));
     ancestors_split_ = true;
   } else {
-    VLOG(VALIDATOR_WARNING) << " cannot retrieve information about shard " + shard.to_str() +
+    VLOG(validator, WARNING) << " cannot retrieve information about shard " + shard.to_str() +
                                    " from masterchain block " + last_mc_id_.to_str() +
                                    ", skipping ShardTopBlockDescr creation";
     if (last_mc_id_.id.seqno <= mc_blkid_.id.seqno || ancestor->seqno() <= id_.id.seqno) {
@@ -645,7 +645,7 @@ void AcceptBlockQuery::find_known_ancestors() {
     return;
   }
   if (ancestors_seqno_ >= id_.id.seqno) {
-    VLOG(VALIDATOR_WARNING) << "skipping ShardTopBlockDescr creation for " << id_ << " because a newer block "
+    VLOG(validator, WARNING) << "skipping ShardTopBlockDescr creation for " << id_ << " because a newer block "
                             << ancestors_.at(0)->blk_ << " is already present in masterchain block " << last_mc_id_;
     written_block_next();
     return;
@@ -664,7 +664,7 @@ void AcceptBlockQuery::find_known_ancestors() {
 }
 
 void AcceptBlockQuery::require_proof_link(BlockIdExt id) {
-  VLOG(VALIDATOR_DEBUG) << "require_proof_link(" << id << ")";
+  VLOG(validator, DEBUG) << "require_proof_link(" << id << ")";
   CHECK(ton::ShardIdFull(id) == ton::ShardIdFull(id_));
   CHECK(id.id.seqno == id_.id.seqno - 1 - proof_links_.size());
   td::actor::send_closure_later(manager_, &ValidatorManager::wait_block_proof_link_short, id, timeout_,
@@ -747,7 +747,7 @@ bool AcceptBlockQuery::unpack_proof_link(BlockIdExt id, Ref<ProofLink> proof_lin
 }
 
 void AcceptBlockQuery::got_proof_link(BlockIdExt id, Ref<ProofLink> proof) {
-  VLOG(VALIDATOR_DEBUG) << "got_proof_link(" << id << ")";
+  VLOG(validator, DEBUG) << "got_proof_link(" << id << ")";
   CHECK(proof.not_null());
   proof_links_.push_back(proof);
   if (!unpack_proof_link(id, std::move(proof))) {
@@ -777,7 +777,7 @@ void AcceptBlockQuery::got_proof_link(BlockIdExt id, Ref<ProofLink> proof) {
 }
 
 bool AcceptBlockQuery::create_top_shard_block_description() {
-  VLOG(VALIDATOR_DEBUG) << "create_top_shard_block_description()";
+  VLOG(validator, DEBUG) << "create_top_shard_block_description()";
   CHECK(proof_roots_.size() == proof_links_.size() + 1);
   int n = (int)proof_roots_.size();
   CHECK(n <= 8);
@@ -814,12 +814,12 @@ bool AcceptBlockQuery::create_top_shard_block_description() {
                        res.move_as_error().to_string());
   }
   top_block_descr_data_ = res.move_as_ok();
-  VLOG(VALIDATOR_DEBUG) << "create_top_shard_block_description() : end";
+  VLOG(validator, DEBUG) << "create_top_shard_block_description() : end";
   return true;
 }
 
 void AcceptBlockQuery::create_topshard_blk_descr() {
-  VLOG(VALIDATOR_DEBUG) << "create_topshard_blk_descr()";
+  VLOG(validator, DEBUG) << "create_topshard_blk_descr()";
   // generate top shard block description
   if (!create_top_shard_block_description()) {
     fatal_error("cannot generate top shard block description for "s + id_.to_str());
@@ -836,9 +836,9 @@ void AcceptBlockQuery::create_topshard_blk_descr() {
 }
 
 void AcceptBlockQuery::top_block_descr_validated(td::Result<Ref<ShardTopBlockDescription>> R) {
-  VLOG(VALIDATOR_DEBUG) << "top_block_descr_validated()";
+  VLOG(validator, DEBUG) << "top_block_descr_validated()";
   if (R.is_error()) {
-    VLOG(VALIDATOR_WARNING) << "error validating newly-created ShardTopBlockDescr for " << id_ << ": "
+    VLOG(validator, WARNING) << "error validating newly-created ShardTopBlockDescr for " << id_ << ": "
                             << R.move_as_error().to_string();
   } else {
     top_block_descr_ = R.move_as_ok();
@@ -849,7 +849,7 @@ void AcceptBlockQuery::top_block_descr_validated(td::Result<Ref<ShardTopBlockDes
 }
 
 void AcceptBlockQuery::written_block_next() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_next()";
+  VLOG(validator, DEBUG) << "written_block_next()";
   if (handle_->need_flush()) {
     handle_->flush(manager_, handle_, [SelfId = actor_id(this)](td::Result<td::Unit> R) {
       check_send_error(SelfId, R) || td::actor::send_closure_bool(SelfId, &AcceptBlockQuery::written_block_info_2);
@@ -860,7 +860,7 @@ void AcceptBlockQuery::written_block_next() {
 }
 
 void AcceptBlockQuery::written_block_info_2() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_info_2()";
+  VLOG(validator, DEBUG) << "written_block_info_2()";
   td::actor::send_closure(manager_, &ValidatorManager::on_block_accepted, id_);
   if (handle_->id().is_masterchain()) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Unit> R) {
@@ -880,7 +880,7 @@ void AcceptBlockQuery::send_broadcasts() {
   if (send_broadcast_mode_ == 0) {
     return;
   }
-  VLOG(VALIDATOR_DEBUG) << "send_broadcasts mode=" << send_broadcast_mode_;
+  VLOG(validator, DEBUG) << "send_broadcasts mode=" << send_broadcast_mode_;
   BlockBroadcast b;
   b.data = data_->data();
   b.block_id = id_;

--- a/validator/impl/check-proof.cpp
+++ b/validator/impl/check-proof.cpp
@@ -42,7 +42,7 @@ void CheckProof::alarm() {
 
 void CheckProof::abort_query(td::Status reason) {
   if (promise_) {
-    VLOG(VALIDATOR_WARNING) << "aborting check proof for " << id_ << " query: " << reason;
+    VLOG(validator, WARNING) << "aborting check proof for " << id_ << " query: " << reason;
     promise_.set_error(std::move(reason));
   }
   stop();
@@ -67,7 +67,7 @@ void CheckProof::finish_query() {
     ValidatorInvariants::check_post_check_proof_link(handle_);
   }
   if (promise_) {
-    VLOG(VALIDATOR_DEBUG) << "checked proof for " << handle_->id();
+    VLOG(validator, DEBUG) << "checked proof for " << handle_->id();
     promise_.set_result(handle_);
   }
   stop();
@@ -265,7 +265,7 @@ bool CheckProof::init_parse(bool is_aux) {
 }
 
 void CheckProof::start_up() {
-  VLOG(VALIDATOR_DEBUG) << "started check proof for " << id_ << ", mode=" << mode_;
+  VLOG(validator, DEBUG) << "started check proof for " << id_ << ", mode=" << mode_;
   alarm_timestamp() = timeout_;
 
   auto res = vm::std_boc_deserialize(proof_->data());
@@ -319,7 +319,7 @@ void CheckProof::start_up() {
 }
 
 void CheckProof::got_block_handle(BlockHandle handle) {
-  VLOG(VALIDATOR_DEBUG) << "got_block_handle";
+  VLOG(validator, DEBUG) << "got_block_handle";
   handle_ = std::move(handle);
   CHECK(handle_);
   if (!is_proof() || skip_check_signatures_) {
@@ -349,7 +349,7 @@ void CheckProof::got_block_handle(BlockHandle handle) {
 }
 
 void CheckProof::got_masterchain_state(td::Ref<MasterchainState> state) {
-  VLOG(VALIDATOR_DEBUG) << "got_masterchain_state #" << state->get_seqno();
+  VLOG(validator, DEBUG) << "got_masterchain_state #" << state->get_seqno();
   CHECK(is_proof());
   state_ = std::move(state);
 
@@ -363,7 +363,7 @@ void CheckProof::got_masterchain_state(td::Ref<MasterchainState> state) {
 }
 
 void CheckProof::process_masterchain_state() {
-  VLOG(VALIDATOR_DEBUG) << "process_masterchain_state";
+  VLOG(validator, DEBUG) << "process_masterchain_state";
   CHECK(is_proof());
   CHECK(state_.not_null());
 
@@ -394,7 +394,7 @@ void CheckProof::process_masterchain_state() {
 }
 
 void CheckProof::check_signatures() {
-  VLOG(VALIDATOR_DEBUG) << "check_signatures";
+  VLOG(validator, DEBUG) << "check_signatures";
   if (sig_set_.is_null()) {
     fatal_error("no block signatures present in proof to check");
     return;
@@ -435,7 +435,7 @@ void CheckProof::check_signatures() {
 }
 
 void CheckProof::got_block_handle_2(BlockHandle handle) {
-  VLOG(VALIDATOR_DEBUG) << "got_block_handle_2 " << handle->id().id;
+  VLOG(validator, DEBUG) << "got_block_handle_2 " << handle->id().id;
   handle_ = std::move(handle);
 
   handle_->set_split(before_split_);
@@ -455,19 +455,19 @@ void CheckProof::got_block_handle_2(BlockHandle handle) {
     // do not save proof if we skipped signatures
     auto proof = Ref<Proof>(proof_);
     CHECK(proof.not_null());
-    VLOG(VALIDATOR_DEBUG) << "set_block_proof";
+    VLOG(validator, DEBUG) << "set_block_proof";
     td::actor::send_closure_later(manager_, &ValidatorManager::set_block_proof, handle_, std::move(proof),
                                   std::move(P));
   } else if (is_proof()) {
     auto proof = Ref<Proof>(proof_);
     CHECK(proof.not_null());
     CHECK(sig_ok_);
-    VLOG(VALIDATOR_DEBUG) << "set_block_proof";
+    VLOG(validator, DEBUG) << "set_block_proof";
     td::actor::send_closure_later(manager_, &ValidatorManager::set_block_proof, handle_, std::move(proof),
                                   std::move(P));
   } else {
     CHECK(proof_.not_null());
-    VLOG(VALIDATOR_DEBUG) << "set_block_proof_link";
+    VLOG(validator, DEBUG) << "set_block_proof_link";
     td::actor::send_closure_later(manager_, &ValidatorManager::set_block_proof_link, handle_, proof_, std::move(P));
   }
 }

--- a/validator/interfaces/validator-manager.h
+++ b/validator/interfaces/validator-manager.h
@@ -25,6 +25,7 @@
 #include "crypto/vm/db/DynamicBagOfCellsDb.h"
 #include "impl/out-msg-queue-proof.hpp"
 #include "td/actor/BackpressureQueue.h"
+#include "td/utils/logging.h"
 #include "validator-session/validator-session-types.h"
 #include "validator/validator.h"
 
@@ -37,15 +38,11 @@
 #include "shard-block.h"
 #include "shard.h"
 
+DECLARE_LOG_CATEGORY(validator)
+
 namespace ton {
 
 namespace validator {
-
-constexpr int VERBOSITY_NAME(VALIDATOR_WARNING) = verbosity_WARNING;
-constexpr int VERBOSITY_NAME(VALIDATOR_NOTICE) = verbosity_INFO;
-constexpr int VERBOSITY_NAME(VALIDATOR_INFO) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(VALIDATOR_DEBUG) = verbosity_DEBUG;
-constexpr int VERBOSITY_NAME(VALIDATOR_EXTRA_DEBUG) = verbosity_DEBUG + 1;
 
 struct CandidateAccept {
   double ok_from_utime = 0.0;

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -53,8 +53,6 @@
 #include "validate-broadcast.hpp"
 #include "validator-group.hpp"
 
-DEFINE_LOG_CATEGORY(validator, VERBOSITY_NAME(INFO))
-
 namespace ton {
 
 namespace validator {

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -53,6 +53,8 @@
 #include "validate-broadcast.hpp"
 #include "validator-group.hpp"
 
+DEFINE_LOG_CATEGORY(validator, VERBOSITY_NAME(INFO))
+
 namespace ton {
 
 namespace validator {
@@ -60,13 +62,13 @@ namespace validator {
 void ValidatorManagerImpl::validate_block_is_next_proof(BlockIdExt prev_block_id, BlockIdExt next_block_id,
                                                         td::BufferSlice proof, td::Promise<td::Unit> promise) {
   if (!prev_block_id.is_masterchain() || !next_block_id.is_masterchain()) {
-    VLOG(VALIDATOR_NOTICE) << "prev=" << prev_block_id << " next=" << next_block_id;
+    VLOG(validator, INFO) << "prev=" << prev_block_id << " next=" << next_block_id;
     promise.set_error(
         td::Status::Error(ErrorCode::protoviolation, "validate_block_is_next_proof() can only work for masterchain"));
     return;
   }
   if (prev_block_id.seqno() + 1 != next_block_id.seqno()) {
-    VLOG(VALIDATOR_NOTICE) << "prev=" << prev_block_id << " next=" << next_block_id;
+    VLOG(validator, INFO) << "prev=" << prev_block_id << " next=" << next_block_id;
     promise.set_error(td::Status::Error(ErrorCode::protoviolation, "validate_block_is_next_proof(): bad seqno"));
     return;
   }
@@ -275,7 +277,7 @@ td::actor::Task<> ValidatorManagerImpl::validated_accepted_block_broadcast(Block
 void ValidatorManagerImpl::sync_complete(td::Promise<td::Unit> promise) {
   started_ = true;
 
-  VLOG(VALIDATOR_WARNING) << "completed sync. Validating " << validator_groups_.size() << " groups";
+  VLOG(validator, WARNING) << "completed sync. Validating " << validator_groups_.size() << " groups";
   for (auto &v : validator_groups_) {
     if (!v.second.actor.empty()) {
       td::actor::send_closure(v.second.actor, &IValidatorGroup::create_session);
@@ -440,19 +442,19 @@ td::actor::Task<> ValidatorManagerImpl::new_external_message_broadcast(td::Buffe
                               /* add_to_mempool = */ is_validator() || !collator_nodes_.empty())
           .wrap();
   if (r_check_result.is_error()) {
-    VLOG(VALIDATOR_DEBUG) << "Dropping external message broadcast (prio=" << priority
-                          << ") : " << r_check_result.error();
+    VLOG(validator, DEBUG) << "Dropping external message broadcast (prio=" << priority
+                           << ") : " << r_check_result.error();
     co_return r_check_result.move_as_error();
   }
   auto check_result = r_check_result.move_as_ok();
   auto allow_broadcast = co_await std::move(check_result.wait_allow_broadcast).wrap();
   if (allow_broadcast.is_error()) {
-    VLOG(VALIDATOR_DEBUG) << "Dropping external message broadcast (prio=" << priority
-                          << ") : " << allow_broadcast.error();
+    VLOG(validator, DEBUG) << "Dropping external message broadcast (prio=" << priority
+                           << ") : " << allow_broadcast.error();
     co_return allow_broadcast.move_as_error();
   }
-  VLOG(VALIDATOR_DEBUG) << "Checked external message broadcast to " << check_result.message->wc() << ":"
-                        << check_result.message->addr().to_hex() << " (prio=" << priority << ")";
+  VLOG(validator, DEBUG) << "Checked external message broadcast to " << check_result.message->wc() << ":"
+                         << check_result.message->addr().to_hex() << " (prio=" << priority << ")";
   co_return td::Unit{};
 }
 
@@ -483,24 +485,24 @@ void ValidatorManagerImpl::new_ihr_message(td::BufferSlice data) {
 void ValidatorManagerImpl::new_shard_block_description_broadcast(BlockIdExt block_id, CatchainSeqno cc_seqno,
                                                                  td::BufferSlice data) {
   if (!last_masterchain_block_handle_ || !started_) {
-    VLOG(VALIDATOR_DEBUG) << "dropping shard block description broadcast: not inited";
+    VLOG(validator, DEBUG) << "dropping shard block description broadcast: not inited";
     return;
   }
   if (!is_validator() && !opts_->need_monitor(block_id.shard_full(), last_masterchain_state_)) {
     return;
   }
   if (cached_checked_shard_block_descriptions_.contains(block_id)) {
-    VLOG(VALIDATOR_DEBUG) << "dropping duplicate shard block description broadcast";
+    VLOG(validator, DEBUG) << "dropping duplicate shard block description broadcast";
     return;
   }
   auto it = shard_blocks_.find(ShardTopBlockDescriptionId{block_id.shard_full(), cc_seqno});
   if (it != shard_blocks_.end() && block_id.id.seqno <= it->second.latest_desc->block_id().id.seqno) {
-    VLOG(VALIDATOR_DEBUG) << "dropping duplicate shard block broadcast";
+    VLOG(validator, DEBUG) << "dropping duplicate shard block broadcast";
     return;
   }
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Ref<ShardTopBlockDescription>> R) {
     if (R.is_error()) {
-      VLOG(VALIDATOR_NOTICE) << "dropping invalid new shard block description: " << R.move_as_error();
+      VLOG(validator, INFO) << "dropping invalid new shard block description: " << R.move_as_error();
     } else {
       td::actor::send_closure(SelfId, &ValidatorManagerImpl::add_shard_block_description, R.move_as_ok());
     }
@@ -512,11 +514,11 @@ void ValidatorManagerImpl::new_shard_block_description_broadcast(BlockIdExt bloc
 td::actor::Task<> ValidatorManagerImpl::new_block_candidate_broadcast(BlockIdExt block_id, CatchainSeqno cc_seqno,
                                                                       td::BufferSlice data, BroadcastSource source) {
   if (!last_masterchain_block_handle_ || !started_) {
-    VLOG(VALIDATOR_DEBUG) << "dropping top shard block broadcast: not inited";
+    VLOG(validator, DEBUG) << "dropping top shard block broadcast: not inited";
     co_return td::Unit{};
   }
   if (!need_monitor(block_id.shard_full())) {
-    VLOG(VALIDATOR_DEBUG) << "dropping block candidate broadcast: not monitoring shard";
+    VLOG(validator, DEBUG) << "dropping block candidate broadcast: not monitoring shard";
     co_return td::Unit{};
   }
   add_cached_block_data(block_id, data.clone());
@@ -528,7 +530,7 @@ td::actor::Task<> ValidatorManagerImpl::new_block_candidate_broadcast(BlockIdExt
     co_await td::actor::ask(actor_id(this), &ValidatorManagerImpl::set_block_data, handle, std::move(block));
     co_await td::actor::ask(actor_id(this), &ValidatorManagerImpl::wait_block_state, handle, 0, td::Timestamp::in(60.0),
                             true);
-    VLOG(VALIDATOR_DEBUG) << "Processed candidate broadcast " << block_id;
+    VLOG(validator, DEBUG) << "Processed candidate broadcast " << block_id;
     if (is_valid_nonfinal_group(block_id.shard_full(), cc_seqno)) {
       NonfinalGroupInfo &info = nonfinal_info_[{block_id.shard_full(), cc_seqno}];
       if (!info.last_accepted.is_valid() || info.last_accepted.seqno() < block_id.seqno()) {
@@ -539,7 +541,7 @@ td::actor::Task<> ValidatorManagerImpl::new_block_candidate_broadcast(BlockIdExt
     }
   }
   if (!db_event_publisher_.empty() && is_valid_nonfinal_group(block_id.shard_full(), cc_seqno)) {
-    VLOG(VALIDATOR_DEBUG) << "DB Event: blockCandidateReceived " << block_id;
+    VLOG(validator, DEBUG) << "DB Event: blockCandidateReceived " << block_id;
     td::actor::ask(db_event_publisher_, &DbEventPublisher::publish,
                    create_tl_object<ton_api::db_event_blockCandidateReceived>(create_tl_block_id(block_id)))
         .detach();
@@ -577,27 +579,27 @@ void ValidatorManagerImpl::add_shard_block_description(td::Ref<ShardTopBlockDesc
   }
   auto it = shard_blocks_.find(ShardTopBlockDescriptionId{desc->shard(), desc->catchain_seqno()});
   if (it != shard_blocks_.end() && desc->block_id().id.seqno <= it->second.latest_desc->block_id().id.seqno) {
-    VLOG(VALIDATOR_DEBUG) << "dropping duplicate shard block broadcast";
+    VLOG(validator, DEBUG) << "dropping duplicate shard block broadcast";
     return;
   }
   shard_blocks_[ShardTopBlockDescriptionId{desc->block_id().shard_full(), desc->catchain_seqno()}].latest_desc = desc;
-  VLOG(VALIDATOR_DEBUG) << "new shard block descr for " << desc->block_id();
+  VLOG(validator, DEBUG) << "new shard block descr for " << desc->block_id();
   if (need_monitor(desc->block_id().shard_full())) {
     ShardIdFull shard = desc->shard();
     shard.shard |= 1;
     auto top_block = last_masterchain_state_->get_shard_from_config(shard, false);
     if (top_block.not_null() && desc->block_id().seqno() > top_block->top_block_id().seqno() + 20) {
-      VLOG(VALIDATOR_DEBUG) << "new shard block descr for " << desc->block_id().id
-                            << " is too new: last known shard block is " << top_block->top_block_id().id;
+      VLOG(validator, DEBUG) << "new shard block descr for " << desc->block_id().id
+                             << " is too new: last known shard block is " << top_block->top_block_id().id;
     } else {
       auto P = td::PromiseCreator::lambda([block_id = desc->block_id(), cc_seqno = desc->catchain_seqno(),
                                            SelfId = actor_id(this)](td::Result<td::Ref<ShardState>> R) {
         if (R.is_error()) {
           auto S = R.move_as_error();
           if (S.code() != ErrorCode::timeout && S.code() != ErrorCode::notready) {
-            VLOG(VALIDATOR_NOTICE) << "failed to get shard state: " << S;
+            VLOG(validator, INFO) << "failed to get shard state: " << S;
           } else {
-            VLOG(VALIDATOR_DEBUG) << "failed to get shard state: " << S;
+            VLOG(validator, DEBUG) << "failed to get shard state: " << S;
           }
           return;
         }
@@ -611,12 +613,12 @@ void ValidatorManagerImpl::add_shard_block_description(td::Ref<ShardTopBlockDesc
     auto ig = mp.init_guard();
     preload_msg_queue_to_masterchain(desc, ig.get_promise());
     wait_verify_shard_blocks({desc->block_id()}, ig.get_promise().wrap([desc](td::Unit) {
-      VLOG(VALIDATOR_DEBUG) << "verified top shard block " << desc->block_id();
+      VLOG(validator, DEBUG) << "verified top shard block " << desc->block_id();
       return td::Unit{};
     }));
     ig.add_promise([SelfId = actor_id(this), desc](td::Result<td::Unit> R) mutable {
       if (R.is_error()) {
-        VLOG(VALIDATOR_DEBUG) << "shard block description: " << R.move_as_error();
+        VLOG(validator, DEBUG) << "shard block description: " << R.move_as_error();
         return;
       }
       td::actor::send_closure(SelfId, &ValidatorManagerImpl::set_shard_block_description_ready, std::move(desc));
@@ -661,7 +663,7 @@ void ValidatorManagerImpl::preload_msg_queue_to_masterchain(td::Ref<ShardTopBloc
 void ValidatorManagerImpl::loaded_msg_queue_to_masterchain(td::Ref<ShardTopBlockDescription> desc,
                                                            td::Ref<OutMsgQueueProof> res,
                                                            td::Promise<td::Unit> promise) {
-  VLOG(VALIDATOR_DEBUG) << "loaded out msg queue to masterchain from " << desc->block_id();
+  VLOG(validator, DEBUG) << "loaded out msg queue to masterchain from " << desc->block_id();
   cached_msg_queue_to_masterchain_[desc->block_id()] = std::move(res);
   promise.set_value(td::Unit());
 }
@@ -677,7 +679,7 @@ void ValidatorManagerImpl::set_shard_block_description_ready(td::Ref<ShardTopBlo
   }
   auto &info = it->second;
   if (info.ready_desc.is_null() || info.ready_desc->block_id().seqno() < desc->block_id().seqno()) {
-    VLOG(VALIDATOR_DEBUG) << "top shard block description is ready: " << desc->block_id();
+    VLOG(validator, DEBUG) << "top shard block description is ready: " << desc->block_id();
     info.ready_desc = desc;
   }
 }
@@ -1564,7 +1566,7 @@ void ValidatorManagerImpl::new_block_cont(BlockHandle handle, td::Ref<ShardState
                                           td::Promise<td::Unit> promise) {
   if (state->get_shard().is_masterchain() && handle->id().id.seqno > last_masterchain_seqno_) {
     if (handle->id().id.seqno == last_masterchain_seqno_ + 1) {
-      VLOG(VALIDATOR_DEBUG) << "new block " << handle->id().id << " is the next masterchain block";
+      VLOG(validator, DEBUG) << "new block " << handle->id().id << " is the next masterchain block";
       last_masterchain_seqno_ = handle->id().id.seqno;
       last_masterchain_state_ = td::Ref<MasterchainState>{state};
       last_masterchain_block_id_ = handle->id();
@@ -1584,7 +1586,7 @@ void ValidatorManagerImpl::new_block_cont(BlockHandle handle, td::Ref<ShardState
           last_masterchain_block_id_ = last_masterchain_block_handle_->id();
           last_masterchain_seqno_ = last_masterchain_block_id_.id.seqno;
           CHECK(it->first == last_masterchain_seqno_);
-          VLOG(VALIDATOR_DEBUG) << "processing pending masterchain block " << last_masterchain_block_id_.id;
+          VLOG(validator, DEBUG) << "processing pending masterchain block " << last_masterchain_block_id_.id;
 
           auto l_promise = std::move(std::get<2>(it->second));
           last_masterchain_block_handle_->set_processed();
@@ -1601,7 +1603,7 @@ void ValidatorManagerImpl::new_block_cont(BlockHandle handle, td::Ref<ShardState
         }
       }
     } else {
-      VLOG(VALIDATOR_DEBUG) << "new block " << handle->id().id << " is too new masterchain block";
+      VLOG(validator, DEBUG) << "new block " << handle->id().id << " is too new masterchain block";
       auto it = pending_masterchain_states_.find(handle->id().id.seqno);
       if (it != pending_masterchain_states_.end()) {
         std::get<2>(it->second).emplace_back(std::move(promise));
@@ -1614,12 +1616,12 @@ void ValidatorManagerImpl::new_block_cont(BlockHandle handle, td::Ref<ShardState
       }
     }
   } else {
-    VLOG(VALIDATOR_DEBUG) << "new block " << handle->id().id << " is already processed";
+    VLOG(validator, DEBUG) << "new block " << handle->id().id << " is already processed";
     handle->set_processed();
     promise.set_value(td::Unit());
   }
   if (!db_event_publisher_.empty() && !handle->id().is_masterchain()) {
-    VLOG(VALIDATOR_DEBUG) << "DB Event: blockApplied " << handle->id();
+    VLOG(validator, DEBUG) << "DB Event: blockApplied " << handle->id();
     td::actor::ask(db_event_publisher_, &DbEventPublisher::publish,
                    create_tl_object<ton_api::db_event_blockApplied>(create_tl_block_id(handle->id())))
         .detach();
@@ -1643,7 +1645,7 @@ void ValidatorManagerImpl::on_block_accepted(BlockIdExt block_id) {
 }
 
 void ValidatorManagerImpl::new_block(BlockHandle handle, td::Ref<ShardState> state, td::Promise<td::Unit> promise) {
-  VLOG(VALIDATOR_DEBUG) << "new block " << handle->id().id;
+  VLOG(validator, DEBUG) << "new block " << handle->id().id;
   if (handle->is_applied()) {
     return new_block_cont(std::move(handle), std::move(state), std::move(promise));
   } else {
@@ -1852,7 +1854,7 @@ void ValidatorManagerImpl::send_top_shard_block_description(td::Ref<ShardTopBloc
   }
   auto it = out_shard_blocks_.find(ShardTopBlockDescriptionId{desc->block_id().shard_full(), desc->catchain_seqno()});
   if (it != out_shard_blocks_.end() && desc->block_id().id.seqno <= it->second->block_id().id.seqno) {
-    VLOG(VALIDATOR_DEBUG) << "dropping duplicate top block description";
+    VLOG(validator, DEBUG) << "dropping duplicate top block description";
   } else {
     out_shard_blocks_[ShardTopBlockDescriptionId{desc->block_id().shard_full(), desc->catchain_seqno()}] = desc;
     callback_->send_shard_block_info(desc->block_id(), desc->catchain_seqno(), desc->serialize());
@@ -2427,7 +2429,7 @@ void ValidatorManagerImpl::update_shards() {
   new_shards.emplace(ShardIdFull{masterchainId, shardIdAll}, std::vector<BlockIdExt>{last_masterchain_block_id_});
   future_shards.insert(ShardIdFull{masterchainId, shardIdAll});
 
-  VLOG(VALIDATOR_DEBUG) << "total shards=" << new_shards.size() << " config shards=" << exp_vec.size();
+  VLOG(validator, DEBUG) << "total shards=" << new_shards.size() << " config shards=" << exp_vec.size();
 
   std::map<ValidatorSessionId, ValidatorGroupEntry> new_validator_groups;
 
@@ -2937,7 +2939,7 @@ void ValidatorManagerImpl::update_shard_client_block_handle(BlockHandle handle, 
     }
   }
   if (!db_event_publisher_.empty()) {
-    VLOG(VALIDATOR_DEBUG) << "DB Event: blockApplied " << shard_client_handle_->id();
+    VLOG(validator, DEBUG) << "DB Event: blockApplied " << shard_client_handle_->id();
     td::actor::ask(db_event_publisher_, &DbEventPublisher::publish,
                    create_tl_object<ton_api::db_event_blockApplied>(create_tl_block_id(shard_client_handle_->id())))
         .detach();
@@ -3050,7 +3052,7 @@ void ValidatorManagerImpl::alarm() {
     if (!serializer_.empty()) {
       auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<BlockSeqno> R) {
         if (R.is_error()) {
-          VLOG(VALIDATOR_WARNING) << "failed to get shard client status: " << R.move_as_error();
+          VLOG(validator, WARNING) << "failed to get shard client status: " << R.move_as_error();
         } else {
           td::actor::send_closure(SelfId, &ValidatorManagerImpl::state_serializer_update, R.move_as_ok());
         }
@@ -3630,7 +3632,7 @@ void ValidatorManagerImpl::add_out_msg_queue_proof(ShardIdFull dst_shard, td::Re
     td::actor::send_closure(out_msg_queue_importer_, &OutMsgQueueImporter::add_out_msg_queue_proof, dst_shard,
                             std::move(proof));
   } else {
-    VLOG(VALIDATOR_DEBUG) << "Dropping unneeded out msg queue proof to shard " << dst_shard;
+    VLOG(validator, DEBUG) << "Dropping unneeded out msg queue proof to shard " << dst_shard;
   }
 }
 
@@ -3799,7 +3801,7 @@ void ValidatorManagerImpl::process_accepted_nonfinal_block(BlockIdExt block_id, 
     }
   }
   if (!db_event_publisher_.empty()) {
-    VLOG(VALIDATOR_DEBUG) << "DB Event: blockSigned " << block_id;
+    VLOG(validator, DEBUG) << "DB Event: blockSigned " << block_id;
     td::actor::ask(db_event_publisher_, &DbEventPublisher::publish,
                    create_tl_object<ton_api::db_event_blockSigned>(create_tl_block_id(block_id)))
         .detach();

--- a/validator/net/download-block-new.cpp
+++ b/validator/net/download-block-new.cpp
@@ -80,10 +80,9 @@ DownloadBlockNew::DownloadBlockNew(adnl::AdnlNodeIdShort local_id, overlay::Over
 void DownloadBlockNew::abort_query(td::Status reason) {
   if (promise_) {
     if (reason.code() == ErrorCode::notready || reason.code() == ErrorCode::timeout) {
-      VLOG(FULL_NODE_DEBUG) << "failed to download block " << block_id_ << "from " << download_from_ << ": " << reason;
+      VLOG(full_node, DEBUG) << "failed to download block " << block_id_ << "from " << download_from_ << ": " << reason;
     } else {
-      VLOG(FULL_NODE_NOTICE) << "failed to download block " << block_id_ << " from " << download_from_ << ": "
-                             << reason;
+      VLOG(full_node, INFO) << "failed to download block " << block_id_ << " from " << download_from_ << ": " << reason;
     }
     promise_.set_error(std::move(reason));
   }
@@ -185,7 +184,7 @@ void DownloadBlockNew::got_download_token(std::unique_ptr<ActionToken> token) {
 void DownloadBlockNew::got_node_to_download(adnl::AdnlNodeIdShort node) {
   download_from_ = node;
 
-  VLOG(FULL_NODE_DEBUG) << "downloading proof for " << block_id_;
+  VLOG(full_node, DEBUG) << "downloading proof for " << block_id_;
 
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::BufferSlice> R) mutable {
     if (R.is_error()) {

--- a/validator/net/download-proof.cpp
+++ b/validator/net/download-proof.cpp
@@ -57,10 +57,9 @@ DownloadProof::DownloadProof(BlockIdExt block_id, bool allow_partial_proof, bool
 void DownloadProof::abort_query(td::Status reason) {
   if (promise_) {
     if (reason.code() == ErrorCode::notready || reason.code() == ErrorCode::timeout) {
-      VLOG(FULL_NODE_DEBUG) << "failed to download proof " << block_id_ << "from " << download_from_ << ": " << reason;
+      VLOG(full_node, DEBUG) << "failed to download proof " << block_id_ << "from " << download_from_ << ": " << reason;
     } else {
-      VLOG(FULL_NODE_NOTICE) << "failed to download proof " << block_id_ << " from " << download_from_ << ": "
-                             << reason;
+      VLOG(full_node, INFO) << "failed to download proof " << block_id_ << " from " << download_from_ << ": " << reason;
     }
     promise_.set_error(std::move(reason));
   }
@@ -147,7 +146,7 @@ void DownloadProof::got_download_token(std::unique_ptr<ActionToken> token) {
 
 void DownloadProof::got_node_to_download(adnl::AdnlNodeIdShort node) {
   download_from_ = node;
-  VLOG(FULL_NODE_DEBUG) << "downloading proof for " << block_id_;
+  VLOG(full_node, DEBUG) << "downloading proof for " << block_id_;
 
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::BufferSlice> R) mutable {
     if (R.is_error()) {
@@ -177,7 +176,7 @@ void DownloadProof::got_node_to_download(adnl::AdnlNodeIdShort node) {
 }
 
 void DownloadProof::got_block_proof_description(td::BufferSlice proof_description) {
-  VLOG(FULL_NODE_DEBUG) << "downloaded proof description for " << block_id_;
+  VLOG(full_node, DEBUG) << "downloaded proof description for " << block_id_;
 
   auto F = fetch_tl_object<ton_api::tonNode_PreparedProof>(std::move(proof_description), true);
   if (F.is_error()) {
@@ -251,14 +250,14 @@ void DownloadProof::got_block_proof_description(td::BufferSlice proof_descriptio
 }
 
 void DownloadProof::got_block_proof(td::BufferSlice proof) {
-  VLOG(FULL_NODE_DEBUG) << "downloaded proof for " << block_id_;
+  VLOG(full_node, DEBUG) << "downloaded proof for " << block_id_;
 
   data_ = std::move(proof);
   finish_query();
 }
 
 void DownloadProof::got_block_partial_proof(td::BufferSlice proof) {
-  VLOG(FULL_NODE_DEBUG) << "downloaded partial proof for " << block_id_;
+  VLOG(full_node, DEBUG) << "downloaded partial proof for " << block_id_;
 
   data_ = std::move(proof);
   finish_query();

--- a/validator/net/get-next-key-blocks.cpp
+++ b/validator/net/get-next-key-blocks.cpp
@@ -58,10 +58,9 @@ GetNextKeyBlocks::GetNextKeyBlocks(BlockIdExt block_id, td::uint32 limit, adnl::
 void GetNextKeyBlocks::abort_query(td::Status reason) {
   if (promise_) {
     if (reason.code() == ErrorCode::notready || reason.code() == ErrorCode::timeout) {
-      VLOG(FULL_NODE_DEBUG) << "failed to download proof " << block_id_ << "from " << download_from_ << ": " << reason;
+      VLOG(full_node, DEBUG) << "failed to download proof " << block_id_ << "from " << download_from_ << ": " << reason;
     } else {
-      VLOG(FULL_NODE_NOTICE) << "failed to download proof " << block_id_ << " from " << download_from_ << ": "
-                             << reason;
+      VLOG(full_node, INFO) << "failed to download proof " << block_id_ << " from " << download_from_ << ": " << reason;
     }
     if (res_.size() > 0) {
       promise_.set_value(std::move(res_));
@@ -125,7 +124,7 @@ void GetNextKeyBlocks::got_download_token(std::unique_ptr<ActionToken> token) {
 
 void GetNextKeyBlocks::got_node_to_download(adnl::AdnlNodeIdShort node) {
   download_from_ = node;
-  VLOG(FULL_NODE_DEBUG) << "downloading proof for " << block_id_;
+  VLOG(full_node, DEBUG) << "downloading proof for " << block_id_;
 
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::BufferSlice> R) mutable {
     if (R.is_error()) {
@@ -157,7 +156,7 @@ void GetNextKeyBlocks::got_result(td::BufferSlice data) {
     return;
   }
 
-  VLOG(FULL_NODE_DEBUG) << "received " << f->blocks_.size() << " key blocks";
+  VLOG(full_node, DEBUG) << "received " << f->blocks_.size() << " key blocks";
   for (auto &x : f->blocks_) {
     pending_.push_back(create_block_id(x));
   }

--- a/validator/state-serializer.cpp
+++ b/validator/state-serializer.cpp
@@ -639,7 +639,7 @@ void AsyncStateSerializer::write_shard_state(BlockHandle handle, ShardIdFull sha
 void AsyncStateSerializer::fail_handler(td::Status reason) {
   current_status_ = PSTRING() << "pending, " << reason;
   current_status_ts_ = {};
-  VLOG(VALIDATOR_NOTICE) << "failure: " << reason;
+  VLOG(validator, INFO) << "failure: " << reason;
   attempt_++;
   delay_action(
       [SelfId = actor_id(this)]() { td::actor::send_closure(SelfId, &AsyncStateSerializer::fail_handler_cont); },

--- a/validator/validate-broadcast.cpp
+++ b/validator/validate-broadcast.cpp
@@ -29,7 +29,7 @@ namespace validator {
 
 void ValidateBroadcast::abort_query(td::Status reason) {
   if (promise_) {
-    VLOG(VALIDATOR_WARNING) << "aborting validate broadcast query for " << broadcast_.block_id << ": " << reason;
+    VLOG(validator, WARNING) << "aborting validate broadcast query for " << broadcast_.block_id << ": " << reason;
     promise_.set_error(std::move(reason));
   }
   stop();
@@ -37,8 +37,8 @@ void ValidateBroadcast::abort_query(td::Status reason) {
 
 void ValidateBroadcast::finish_query() {
   if (promise_) {
-    VLOG(VALIDATOR_DEBUG) << "validated broadcast for " << broadcast_.block_id << " in " << perf_timer_.elapsed()
-                          << " s";
+    VLOG(validator, DEBUG) << "validated broadcast for " << broadcast_.block_id << " in " << perf_timer_.elapsed()
+                           << " s";
     promise_.set_result(td::Unit());
   }
   stop();
@@ -49,9 +49,9 @@ void ValidateBroadcast::alarm() {
 }
 
 void ValidateBroadcast::start_up() {
-  VLOG(VALIDATOR_DEBUG) << "received broadcast for " << broadcast_.block_id
-                        << " : last_mc_seqno=" << last_masterchain_state_->get_seqno()
-                        << " last_key_block_seqno=" << last_known_masterchain_block_handle_->id().seqno();
+  VLOG(validator, DEBUG) << "received broadcast for " << broadcast_.block_id
+                         << " : last_mc_seqno=" << last_masterchain_state_->get_seqno()
+                         << " last_key_block_seqno=" << last_known_masterchain_block_handle_->id().seqno();
   alarm_timestamp() = timeout_;
 
   if (!signatures_only_) {
@@ -140,7 +140,7 @@ void ValidateBroadcast::start_up() {
 }
 
 void ValidateBroadcast::got_key_block_id(BlockIdExt block_id) {
-  VLOG(VALIDATOR_DEBUG) << "got_key_block_id " << block_id.id;
+  VLOG(validator, DEBUG) << "got_key_block_id " << block_id.id;
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<BlockHandle> R) {
     if (R.is_error()) {
       td::actor::send_closure(SelfId, &ValidateBroadcast::abort_query,
@@ -153,7 +153,7 @@ void ValidateBroadcast::got_key_block_id(BlockIdExt block_id) {
 }
 
 void ValidateBroadcast::got_key_block_handle(ConstBlockHandle handle) {
-  VLOG(VALIDATOR_DEBUG) << "got_key_block_handle " << handle->id().id;
+  VLOG(validator, DEBUG) << "got_key_block_handle " << handle->id().id;
   if (handle->id().seqno() == 0) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Ref<ShardState>> R) {
       if (R.is_error()) {
@@ -187,7 +187,7 @@ void ValidateBroadcast::got_key_block_handle(ConstBlockHandle handle) {
 }
 
 void ValidateBroadcast::got_key_block_proof_link(td::Ref<ProofLink> key_proof_link) {
-  VLOG(VALIDATOR_DEBUG) << "got_key_block_proof_link";
+  VLOG(validator, DEBUG) << "got_key_block_proof_link";
   key_proof_link_ = key_proof_link;
   auto confR = key_proof_link->get_key_block_config();
   if (confR.is_error()) {
@@ -198,7 +198,7 @@ void ValidateBroadcast::got_key_block_proof_link(td::Ref<ProofLink> key_proof_li
 }
 
 void ValidateBroadcast::got_zero_state(td::Ref<MasterchainState> state) {
-  VLOG(VALIDATOR_DEBUG) << "got_zero_state";
+  VLOG(validator, DEBUG) << "got_zero_state";
   zero_state_ = state;
   auto confR = state->get_config_holder();
   if (confR.is_error()) {
@@ -209,7 +209,7 @@ void ValidateBroadcast::got_zero_state(td::Ref<MasterchainState> state) {
 }
 
 void ValidateBroadcast::check_signatures_common(td::Ref<ConfigHolder> conf) {
-  VLOG(VALIDATOR_DEBUG) << "checking signatures (" << (broadcast_.sig_set->is_final() ? "final" : "approve") << ")";
+  VLOG(validator, DEBUG) << "checking signatures (" << (broadcast_.sig_set->is_final() ? "final" : "approve") << ")";
   if (signatures_checked_) {
     checked_signatures();
     return;
@@ -243,7 +243,7 @@ void ValidateBroadcast::check_signatures_common(td::Ref<ConfigHolder> conf) {
 }
 
 void ValidateBroadcast::checked_signatures() {
-  VLOG(VALIDATOR_DEBUG) << "checked_signatures";
+  VLOG(validator, DEBUG) << "checked_signatures";
   if (signatures_only_) {
     finish_query();
     return;
@@ -261,7 +261,7 @@ void ValidateBroadcast::checked_signatures() {
 }
 
 void ValidateBroadcast::got_block_handle(BlockHandle handle) {
-  VLOG(VALIDATOR_DEBUG) << "got_block_handle " << handle->id().id;
+  VLOG(validator, DEBUG) << "got_block_handle " << handle->id().id;
   handle_ = std::move(handle);
 
   auto dataR = create_block(broadcast_.block_id, broadcast_.data.clone());
@@ -284,12 +284,12 @@ void ValidateBroadcast::got_block_handle(BlockHandle handle) {
     }
   });
 
-  VLOG(VALIDATOR_DEBUG) << "writing block data for " << handle_->id().id;
+  VLOG(validator, DEBUG) << "writing block data for " << handle_->id().id;
   td::actor::send_closure(manager_, &ValidatorManager::set_block_data, handle_, data_, std::move(P));
 }
 
 void ValidateBroadcast::written_block_data() {
-  VLOG(VALIDATOR_DEBUG) << "written_block_data";
+  VLOG(validator, DEBUG) << "written_block_data";
   if (handle_->id().is_masterchain()) {
     if (handle_->inited_proof()) {
       checked_proof();
@@ -303,7 +303,7 @@ void ValidateBroadcast::written_block_data() {
           td::actor::send_closure(SelfId, &ValidateBroadcast::checked_proof);
         }
       });
-      VLOG(VALIDATOR_DEBUG) << "checking proof";
+      VLOG(validator, DEBUG) << "checking proof";
       if (!key_proof_link_.is_null()) {
         run_check_proof_query(broadcast_.block_id, proof_, manager_, timeout_, std::move(P), key_proof_link_);
       } else {
@@ -325,13 +325,13 @@ void ValidateBroadcast::written_block_data() {
         td::actor::send_closure(SelfId, &ValidateBroadcast::checked_proof);
       }
     });
-    VLOG(VALIDATOR_DEBUG) << "checking proof link";
+    VLOG(validator, DEBUG) << "checking proof link";
     run_check_proof_link_query(broadcast_.block_id, proof_link_, manager_, timeout_, std::move(P));
   }
 }
 
 void ValidateBroadcast::checked_proof() {
-  VLOG(VALIDATOR_DEBUG) << "checked_proof";
+  VLOG(validator, DEBUG) << "checked_proof";
   if (handle_->inited_proof() && handle_->is_key_block()) {
     td::actor::send_closure(manager_, &ValidatorManager::update_last_known_key_block, handle_, false);
   }
@@ -344,7 +344,7 @@ void ValidateBroadcast::checked_proof() {
       }
     });
 
-    VLOG(VALIDATOR_DEBUG) << "apply block";
+    VLOG(validator, DEBUG) << "apply block";
     td::actor::create_actor<ApplyBlock>(PSTRING() << "apply" << handle_->id().id, handle_->id(), data_, handle_->id(),
                                         manager_, timeout_, std::move(P))
         .release();


### PR DESCRIPTION
Adds per-category verbosity control on top of the existing global verbosity level.

- LogCategory with DECLARE_LOG_CATEGORY / DEFINE_LOG_CATEGORY and a variadic VLOG(category, LEVEL) << .... Each category inherits the global level until explicitly overridden, then tracks its own level.
- Migrated existing per-subsystem VLOG usages (adnl, dht, overlay, rldp/rldp2, validator, full-node, collator-node) to named categories and removed the old *_WARNING/*_INFO-style prefix constants in favour of
  plain INFO/WARNING/… levels per category.
- Configure at startup: validator-engine --vcategory adnl=5,overlay=2 (and --vcategory list to print categories).
- Adjust at runtime from the validator console.