### PR TITLE
Do not track "permanent validator keys" in manager

### DIFF
--- a/validator-engine/validator-engine.cpp
+++ b/validator-engine/validator-engine.cpp
@@ -1477,10 +1477,6 @@ void ValidatorEngine::alarm() {
       }
       for (auto &x : to_del) {
         config_.config_del_validator_permanent_key(x);
-        if (!validator_manager_.empty()) {
-          td::actor::send_closure(validator_manager_, &ton::validator::ValidatorManagerInterface::del_permanent_key, x,
-                                  [](td::Result<>) {});
-        }
         if (!full_node_.empty()) {
           td::actor::send_closure(full_node_, &ton::validator::fullnode::FullNode::del_permanent_key, x,
                                   [](td::Result<>) {});
@@ -2328,9 +2324,6 @@ void ValidatorEngine::start_validator() {
       validator_options_, db_root_, keyring_.get(), adnl_.get(), rldp2_.get(), quic_.get(), overlay_manager_.get());
 
   for (auto &v : config_.validators) {
-    td::actor::send_closure(validator_manager_, &ton::validator::ValidatorManagerInterface::add_permanent_key, v.first,
-                            [](td::Result<>) {});
-
     for (auto &t : v.second.temp_keys) {
       td::actor::send_closure(validator_manager_, &ton::validator::ValidatorManagerInterface::add_temp_key, t.first,
                               [](td::Result<>) {});
@@ -2595,10 +2588,6 @@ void ValidatorEngine::try_add_validator_permanent_key(ton::PublicKeyHash key_has
   auto ig = mp.init_guard();
   ig.add_promise(std::move(promise));
 
-  if (!validator_manager_.empty()) {
-    td::actor::send_closure(validator_manager_, &ton::validator::ValidatorManagerInterface::add_permanent_key, key_hash,
-                            ig.get_promise());
-  }
   if (!full_node_.empty()) {
     td::actor::send_closure(full_node_, &ton::validator::fullnode::FullNode::add_permanent_key, key_hash,
                             ig.get_promise());
@@ -2787,10 +2776,6 @@ void ValidatorEngine::try_del_validator_permanent_key(ton::PublicKeyHash pub, td
     return;
   }
 
-  if (!validator_manager_.empty()) {
-    td::actor::send_closure(validator_manager_, &ton::validator::ValidatorManagerInterface::del_permanent_key, pub,
-                            [](td::Result<>) {});
-  }
   if (!full_node_.empty()) {
     td::actor::send_closure(full_node_, &ton::validator::fullnode::FullNode::del_permanent_key, pub,
                             [](td::Result<>) {});

--- a/validator/manager-disk.hpp
+++ b/validator/manager-disk.hpp
@@ -75,13 +75,7 @@ class ValidatorManagerImpl : public ValidatorManager {
     callback_ = std::move(new_callback);
     promise.set_value(td::Unit());
   }
-  void add_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    UNREACHABLE();
-  }
   void add_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    UNREACHABLE();
-  }
-  void del_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
     UNREACHABLE();
   }
   void del_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {

--- a/validator/manager-hardfork.hpp
+++ b/validator/manager-hardfork.hpp
@@ -78,13 +78,7 @@ class ValidatorManagerImpl : public ValidatorManager {
 
     callback_->initial_read_complete(nullptr);
   }
-  void add_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    UNREACHABLE();
-  }
   void add_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    UNREACHABLE();
-  }
-  void del_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
     UNREACHABLE();
   }
   void del_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -2433,7 +2433,7 @@ void ValidatorManagerImpl::update_shards() {
       PublicKeyHash key_hash = ValidatorFullId{val.key}.compute_short_id();
       adnl::AdnlNodeIdShort adnl_id{val.addr.is_zero() ? key_hash.bits256_value() : val.addr};
       overlay_members.push_back(adnl_id);
-      if (temp_keys_.count(key_hash) || permanent_keys_.count(key_hash)) {
+      if (validator_keys_.count(key_hash)) {
         local_key_to_adnl.emplace(key_hash, adnl_id);
       }
     }
@@ -3099,7 +3099,7 @@ void ValidatorManagerImpl::get_archive_slice(td::uint64 archive_id, td::uint64 o
 }
 
 bool ValidatorManagerImpl::is_validator() {
-  return temp_keys_.size() > 0 || permanent_keys_.size() > 0;
+  return validator_keys_.size() > 0;
 }
 
 bool ValidatorManagerImpl::validating_masterchain() {
@@ -3109,7 +3109,7 @@ bool ValidatorManagerImpl::validating_masterchain() {
 }
 
 PublicKeyHash ValidatorManagerImpl::get_validator(ShardIdFull shard, td::Ref<block::ValidatorSet> val_set) {
-  for (auto &key : temp_keys_) {
+  for (auto &key : validator_keys_) {
     if (val_set->is_validator(key.bits256_value())) {
       return key;
     }

--- a/validator/manager.hpp
+++ b/validator/manager.hpp
@@ -293,20 +293,12 @@ class ValidatorManagerImpl : public ValidatorManager {
     promise.set_value(td::Unit());
   }
 
-  void add_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    permanent_keys_.insert(key);
-    promise.set_value(td::Unit());
-  }
   void add_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    temp_keys_.insert(key);
-    promise.set_value(td::Unit());
-  }
-  void del_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    permanent_keys_.erase(key);
+    validator_keys_.insert(key);
     promise.set_value(td::Unit());
   }
   void del_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) override {
-    temp_keys_.erase(key);
+    validator_keys_.erase(key);
     promise.set_value(td::Unit());
   }
 
@@ -638,8 +630,7 @@ class ValidatorManagerImpl : public ValidatorManager {
   td::actor::ActorOwn<TokenManager> token_manager_;
 
  private:
-  std::set<PublicKeyHash> permanent_keys_;
-  std::set<PublicKeyHash> temp_keys_;
+  std::set<PublicKeyHash> validator_keys_;
 
  private:
   td::Ref<ValidatorManagerOptions> opts_;

--- a/validator/validator.h
+++ b/validator/validator.h
@@ -293,9 +293,7 @@ class ValidatorManagerInterface : public td::actor::Actor {
 
   virtual ~ValidatorManagerInterface() = default;
   virtual void install_callback(std::unique_ptr<Callback> new_callback, td::Promise<td::Unit> promise) = 0;
-  virtual void add_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) = 0;
   virtual void add_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) = 0;
-  virtual void del_permanent_key(PublicKeyHash key, td::Promise<td::Unit> promise) = 0;
   virtual void del_temp_key(PublicKeyHash key, td::Promise<td::Unit> promise) = 0;
 
   virtual void validate_block_is_next_proof(BlockIdExt prev_block_id, BlockIdExt next_block_id, td::BufferSlice proof,


### PR DESCRIPTION
I have no idea what they were intended to be used for but they are definitely unused now.