### PR TITLE
docs: re-apply GETORIGINALFWDFEE formula fix (regressed in #2386)

### DIFF
--- a/doc/GlobalVersions.md
+++ b/doc/GlobalVersions.md
@@ -82,7 +82,7 @@ __Enabled in mainnet on 2024-03-16__
 * `GETSTORAGEFEE` (`cells bits seconds is_mc - price`) - calculates storage fees (only current StoragePrices entry is used).
 * `GETFORWARDFEE` (`cells bits is_mc - price`) - calculates forward fee.
 * `GETPRECOMPILEDGAS` (`- x`) - returns gas usage for the current contract if it is precompiled, `null` otherwise.
-* `GETORIGINALFWDFEE` (`fwd_fee is_mc - orig_fwd_fee`) - calculate `fwd_fee * 2^16 / first_frac`. Can be used to get the original `fwd_fee` of the message.
+* `GETORIGINALFWDFEE` (`fwd_fee is_mc - orig_fwd_fee`) - calculate `fwd_fee * 2^16 / (2^16 - first_frac)`. Can be used to get the original `fwd_fee` of the message.
 * `GETGASFEESIMPLE` (`gas_used is_mc - price`) - same as `GETGASFEE`, but without flat price (just `(gas_used * price) / 2^16`).
 * `GETFORWARDFEESIMPLE` (`cells bits is_mc - price`) - same as `GETFORWARDFEE`, but without lump price (just `(bits*bit_price + cells*cell_price) / 2^16`).
 


### PR DESCRIPTION
The documented formula for `GETORIGINALFWDFEE` in `doc/GlobalVersions.md` is wrong on current master (`200a6e6`):

```
calculate `fwd_fee * 2^16 / first_frac`
```

The implementation in `crypto/vm/tonops.cpp` (`exec_get_original_fwd_fee`) computes:

```cpp
stack.push_int(td::muldiv(fwd_fee, td::make_refint(1 << 16), td::make_refint((1 << 16) - prices.first_frac)));
```

i.e. `fwd_fee * 2^16 / (2^16 - first_frac)`.

This was already corrected in #2278 (merged 2026-04-29), but the #2386 tolk-v1.4.1 merge (2026-05-22) reintroduced the old, incorrect text. This PR re-applies the one-line fix.

Closes #1878.