### PR TITLE
Clamp slots_per_leader_window to at least 1

### DIFF
--- a/crypto/block/mc-config.cpp
+++ b/crypto/block/mc-config.cpp
@@ -408,7 +408,7 @@ td::optional<ton::NewConsensusConfig> Config::get_new_consensus_config(ton::Work
         .max_collated_data_size = consensus_config.max_collated_data_size,
 
         .use_quic = v1.use_quic,
-        .slots_per_leader_window = v1.slots_per_leader_window,
+        .slots_per_leader_window = std::max<td::uint32>(1, v1.slots_per_leader_window),
 
         .noncritical_params =
             {
@@ -424,7 +424,7 @@ td::optional<ton::NewConsensusConfig> Config::get_new_consensus_config(ton::Work
 
         .use_quic = v2.use_quic,
         .enable_observers = v2.enable_observers,
-        .slots_per_leader_window = v2.slots_per_leader_window,
+        .slots_per_leader_window = std::max<td::uint32>(1, v2.slots_per_leader_window),
     };
 
     using NoncriticalParams = ton::NewConsensusConfig::NoncriticalParams;


### PR DESCRIPTION
`slots_per_leader_window` (consensus config, param 30) is used directly as a divisor in the Simplex leader schedule, e.g. in `validator/consensus/simplex/bus.cpp`:

    slot / slots_per_leader_window_ % leaders_count_

and similarly in `consensus.cpp`, `pool.cpp` and `db.cpp`. It is read from the config in `crypto/block/mc-config.cpp` without any lower bound, so a value of 0 results in an integer division by zero and crashes the validator.

This clamps it to at least 1 when the config is parsed. Changing param 30 requires a config-change vote, so it is not reachable by an external party - it is just defense in depth, but a divisor coming straight from config seemed worth guarding against.
