### PR TITLE
Improve recovery sync over custom overlays

### DIFF
--- a/validator-engine/validator-engine.hpp
+++ b/validator-engine/validator-engine.hpp
@@ -278,7 +278,7 @@ class ValidatorEngine : public td::actor::Actor {
                                                                   .public_broadcast_speed_multiplier_ = 3.33,
                                                                   .private_broadcast_speed_multiplier_ = 3.33,
                                                                   .fast_sync_broadcast_speed_multiplier_ = 3.33,
-                                                                  .initial_sync_delay_ = 60.0};
+                                                                  .initial_sync_delay_ = 0.0};
 
   std::map<ton::BlockSeqno, std::pair<ton::CatchainSeqno, td::uint32>> unsafe_catchain_rotations_;
   ton::quic::QuicServer::Options quic_options_ = {};

--- a/validator/full-node-custom-overlays.cpp
+++ b/validator/full-node-custom-overlays.cpp
@@ -492,6 +492,24 @@ void FullNodeCustomOverlay::download_block(BlockIdExt id, td::uint32 priority, t
       .release();
 }
 
+void FullNodeCustomOverlay::download_next_block(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
+                                                td::Promise<ReceivedBlock> promise) {
+  if (!inited_) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay is not ready"));
+    return;
+  }
+  if (!custom_overlay_serves_shard(sender_shards_, prev_id.shard_full())) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
+    return;
+  }
+  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" next block after " << prev_id.to_str();
+  td::actor::create_actor<DownloadBlockNew>(
+      "customdownloadnext", local_id_, overlay_id_, prev_id, adnl::AdnlNodeIdShort::zero(), priority, timeout,
+      validator_manager_, td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise))
+      .release();
+}
+
 void FullNodeCustomOverlay::download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
                                                  td::Promise<td::BufferSlice> promise) {
   if (!inited_) {

--- a/validator/full-node-custom-overlays.cpp
+++ b/validator/full-node-custom-overlays.cpp
@@ -637,12 +637,7 @@ void FullNodeCustomOverlay::download_archive(BlockSeqno masterchain_seqno, Shard
     promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
     return;
   }
-  std::vector<adnl::AdnlNodeIdShort> peers;
-  for (const auto &node : nodes_) {
-    if (node != local_id_) {
-      peers.push_back(node);
-    }
-  }
+  auto peers = custom_download_peers();
   if (peers.empty()) {
     promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay has no remote peers"));
     return;
@@ -654,7 +649,8 @@ void FullNodeCustomOverlay::download_archive(BlockSeqno masterchain_seqno, Shard
       local_id_, overlay_id_, adnl::AdnlNodeIdShort::zero(), timeout, validator_manager_,
       td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
       td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise), std::move(peers),
-      true /* use_sender_for_prepare_query */)
+      false /* use_sender_for_prepare_query */, false /* use_sender_for_slice_query */,
+      true /* resolve_peers_before_download */)
       .release();
 }
 
@@ -733,6 +729,37 @@ void FullNodeCustomOverlay::init() {
       overlay_options);
 
   inited_ = true;
+  prewarm_archive_peers();
+  alarm_timestamp().relax(td::Timestamp::in(60.0));
+}
+
+void FullNodeCustomOverlay::prewarm_archive_peers() {
+  auto peers = custom_download_peers();
+  if (peers.empty()) {
+    return;
+  }
+  LOG(INFO) << "Prewarming " << peers.size() << " custom overlay \"" << name_ << "\" archive peers via DHT";
+  for (const auto &peer : peers) {
+    td::actor::send_closure(
+        adnl_, &adnl::Adnl::get_peer_node, local_id_, peer,
+        [name = name_, local_id = local_id_, peer](td::Result<adnl::AdnlNode> R) mutable {
+          if (R.is_ok()) {
+            auto node = R.move_as_ok();
+            LOG(INFO) << "Prewarmed custom overlay \"" << name << "\" peer " << peer << " for local id "
+                      << local_id << " addr_count=" << node.addr_list().size();
+          } else {
+            LOG(INFO) << "Failed to prewarm custom overlay \"" << name << "\" peer " << peer << " for local id "
+                      << local_id << ": " << R.move_as_error();
+          }
+        });
+  }
+}
+
+void FullNodeCustomOverlay::alarm() {
+  if (inited_) {
+    prewarm_archive_peers();
+    alarm_timestamp() = td::Timestamp::in(60.0);
+  }
 }
 
 void FullNodeCustomOverlay::tear_down() {

--- a/validator/full-node-custom-overlays.cpp
+++ b/validator/full-node-custom-overlays.cpp
@@ -14,12 +14,16 @@
     You should have received a copy of the GNU Lesser General Public License
     along with TON Blockchain Library.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <algorithm>
+
 #include "auto/tl/ton_api_json.h"
 #include "common/checksum.h"
 #include "common/delay.h"
+#include "net/download-archive-slice.hpp"
 #include "td/utils/JsonBuilder.h"
 #include "tl/tl_json.h"
 #include "ton/ton-io.hpp"
+#include "ton/ton-shard.h"
 #include "ton/ton-tl.hpp"
 
 #include "full-node-custom-overlays.hpp"
@@ -30,6 +34,29 @@ namespace ton::validator::fullnode {
 namespace {
 
 constexpr const char *k_called_from_custom = "custom";
+constexpr td::uint32 k_heavy_request_cost_unit = 1 << 21;
+
+size_t heavy_request_cost(td::uint64 requested_max_size) {
+  size_t cost = static_cast<size_t>((requested_max_size + k_heavy_request_cost_unit - 1) / k_heavy_request_cost_unit);
+  return cost == 0 ? 1 : cost;
+}
+
+size_t request_cost_for_custom_overlay_query(ton_api::Function &function) {
+  size_t cost = 1;
+  ton_api::downcast_call(function, td::overloaded(
+                                       [&](const ton_api::tonNode_getArchiveSlice &query) {
+                                         cost = heavy_request_cost(
+                                             query.max_size_ > 0 ? static_cast<td::uint64>(query.max_size_) : 0);
+                                       },
+                                       [&](const auto &) {}));
+  return cost;
+}
+
+bool custom_overlay_serves_shard(const std::vector<ShardIdFull> &sender_shards, const ShardIdFull &shard) {
+  return sender_shards.empty() ||
+         std::any_of(sender_shards.begin(), sender_shards.end(),
+                     [&](const ShardIdFull &our_shard) { return shard_intersects(shard, our_shard); });
+}
 
 }  // namespace
 
@@ -208,6 +235,71 @@ void FullNodeCustomOverlay::receive_broadcast(PublicKeyHash src, td::BufferSlice
   ton_api::downcast_call(*B.move_as_ok(), [src, Self = this](auto &obj) { Self->process_broadcast(src, obj); });
 }
 
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getArchiveInfo &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  auto P = td::PromiseCreator::lambda([promise = std::move(promise)](td::Result<td::uint64> R) mutable {
+    if (R.is_error()) {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_archiveNotFound>());
+    } else {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_archiveInfo>(R.move_as_ok()));
+    }
+  });
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay getArchiveInfo " << query.masterchain_seqno_ << " from " << src;
+  td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_archive_id, query.masterchain_seqno_,
+                          ShardIdFull{masterchainId}, std::move(P));
+}
+
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getShardArchiveInfo &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  ShardIdFull shard_prefix = create_shard_id(query.shard_prefix_);
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay getShardArchiveInfo " << query.masterchain_seqno_ << " "
+                        << shard_prefix.to_str() << " from " << src;
+  if (!custom_overlay_serves_shard(sender_shards_, shard_prefix)) {
+    promise.set_value(create_serialize_tl_object<ton_api::tonNode_archiveNotFound>());
+    return;
+  }
+  auto P = td::PromiseCreator::lambda([promise = std::move(promise)](td::Result<td::uint64> R) mutable {
+    if (R.is_error()) {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_archiveNotFound>());
+    } else {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_archiveInfo>(R.move_as_ok()));
+    }
+  });
+  td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_archive_id, query.masterchain_seqno_,
+                          shard_prefix, std::move(P));
+}
+
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getArchiveSlice &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay getArchiveSlice " << query.archive_id_ << " " << query.offset_ << " "
+                        << query.max_size_ << " from " << src;
+  if (query.max_size_ < 0 || query.max_size_ > (1 << 24)) {
+    promise.set_error(td::Status::Error(ErrorCode::protoviolation, "invalid max_size"));
+    return;
+  }
+  td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_archive_slice, query.archive_id_,
+                          query.offset_, query.max_size_, std::move(promise));
+}
+
+void FullNodeCustomOverlay::receive_query(adnl::AdnlNodeIdShort src, td::BufferSlice query,
+                                          td::Promise<td::BufferSlice> promise) {
+  if (std::find(nodes_.begin(), nodes_.end(), src) == nodes_.end()) {
+    promise.set_error(td::Status::Error(ErrorCode::protoviolation, "custom overlay peer is not authorized"));
+    return;
+  }
+  auto B = fetch_tl_object<ton_api::Function>(std::move(query), true);
+  if (B.is_error()) {
+    promise.set_error(td::Status::Error(ErrorCode::protoviolation, "cannot parse custom overlay tonnode query"));
+    return;
+  }
+  auto fun_ptr = B.move_as_ok();
+  if (limiter_ && !limiter_->check_in(fun_ptr->get_id(), request_cost_for_custom_overlay_query(*fun_ptr))) {
+    promise.set_error(td::Status::Error(ErrorCode::failure, "too many custom overlay archive requests"));
+    return;
+  }
+  ton_api::downcast_call(*fun_ptr.get(), [&](auto &obj) { this->process_query(src, obj, std::move(promise)); });
+}
+
 void FullNodeCustomOverlay::send_external_message(td::BufferSlice data) {
   if (!inited_ || opts_.config_.ext_messages_broadcast_disabled_) {
     return;
@@ -262,6 +354,38 @@ void FullNodeCustomOverlay::send_shard_block_info(BlockIdExt block_id, CatchainS
   }
 }
 
+void FullNodeCustomOverlay::download_archive(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix,
+                                             std::string tmp_dir, td::Timestamp timeout,
+                                             td::Promise<std::string> promise) {
+  if (!inited_) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay is not ready"));
+    return;
+  }
+  if (!custom_overlay_serves_shard(sender_shards_, shard_prefix)) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
+    return;
+  }
+  std::vector<adnl::AdnlNodeIdShort> peers;
+  for (const auto &node : nodes_) {
+    if (node != local_id_) {
+      peers.push_back(node);
+    }
+  }
+  if (peers.empty()) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay has no remote peers"));
+    return;
+  }
+  LOG(INFO) << "Trying custom overlay \"" << name_ << "\" archive slice #" << masterchain_seqno << " "
+            << shard_prefix.to_str() << " from " << peers.size() << " peers";
+  td::actor::create_actor<DownloadArchiveSlice>(
+      PSTRING() << "customarchive." << masterchain_seqno, masterchain_seqno, shard_prefix, std::move(tmp_dir),
+      local_id_, overlay_id_, adnl::AdnlNodeIdShort::zero(), timeout, validator_manager_,
+      td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise), std::move(peers),
+      true /* use_sender_for_prepare_query */)
+      .release();
+}
+
 void FullNodeCustomOverlay::start_up() {
   std::sort(nodes_.begin(), nodes_.end());
   nodes_.erase(std::unique(nodes_.begin(), nodes_.end()), nodes_.end());
@@ -302,6 +426,7 @@ void FullNodeCustomOverlay::init() {
     }
     void receive_query(adnl::AdnlNodeIdShort src, overlay::OverlayIdShort overlay_id, td::BufferSlice data,
                        td::Promise<td::BufferSlice> promise) override {
+      td::actor::send_closure(node_, &FullNodeCustomOverlay::receive_query, src, std::move(data), std::move(promise));
     }
     void receive_broadcast(PublicKeyHash src, overlay::OverlayIdShort overlay_id, td::BufferSlice data) override {
       td::actor::send_closure(node_, &FullNodeCustomOverlay::receive_broadcast, src, std::move(data));

--- a/validator/full-node-custom-overlays.cpp
+++ b/validator/full-node-custom-overlays.cpp
@@ -474,6 +474,90 @@ void FullNodeCustomOverlay::send_shard_block_info(BlockIdExt block_id, CatchainS
   }
 }
 
+std::vector<adnl::AdnlNodeIdShort> FullNodeCustomOverlay::custom_download_peers() const {
+  std::vector<adnl::AdnlNodeIdShort> peers;
+  auto add_peer = [&](adnl::AdnlNodeIdShort peer) {
+    if (peer.is_zero() || peer == local_id_) {
+      return;
+    }
+    if (std::find(peers.begin(), peers.end(), peer) == peers.end()) {
+      peers.push_back(peer);
+    }
+  };
+  for (auto peer : block_senders_) {
+    add_peer(peer);
+  }
+  for (auto peer : nodes_) {
+    add_peer(peer);
+  }
+  return peers;
+}
+
+void FullNodeCustomOverlay::download_block_from_custom_peers(BlockIdExt id, td::uint32 priority,
+                                                             td::Timestamp timeout,
+                                                             std::vector<adnl::AdnlNodeIdShort> peers, size_t offset,
+                                                             td::Promise<ReceivedBlock> promise) {
+  if (offset >= peers.size()) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "no custom overlay peer has this block"));
+    return;
+  }
+  if (timeout.is_in_past()) {
+    promise.set_error(td::Status::Error(ErrorCode::timeout, "custom overlay block download timeout"));
+    return;
+  }
+  auto peer = peers[offset];
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), id, priority, timeout, peers = std::move(peers),
+                                       offset, promise = std::move(promise),
+                                       peer](td::Result<ReceivedBlock> R) mutable {
+    if (R.is_ok()) {
+      promise.set_value(R.move_as_ok());
+      return;
+    }
+    VLOG(FULL_NODE_DEBUG) << "failed to download block " << id.to_str() << " from custom overlay peer " << peer
+                          << ": " << R.move_as_error();
+    td::actor::send_closure(SelfId, &FullNodeCustomOverlay::download_block_from_custom_peers, id, priority, timeout,
+                            std::move(peers), offset + 1, std::move(promise));
+  });
+  td::actor::create_actor<DownloadBlockNew>(
+      "customdownloadreq", id, local_id_, overlay_id_, peer, priority, timeout, validator_manager_,
+      td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(P))
+      .release();
+}
+
+void FullNodeCustomOverlay::download_next_block_from_custom_peers(BlockIdExt prev_id, td::uint32 priority,
+                                                                  td::Timestamp timeout,
+                                                                  std::vector<adnl::AdnlNodeIdShort> peers,
+                                                                  size_t offset,
+                                                                  td::Promise<ReceivedBlock> promise) {
+  if (offset >= peers.size()) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "no custom overlay peer has next block"));
+    return;
+  }
+  if (timeout.is_in_past()) {
+    promise.set_error(td::Status::Error(ErrorCode::timeout, "custom overlay next block download timeout"));
+    return;
+  }
+  auto peer = peers[offset];
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), prev_id, priority, timeout, peers = std::move(peers),
+                                       offset, promise = std::move(promise),
+                                       peer](td::Result<ReceivedBlock> R) mutable {
+    if (R.is_ok()) {
+      promise.set_value(R.move_as_ok());
+      return;
+    }
+    VLOG(FULL_NODE_DEBUG) << "failed to download next block after " << prev_id.to_str()
+                          << " from custom overlay peer " << peer << ": " << R.move_as_error();
+    td::actor::send_closure(SelfId, &FullNodeCustomOverlay::download_next_block_from_custom_peers, prev_id, priority,
+                            timeout, std::move(peers), offset + 1, std::move(promise));
+  });
+  td::actor::create_actor<DownloadBlockNew>(
+      "customdownloadnext", local_id_, overlay_id_, prev_id, peer, priority, timeout, validator_manager_,
+      td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(P))
+      .release();
+}
+
 void FullNodeCustomOverlay::download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
                                            td::Promise<ReceivedBlock> promise) {
   if (!inited_) {
@@ -484,12 +568,10 @@ void FullNodeCustomOverlay::download_block(BlockIdExt id, td::uint32 priority, t
     promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" block " << id.to_str();
-  td::actor::create_actor<DownloadBlockNew>(
-      "customdownloadreq", id, local_id_, overlay_id_, adnl::AdnlNodeIdShort::zero(), priority, timeout,
-      validator_manager_, td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
-      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise))
-      .release();
+  auto peers = custom_download_peers();
+  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" block " << id.to_str() << " from "
+                        << peers.size() << " peers";
+  download_block_from_custom_peers(id, priority, timeout, std::move(peers), 0, std::move(promise));
 }
 
 void FullNodeCustomOverlay::download_next_block(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
@@ -502,12 +584,10 @@ void FullNodeCustomOverlay::download_next_block(BlockIdExt prev_id, td::uint32 p
     promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
     return;
   }
-  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" next block after " << prev_id.to_str();
-  td::actor::create_actor<DownloadBlockNew>(
-      "customdownloadnext", local_id_, overlay_id_, prev_id, adnl::AdnlNodeIdShort::zero(), priority, timeout,
-      validator_manager_, td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
-      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise))
-      .release();
+  auto peers = custom_download_peers();
+  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" next block after " << prev_id.to_str()
+                        << " from " << peers.size() << " peers";
+  download_next_block_from_custom_peers(prev_id, priority, timeout, std::move(peers), 0, std::move(promise));
 }
 
 void FullNodeCustomOverlay::download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,

--- a/validator/full-node-custom-overlays.cpp
+++ b/validator/full-node-custom-overlays.cpp
@@ -20,6 +20,8 @@
 #include "common/checksum.h"
 #include "common/delay.h"
 #include "net/download-archive-slice.hpp"
+#include "net/download-block-new.hpp"
+#include "net/download-proof.hpp"
 #include "td/utils/JsonBuilder.h"
 #include "tl/tl_json.h"
 #include "ton/ton-io.hpp"
@@ -27,6 +29,7 @@
 #include "ton/ton-tl.hpp"
 
 #include "full-node-custom-overlays.hpp"
+#include "full-node-shard-queries.hpp"
 #include "full-node-serializer.hpp"
 
 namespace ton::validator::fullnode {
@@ -47,6 +50,14 @@ size_t request_cost_for_custom_overlay_query(ton_api::Function &function) {
                                        [&](const ton_api::tonNode_getArchiveSlice &query) {
                                          cost = heavy_request_cost(
                                              query.max_size_ > 0 ? static_cast<td::uint64>(query.max_size_) : 0);
+                                       },
+                                       [&](const ton_api::tonNode_downloadBlockFull &) {
+                                         cost = heavy_request_cost(FullNode::max_proof_size() +
+                                                                   FullNode::max_block_size());
+                                       },
+                                       [&](const ton_api::tonNode_downloadNextBlockFull &) {
+                                         cost = heavy_request_cost(FullNode::max_proof_size() +
+                                                                   FullNode::max_block_size());
                                        },
                                        [&](const auto &) {}));
   return cost;
@@ -281,6 +292,115 @@ void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::to
                           query.offset_, query.max_size_, std::move(promise));
 }
 
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockFull &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  BlockIdExt block_id = create_block_id(query.block_);
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay downloadBlockFull " << block_id.to_str() << " from " << src;
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_value(create_serialize_tl_object<ton_api::tonNode_dataFullEmpty>());
+    return;
+  }
+  td::actor::create_actor<BlockFullSender>("customsender", block_id, false, validator_manager_, std::move(promise))
+      .release();
+}
+
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadNextBlockFull &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  BlockIdExt block_id = create_block_id(query.prev_block_);
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay downloadNextBlockFull " << block_id.to_str() << " from " << src;
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_value(create_serialize_tl_object<ton_api::tonNode_dataFullEmpty>());
+    return;
+  }
+  td::actor::create_actor<BlockFullSender>("customsender", block_id, true, validator_manager_, std::move(promise))
+      .release();
+}
+
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_prepareBlockProof &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  if (query.block_->seqno_ == 0) {
+    promise.set_error(td::Status::Error(ErrorCode::protoviolation, "cannot download proof for zero state"));
+    return;
+  }
+  BlockIdExt block_id = create_block_id(query.block_);
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay prepareBlockProof " << block_id.to_str() << " from " << src;
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_value(create_serialize_tl_object<ton_api::tonNode_preparedProofEmpty>());
+    return;
+  }
+  auto P = td::PromiseCreator::lambda([allow_partial = query.allow_partial_,
+                                       promise = std::move(promise)](td::Result<BlockHandle> R) mutable {
+    if (R.is_error()) {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_preparedProofEmpty>());
+      return;
+    }
+    auto handle = R.move_as_ok();
+    if (!handle || (!handle->inited_proof() && (!allow_partial || !handle->inited_proof_link()))) {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_preparedProofEmpty>());
+      return;
+    }
+    if (handle->inited_proof() && handle->id().is_masterchain()) {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_preparedProof>());
+    } else {
+      promise.set_value(create_serialize_tl_object<ton_api::tonNode_preparedProofLink>());
+    }
+  });
+  td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
+                          std::move(P));
+}
+
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockProof &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  BlockIdExt block_id = create_block_id(query.block_);
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay downloadBlockProof " << block_id.to_str() << " from " << src;
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_error(td::Status::Error(ErrorCode::protoviolation, "unknown block proof"));
+    return;
+  }
+  auto P = td::PromiseCreator::lambda(
+      [promise = std::move(promise), validator_manager = validator_manager_](td::Result<BlockHandle> R) mutable {
+        if (R.is_error()) {
+          promise.set_error(td::Status::Error(ErrorCode::protoviolation, "unknown block proof"));
+          return;
+        }
+        auto handle = R.move_as_ok();
+        if (!handle || !handle->inited_proof()) {
+          promise.set_error(td::Status::Error(ErrorCode::protoviolation, "unknown block proof"));
+          return;
+        }
+        td::actor::send_closure(validator_manager, &ValidatorManagerInterface::get_block_proof, handle,
+                                std::move(promise));
+      });
+  td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
+                          std::move(P));
+}
+
+void FullNodeCustomOverlay::process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockProofLink &query,
+                                          td::Promise<td::BufferSlice> promise) {
+  BlockIdExt block_id = create_block_id(query.block_);
+  VLOG(FULL_NODE_DEBUG) << "Got custom overlay downloadBlockProofLink " << block_id.to_str() << " from " << src;
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_error(td::Status::Error(ErrorCode::protoviolation, "unknown block proof"));
+    return;
+  }
+  auto P = td::PromiseCreator::lambda(
+      [promise = std::move(promise), validator_manager = validator_manager_](td::Result<BlockHandle> R) mutable {
+        if (R.is_error()) {
+          promise.set_error(td::Status::Error(ErrorCode::protoviolation, "unknown block proof"));
+          return;
+        }
+        auto handle = R.move_as_ok();
+        if (!handle || !handle->inited_proof_link()) {
+          promise.set_error(td::Status::Error(ErrorCode::protoviolation, "unknown block proof"));
+          return;
+        }
+        td::actor::send_closure(validator_manager, &ValidatorManagerInterface::get_block_proof_link, handle,
+                                std::move(promise));
+      });
+  td::actor::send_closure(validator_manager_, &ValidatorManagerInterface::get_block_handle, block_id, false,
+                          std::move(P));
+}
+
 void FullNodeCustomOverlay::receive_query(adnl::AdnlNodeIdShort src, td::BufferSlice query,
                                           td::Promise<td::BufferSlice> promise) {
   if (std::find(nodes_.begin(), nodes_.end(), src) == nodes_.end()) {
@@ -352,6 +472,60 @@ void FullNodeCustomOverlay::send_shard_block_info(BlockIdExt block_id, CatchainS
     td::actor::send_closure(overlays_, &overlay::Overlays::send_broadcast_fec_ex, local_id_, overlay_id_,
                             local_id_.pubkey_hash(), overlay::Overlays::BroadcastFlagAnySender(), std::move(B));
   }
+}
+
+void FullNodeCustomOverlay::download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
+                                           td::Promise<ReceivedBlock> promise) {
+  if (!inited_) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay is not ready"));
+    return;
+  }
+  if (!custom_overlay_serves_shard(sender_shards_, id.shard_full())) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
+    return;
+  }
+  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" block " << id.to_str();
+  td::actor::create_actor<DownloadBlockNew>(
+      "customdownloadreq", id, local_id_, overlay_id_, adnl::AdnlNodeIdShort::zero(), priority, timeout,
+      validator_manager_, td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise))
+      .release();
+}
+
+void FullNodeCustomOverlay::download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
+                                                 td::Promise<td::BufferSlice> promise) {
+  if (!inited_) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay is not ready"));
+    return;
+  }
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
+    return;
+  }
+  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" block proof " << block_id.to_str();
+  td::actor::create_actor<DownloadProof>(
+      "customdownloadproof", block_id, false, false, local_id_, overlay_id_, adnl::AdnlNodeIdShort::zero(), priority,
+      timeout, validator_manager_, td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise))
+      .release();
+}
+
+void FullNodeCustomOverlay::download_block_proof_link(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
+                                                      td::Promise<td::BufferSlice> promise) {
+  if (!inited_) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay is not ready"));
+    return;
+  }
+  if (!custom_overlay_serves_shard(sender_shards_, block_id.shard_full())) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "custom overlay does not serve shard"));
+    return;
+  }
+  VLOG(FULL_NODE_DEBUG) << "Trying custom overlay \"" << name_ << "\" block proof link " << block_id.to_str();
+  td::actor::create_actor<DownloadProof>(
+      "customdownloadproof", block_id, true, false, local_id_, overlay_id_, adnl::AdnlNodeIdShort::zero(), priority,
+      timeout, validator_manager_, td::actor::ActorId<adnl::AdnlSenderInterface>{adnl_sender_}, overlays_, adnl_,
+      td::actor::ActorId<adnl::AdnlExtClient>{}, std::move(promise))
+      .release();
 }
 
 void FullNodeCustomOverlay::download_archive(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix,

--- a/validator/full-node-custom-overlays.hpp
+++ b/validator/full-node-custom-overlays.hpp
@@ -51,6 +51,16 @@ class FullNodeCustomOverlay : public td::actor::Actor {
                      td::Promise<td::BufferSlice> promise);
   void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getArchiveSlice &query,
                      td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockFull &query,
+                     td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadNextBlockFull &query,
+                     td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_prepareBlockProof &query,
+                     td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockProof &query,
+                     td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_downloadBlockProofLink &query,
+                     td::Promise<td::BufferSlice> promise);
   template <class T>
   void process_query(adnl::AdnlNodeIdShort, T &, td::Promise<td::BufferSlice> promise) {
     promise.set_error(td::Status::Error(ErrorCode::notready, "unsupported custom overlay query"));
@@ -68,6 +78,12 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   void send_block_candidate(BlockIdExt block_id, CatchainSeqno cc_seqno, td::uint32 validator_set_hash,
                             td::BufferSlice data);
   void send_shard_block_info(BlockIdExt block_id, CatchainSeqno cc_seqno, td::BufferSlice data);
+  void download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
+                      td::Promise<ReceivedBlock> promise);
+  void download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
+                            td::Promise<td::BufferSlice> promise);
+  void download_block_proof_link(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
+                                 td::Promise<td::BufferSlice> promise);
   void download_archive(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix, std::string tmp_dir,
                         td::Timestamp timeout, td::Promise<std::string> promise);
 

--- a/validator/full-node-custom-overlays.hpp
+++ b/validator/full-node-custom-overlays.hpp
@@ -17,8 +17,11 @@
 #pragma once
 
 #include <fstream>
+#include <memory>
 
+#include "common/errorcode.h"
 #include "full-node.h"
+#include "rate-limiter.h"
 #include "validator-telemetry.hpp"
 
 namespace ton::validator::fullnode {
@@ -42,6 +45,18 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   void process_block_candidate_broadcast(PublicKeyHash src, ton_api::tonNode_Broadcast &query);
   void process_broadcast(PublicKeyHash src, ton_api::tonNode_newShardBlockBroadcast &query);
 
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getArchiveInfo &query,
+                     td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getShardArchiveInfo &query,
+                     td::Promise<td::BufferSlice> promise);
+  void process_query(adnl::AdnlNodeIdShort src, ton_api::tonNode_getArchiveSlice &query,
+                     td::Promise<td::BufferSlice> promise);
+  template <class T>
+  void process_query(adnl::AdnlNodeIdShort, T &, td::Promise<td::BufferSlice> promise) {
+    promise.set_error(td::Status::Error(ErrorCode::notready, "unsupported custom overlay query"));
+  }
+  void receive_query(adnl::AdnlNodeIdShort src, td::BufferSlice query, td::Promise<td::BufferSlice> promise);
+
   template <class T>
   void process_broadcast(PublicKeyHash, T &) {
     VLOG(FULL_NODE_WARNING) << "dropping unknown broadcast";
@@ -53,6 +68,8 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   void send_block_candidate(BlockIdExt block_id, CatchainSeqno cc_seqno, td::uint32 validator_set_hash,
                             td::BufferSlice data);
   void send_shard_block_info(BlockIdExt block_id, CatchainSeqno cc_seqno, td::BufferSlice data);
+  void download_archive(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix, std::string tmp_dir,
+                        td::Timestamp timeout, td::Promise<std::string> promise);
 
   void set_config(FullNodeConfig config) {
     opts_.config_ = std::move(config);
@@ -66,12 +83,13 @@ class FullNodeCustomOverlay : public td::actor::Actor {
                         td::actor::ActorId<adnl::Adnl> adnl, td::actor::ActorId<adnl::AdnlSenderEx> adnl_sender,
                         td::actor::ActorId<overlay::Overlays> overlays,
                         td::actor::ActorId<ValidatorManagerInterface> validator_manager,
-                        td::actor::ActorId<FullNode> full_node)
+                        td::actor::ActorId<FullNode> full_node, std::shared_ptr<RateLimiter<>> limiter)
       : local_id_(local_id)
       , name_(std::move(params.name_))
       , nodes_(std::move(params.nodes_))
       , msg_senders_(std::move(params.msg_senders_))
       , block_senders_(std::move(params.block_senders_))
+      , sender_shards_(std::move(params.sender_shards_))
       , zero_state_file_hash_(zero_state_file_hash)
       , opts_(opts)
       , keyring_(keyring)
@@ -79,7 +97,8 @@ class FullNodeCustomOverlay : public td::actor::Actor {
       , adnl_sender_(adnl_sender)
       , overlays_(overlays)
       , validator_manager_(validator_manager)
-      , full_node_(full_node) {
+      , full_node_(full_node)
+      , limiter_(std::move(limiter)) {
   }
 
  private:
@@ -88,6 +107,7 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   std::vector<adnl::AdnlNodeIdShort> nodes_;
   std::map<adnl::AdnlNodeIdShort, int> msg_senders_;
   std::set<adnl::AdnlNodeIdShort> block_senders_;
+  std::vector<ShardIdFull> sender_shards_;
   FileHash zero_state_file_hash_;
   FullNodeOptions opts_;
 
@@ -97,6 +117,7 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   td::actor::ActorId<overlay::Overlays> overlays_;
   td::actor::ActorId<ValidatorManagerInterface> validator_manager_;
   td::actor::ActorId<FullNode> full_node_;
+  std::shared_ptr<RateLimiter<>> limiter_;
 
   bool inited_ = false;
   overlay::OverlayIdFull overlay_id_full_;

--- a/validator/full-node-custom-overlays.hpp
+++ b/validator/full-node-custom-overlays.hpp
@@ -141,6 +141,14 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   overlay::OverlayIdFull overlay_id_full_;
   overlay::OverlayIdShort overlay_id_;
 
+  std::vector<adnl::AdnlNodeIdShort> custom_download_peers() const;
+  void download_block_from_custom_peers(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
+                                        std::vector<adnl::AdnlNodeIdShort> peers, size_t offset,
+                                        td::Promise<ReceivedBlock> promise);
+  void download_next_block_from_custom_peers(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
+                                             std::vector<adnl::AdnlNodeIdShort> peers, size_t offset,
+                                             td::Promise<ReceivedBlock> promise);
+
   void try_init();
   void init();
 };

--- a/validator/full-node-custom-overlays.hpp
+++ b/validator/full-node-custom-overlays.hpp
@@ -80,6 +80,8 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   void send_shard_block_info(BlockIdExt block_id, CatchainSeqno cc_seqno, td::BufferSlice data);
   void download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
                       td::Promise<ReceivedBlock> promise);
+  void download_next_block(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
+                           td::Promise<ReceivedBlock> promise);
   void download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
                             td::Promise<td::BufferSlice> promise);
   void download_block_proof_link(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,

--- a/validator/full-node-custom-overlays.hpp
+++ b/validator/full-node-custom-overlays.hpp
@@ -94,6 +94,7 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   }
 
   void start_up() override;
+  void alarm() override;
   void tear_down() override;
 
   FullNodeCustomOverlay(adnl::AdnlNodeIdShort local_id, CustomOverlayParams params, FileHash zero_state_file_hash,
@@ -142,6 +143,7 @@ class FullNodeCustomOverlay : public td::actor::Actor {
   overlay::OverlayIdShort overlay_id_;
 
   std::vector<adnl::AdnlNodeIdShort> custom_download_peers() const;
+  void prewarm_archive_peers();
   void download_block_from_custom_peers(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
                                         std::vector<adnl::AdnlNodeIdShort> peers, size_t offset,
                                         td::Promise<ReceivedBlock> promise);

--- a/validator/full-node-shard.cpp
+++ b/validator/full-node-shard.cpp
@@ -219,7 +219,7 @@ void FullNodeShardImpl::try_get_next_block(td::Timestamp timeout, td::Promise<Re
                                 std::move(promise));
       });
   td::actor::send_closure(full_node_, &FullNode::download_next_block, handle_->id(), download_next_priority(),
-                          td::Timestamp::in(0.5), std::move(P));
+                          td::Timestamp::in(1.0), std::move(P));
 }
 
 void FullNodeShardImpl::try_get_next_block_from_public_overlay(td::Timestamp timeout,

--- a/validator/full-node-shard.cpp
+++ b/validator/full-node-shard.cpp
@@ -209,6 +209,26 @@ void FullNodeShardImpl::try_get_next_block(td::Timestamp timeout, td::Promise<Re
     return;
   }
 
+  auto P = td::PromiseCreator::lambda(
+      [SelfId = actor_id(this), timeout, promise = std::move(promise)](td::Result<ReceivedBlock> R) mutable {
+        if (R.is_ok()) {
+          promise.set_value(R.move_as_ok());
+          return;
+        }
+        td::actor::send_closure(SelfId, &FullNodeShardImpl::try_get_next_block_from_public_overlay, timeout,
+                                std::move(promise));
+      });
+  td::actor::send_closure(full_node_, &FullNode::download_next_block, handle_->id(), download_next_priority(),
+                          td::Timestamp::in(0.5), std::move(P));
+}
+
+void FullNodeShardImpl::try_get_next_block_from_public_overlay(td::Timestamp timeout,
+                                                               td::Promise<ReceivedBlock> promise) {
+  if (timeout.is_in_past()) {
+    promise.set_error(td::Status::Error(ErrorCode::timeout, "timeout"));
+    return;
+  }
+
   auto &b = choose_neighbour();
   td::actor::create_actor<DownloadBlockNew>("downloadnext", adnl_id_, overlay_id_, handle_->id(), b.adnl_id,
                                             download_next_priority(), timeout, validator_manager_, rldp2_, overlays_,

--- a/validator/full-node-shard.hpp
+++ b/validator/full-node-shard.hpp
@@ -93,6 +93,7 @@ class FullNodeShardImpl : public FullNodeShard {
   }
 
   void try_get_next_block(td::Timestamp timestamp, td::Promise<ReceivedBlock> promise);
+  void try_get_next_block_from_public_overlay(td::Timestamp timestamp, td::Promise<ReceivedBlock> promise);
   void got_next_block(td::Result<BlockHandle> block);
   void get_next_block();
 

--- a/validator/full-node.cpp
+++ b/validator/full-node.cpp
@@ -401,6 +401,34 @@ void FullNodeImpl::send_broadcast(BlockBroadcast broadcast, int mode) {
 
 void FullNodeImpl::download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
                                   td::Promise<ReceivedBlock> promise) {
+  if (client_.empty()) {
+    for (auto &[name, custom_overlay] : custom_overlays_) {
+      if (!custom_overlay.params_.send_shard(id.shard_full())) {
+        continue;
+      }
+      for (auto &[local_id, actor] : custom_overlay.actors_) {
+        auto P = td::PromiseCreator::lambda(
+            [SelfId = actor_id(this), id, priority, timeout, promise = std::move(promise),
+             name](td::Result<ReceivedBlock> R) mutable {
+              if (R.is_ok()) {
+                promise.set_value(R.move_as_ok());
+                return;
+              }
+              VLOG(FULL_NODE_DEBUG) << "failed to download block " << id.to_str() << " from custom overlay \""
+                                    << name << "\": " << R.move_as_error() << "; falling back to public overlay";
+              td::actor::send_closure(SelfId, &FullNodeImpl::download_block_from_public_overlay, id, priority, timeout,
+                                      std::move(promise));
+            });
+        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block, id, priority, timeout, std::move(P));
+        return;
+      }
+    }
+  }
+  download_block_from_public_overlay(id, priority, timeout, std::move(promise));
+}
+
+void FullNodeImpl::download_block_from_public_overlay(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
+                                                      td::Promise<ReceivedBlock> promise) {
   auto shard = get_shard(id.shard_full());
   if (shard.empty()) {
     VLOG(FULL_NODE_WARNING) << "dropping download block query to unknown shard";
@@ -436,6 +464,37 @@ void FullNodeImpl::download_persistent_state(BlockIdExt id, BlockIdExt mastercha
 
 void FullNodeImpl::download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
                                         td::Promise<td::BufferSlice> promise) {
+  if (client_.empty()) {
+    for (auto &[name, custom_overlay] : custom_overlays_) {
+      if (!custom_overlay.params_.send_shard(block_id.shard_full())) {
+        continue;
+      }
+      for (auto &[local_id, actor] : custom_overlay.actors_) {
+        auto P = td::PromiseCreator::lambda(
+            [SelfId = actor_id(this), block_id, priority, timeout, promise = std::move(promise),
+             name](td::Result<td::BufferSlice> R) mutable {
+              if (R.is_ok()) {
+                promise.set_value(R.move_as_ok());
+                return;
+              }
+              VLOG(FULL_NODE_DEBUG) << "failed to download block proof " << block_id.to_str()
+                                    << " from custom overlay \"" << name << "\": " << R.move_as_error()
+                                    << "; falling back to public overlay";
+              td::actor::send_closure(SelfId, &FullNodeImpl::download_block_proof_from_public_overlay, block_id,
+                                      priority, timeout, std::move(promise));
+            });
+        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block_proof, block_id, priority, timeout,
+                                std::move(P));
+        return;
+      }
+    }
+  }
+  download_block_proof_from_public_overlay(block_id, priority, timeout, std::move(promise));
+}
+
+void FullNodeImpl::download_block_proof_from_public_overlay(BlockIdExt block_id, td::uint32 priority,
+                                                            td::Timestamp timeout,
+                                                            td::Promise<td::BufferSlice> promise) {
   auto shard = get_shard(block_id.shard_full());
   if (shard.empty()) {
     VLOG(FULL_NODE_WARNING) << "dropping download proof query to unknown shard";
@@ -447,6 +506,37 @@ void FullNodeImpl::download_block_proof(BlockIdExt block_id, td::uint32 priority
 
 void FullNodeImpl::download_block_proof_link(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
                                              td::Promise<td::BufferSlice> promise) {
+  if (client_.empty()) {
+    for (auto &[name, custom_overlay] : custom_overlays_) {
+      if (!custom_overlay.params_.send_shard(block_id.shard_full())) {
+        continue;
+      }
+      for (auto &[local_id, actor] : custom_overlay.actors_) {
+        auto P = td::PromiseCreator::lambda(
+            [SelfId = actor_id(this), block_id, priority, timeout, promise = std::move(promise),
+             name](td::Result<td::BufferSlice> R) mutable {
+              if (R.is_ok()) {
+                promise.set_value(R.move_as_ok());
+                return;
+              }
+              VLOG(FULL_NODE_DEBUG) << "failed to download block proof link " << block_id.to_str()
+                                    << " from custom overlay \"" << name << "\": " << R.move_as_error()
+                                    << "; falling back to public overlay";
+              td::actor::send_closure(SelfId, &FullNodeImpl::download_block_proof_link_from_public_overlay, block_id,
+                                      priority, timeout, std::move(promise));
+            });
+        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block_proof_link, block_id, priority, timeout,
+                                std::move(P));
+        return;
+      }
+    }
+  }
+  download_block_proof_link_from_public_overlay(block_id, priority, timeout, std::move(promise));
+}
+
+void FullNodeImpl::download_block_proof_link_from_public_overlay(BlockIdExt block_id, td::uint32 priority,
+                                                                 td::Timestamp timeout,
+                                                                 td::Promise<td::BufferSlice> promise) {
   auto shard = get_shard(block_id.shard_full(), /* historical = */ true);
   if (shard.empty()) {
     VLOG(FULL_NODE_WARNING) << "dropping download proof link query to unknown shard";

--- a/validator/full-node.cpp
+++ b/validator/full-node.cpp
@@ -401,30 +401,53 @@ void FullNodeImpl::send_broadcast(BlockBroadcast broadcast, int mode) {
 
 void FullNodeImpl::download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
                                   td::Promise<ReceivedBlock> promise) {
-  if (client_.empty()) {
-    for (auto &[name, custom_overlay] : custom_overlays_) {
-      if (!custom_overlay.params_.send_shard(id.shard_full())) {
-        continue;
-      }
-      for (auto &[local_id, actor] : custom_overlay.actors_) {
-        auto P = td::PromiseCreator::lambda(
-            [SelfId = actor_id(this), id, priority, timeout, promise = std::move(promise),
-             name](td::Result<ReceivedBlock> R) mutable {
-              if (R.is_ok()) {
-                promise.set_value(R.move_as_ok());
-                return;
-              }
-              VLOG(FULL_NODE_DEBUG) << "failed to download block " << id.to_str() << " from custom overlay \""
-                                    << name << "\": " << R.move_as_error() << "; falling back to public overlay";
-              td::actor::send_closure(SelfId, &FullNodeImpl::download_block_from_public_overlay, id, priority, timeout,
-                                      std::move(promise));
-            });
-        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block, id, priority, timeout, std::move(P));
-        return;
-      }
+  for (auto &[name, custom_overlay] : custom_overlays_) {
+    if (!custom_overlay.params_.send_shard(id.shard_full())) {
+      continue;
+    }
+    for (auto &[local_id, actor] : custom_overlay.actors_) {
+      auto P = td::PromiseCreator::lambda(
+          [SelfId = actor_id(this), id, priority, timeout, promise = std::move(promise),
+           name](td::Result<ReceivedBlock> R) mutable {
+            if (R.is_ok()) {
+              promise.set_value(R.move_as_ok());
+              return;
+            }
+            VLOG(FULL_NODE_DEBUG) << "failed to download block " << id.to_str() << " from custom overlay \""
+                                  << name << "\": " << R.move_as_error() << "; falling back to public overlay";
+            td::actor::send_closure(SelfId, &FullNodeImpl::download_block_from_public_overlay, id, priority, timeout,
+                                    std::move(promise));
+          });
+      td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block, id, priority, timeout, std::move(P));
+      return;
     }
   }
   download_block_from_public_overlay(id, priority, timeout, std::move(promise));
+}
+
+void FullNodeImpl::download_next_block(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
+                                       td::Promise<ReceivedBlock> promise) {
+  for (auto &[name, custom_overlay] : custom_overlays_) {
+    if (!custom_overlay.params_.send_shard(prev_id.shard_full())) {
+      continue;
+    }
+    for (auto &[local_id, actor] : custom_overlay.actors_) {
+      auto P = td::PromiseCreator::lambda(
+          [promise = std::move(promise), prev_id, name](td::Result<ReceivedBlock> R) mutable {
+            if (R.is_ok()) {
+              promise.set_value(R.move_as_ok());
+              return;
+            }
+            VLOG(FULL_NODE_DEBUG) << "failed to download next block after " << prev_id.to_str()
+                                  << " from custom overlay \"" << name << "\": " << R.move_as_error();
+            promise.set_error(R.move_as_error());
+          });
+      td::actor::send_closure(actor, &FullNodeCustomOverlay::download_next_block, prev_id, priority, timeout,
+                              std::move(P));
+      return;
+    }
+  }
+  promise.set_error(td::Status::Error(ErrorCode::notready, "no custom overlay for shard"));
 }
 
 void FullNodeImpl::download_block_from_public_overlay(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
@@ -464,29 +487,27 @@ void FullNodeImpl::download_persistent_state(BlockIdExt id, BlockIdExt mastercha
 
 void FullNodeImpl::download_block_proof(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
                                         td::Promise<td::BufferSlice> promise) {
-  if (client_.empty()) {
-    for (auto &[name, custom_overlay] : custom_overlays_) {
-      if (!custom_overlay.params_.send_shard(block_id.shard_full())) {
-        continue;
-      }
-      for (auto &[local_id, actor] : custom_overlay.actors_) {
-        auto P = td::PromiseCreator::lambda(
-            [SelfId = actor_id(this), block_id, priority, timeout, promise = std::move(promise),
-             name](td::Result<td::BufferSlice> R) mutable {
-              if (R.is_ok()) {
-                promise.set_value(R.move_as_ok());
-                return;
-              }
-              VLOG(FULL_NODE_DEBUG) << "failed to download block proof " << block_id.to_str()
-                                    << " from custom overlay \"" << name << "\": " << R.move_as_error()
-                                    << "; falling back to public overlay";
-              td::actor::send_closure(SelfId, &FullNodeImpl::download_block_proof_from_public_overlay, block_id,
-                                      priority, timeout, std::move(promise));
-            });
-        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block_proof, block_id, priority, timeout,
-                                std::move(P));
-        return;
-      }
+  for (auto &[name, custom_overlay] : custom_overlays_) {
+    if (!custom_overlay.params_.send_shard(block_id.shard_full())) {
+      continue;
+    }
+    for (auto &[local_id, actor] : custom_overlay.actors_) {
+      auto P = td::PromiseCreator::lambda(
+          [SelfId = actor_id(this), block_id, priority, timeout, promise = std::move(promise),
+           name](td::Result<td::BufferSlice> R) mutable {
+            if (R.is_ok()) {
+              promise.set_value(R.move_as_ok());
+              return;
+            }
+            VLOG(FULL_NODE_DEBUG) << "failed to download block proof " << block_id.to_str()
+                                  << " from custom overlay \"" << name << "\": " << R.move_as_error()
+                                  << "; falling back to public overlay";
+            td::actor::send_closure(SelfId, &FullNodeImpl::download_block_proof_from_public_overlay, block_id,
+                                    priority, timeout, std::move(promise));
+          });
+      td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block_proof, block_id, priority, timeout,
+                              std::move(P));
+      return;
     }
   }
   download_block_proof_from_public_overlay(block_id, priority, timeout, std::move(promise));
@@ -506,29 +527,27 @@ void FullNodeImpl::download_block_proof_from_public_overlay(BlockIdExt block_id,
 
 void FullNodeImpl::download_block_proof_link(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
                                              td::Promise<td::BufferSlice> promise) {
-  if (client_.empty()) {
-    for (auto &[name, custom_overlay] : custom_overlays_) {
-      if (!custom_overlay.params_.send_shard(block_id.shard_full())) {
-        continue;
-      }
-      for (auto &[local_id, actor] : custom_overlay.actors_) {
-        auto P = td::PromiseCreator::lambda(
-            [SelfId = actor_id(this), block_id, priority, timeout, promise = std::move(promise),
-             name](td::Result<td::BufferSlice> R) mutable {
-              if (R.is_ok()) {
-                promise.set_value(R.move_as_ok());
-                return;
-              }
-              VLOG(FULL_NODE_DEBUG) << "failed to download block proof link " << block_id.to_str()
-                                    << " from custom overlay \"" << name << "\": " << R.move_as_error()
-                                    << "; falling back to public overlay";
-              td::actor::send_closure(SelfId, &FullNodeImpl::download_block_proof_link_from_public_overlay, block_id,
-                                      priority, timeout, std::move(promise));
-            });
-        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block_proof_link, block_id, priority, timeout,
-                                std::move(P));
-        return;
-      }
+  for (auto &[name, custom_overlay] : custom_overlays_) {
+    if (!custom_overlay.params_.send_shard(block_id.shard_full())) {
+      continue;
+    }
+    for (auto &[local_id, actor] : custom_overlay.actors_) {
+      auto P = td::PromiseCreator::lambda(
+          [SelfId = actor_id(this), block_id, priority, timeout, promise = std::move(promise),
+           name](td::Result<td::BufferSlice> R) mutable {
+            if (R.is_ok()) {
+              promise.set_value(R.move_as_ok());
+              return;
+            }
+            VLOG(FULL_NODE_DEBUG) << "failed to download block proof link " << block_id.to_str()
+                                  << " from custom overlay \"" << name << "\": " << R.move_as_error()
+                                  << "; falling back to public overlay";
+            td::actor::send_closure(SelfId, &FullNodeImpl::download_block_proof_link_from_public_overlay, block_id,
+                                    priority, timeout, std::move(promise));
+          });
+      td::actor::send_closure(actor, &FullNodeCustomOverlay::download_block_proof_link, block_id, priority, timeout,
+                              std::move(P));
+      return;
     }
   }
   download_block_proof_link_from_public_overlay(block_id, priority, timeout, std::move(promise));

--- a/validator/full-node.cpp
+++ b/validator/full-node.cpp
@@ -470,6 +470,38 @@ void FullNodeImpl::get_next_key_blocks(BlockIdExt block_id, td::Timestamp timeou
 
 void FullNodeImpl::download_archive(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix, std::string tmp_dir,
                                     td::Timestamp timeout, td::Promise<std::string> promise) {
+  if (client_.empty()) {
+    for (auto &[name, custom_overlay] : custom_overlays_) {
+      if (!custom_overlay.params_.send_shard(shard_prefix)) {
+        continue;
+      }
+      for (auto &[local_id, actor] : custom_overlay.actors_) {
+        auto P = td::PromiseCreator::lambda(
+            [SelfId = actor_id(this), masterchain_seqno, shard_prefix, tmp_dir = tmp_dir, timeout,
+             promise = std::move(promise), name](td::Result<std::string> R) mutable {
+              if (R.is_ok()) {
+                promise.set_value(R.move_as_ok());
+                return;
+              }
+              LOG(INFO) << "failed to download archive slice #" << masterchain_seqno << " " << shard_prefix.to_str()
+                        << " from custom overlay \"" << name << "\": " << R.move_as_error()
+                        << "; falling back to public overlay";
+              td::actor::send_closure(SelfId, &FullNodeImpl::download_archive_from_public_overlay,
+                                      masterchain_seqno, shard_prefix, std::move(tmp_dir), timeout,
+                                      std::move(promise));
+            });
+        td::actor::send_closure(actor, &FullNodeCustomOverlay::download_archive, masterchain_seqno, shard_prefix,
+                                std::move(tmp_dir), timeout, std::move(P));
+        return;
+      }
+    }
+  }
+  download_archive_from_public_overlay(masterchain_seqno, shard_prefix, std::move(tmp_dir), timeout, std::move(promise));
+}
+
+void FullNodeImpl::download_archive_from_public_overlay(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix,
+                                                        std::string tmp_dir, td::Timestamp timeout,
+                                                        td::Promise<std::string> promise) {
   auto shard = get_shard(shard_prefix, /* historical = */ true);
   if (shard.empty()) {
     VLOG(FULL_NODE_WARNING) << "dropping download archive query to unknown shard";
@@ -781,7 +813,7 @@ void FullNodeImpl::update_custom_overlay(CustomOverlayInfo &overlay) {
         auto adnl_sender = (params.use_quic_ ? td::actor::ActorId<adnl::AdnlSenderEx>{quic_} : rldp2_);
         overlay.actors_[local_id] = td::actor::create_actor<FullNodeCustomOverlay>(
             "CustomOverlay", local_id, params, zero_state_file_hash_, opts_, keyring_, adnl_, adnl_sender, overlays_,
-            validator_manager_, actor_id(this));
+            validator_manager_, actor_id(this), limiter_);
       }
     }
   };

--- a/validator/full-node.h
+++ b/validator/full-node.h
@@ -107,6 +107,8 @@ class FullNode : public td::actor::Actor {
   virtual void process_shard_block_info_broadcast(BlockIdExt block_id, CatchainSeqno cc_seqno,
                                                   td::BufferSlice data) = 0;
   virtual void get_out_msg_queue_query_token(td::Promise<std::unique_ptr<ActionToken>> promise) = 0;
+  virtual void download_next_block(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
+                                   td::Promise<ReceivedBlock> promise) = 0;
 
   virtual void set_validator_telemetry_filename(std::string value) = 0;
 

--- a/validator/full-node.h
+++ b/validator/full-node.h
@@ -60,7 +60,7 @@ struct FullNodeOptions {
   double public_broadcast_speed_multiplier_ = 1.0;
   double private_broadcast_speed_multiplier_ = 1.0;
   double fast_sync_broadcast_speed_multiplier_ = 1.0;
-  double initial_sync_delay_ = 60.0;
+  double initial_sync_delay_ = 0.0;
   double ratelimit_window_size_ = 1.0;
   size_t ratelimit_global_ = 96, ratelimit_heavy_ = 64, ratelimit_medium_ = 72;
 };

--- a/validator/full-node.hpp
+++ b/validator/full-node.hpp
@@ -135,6 +135,12 @@ class FullNodeImpl : public FullNode {
 
   td::actor::ActorId<FullNodeShard> get_shard(AccountIdPrefixFull dst);
   td::actor::ActorId<FullNodeShard> get_shard(ShardIdFull shard, bool historical = false);
+  void download_block_from_public_overlay(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
+                                          td::Promise<ReceivedBlock> promise);
+  void download_block_proof_from_public_overlay(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
+                                                td::Promise<td::BufferSlice> promise);
+  void download_block_proof_link_from_public_overlay(BlockIdExt block_id, td::uint32 priority, td::Timestamp timeout,
+                                                     td::Promise<td::BufferSlice> promise);
   void download_archive_from_public_overlay(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix,
                                             std::string tmp_dir, td::Timestamp timeout,
                                             td::Promise<std::string> promise);

--- a/validator/full-node.hpp
+++ b/validator/full-node.hpp
@@ -76,6 +76,8 @@ class FullNodeImpl : public FullNode {
   void send_broadcast(BlockBroadcast broadcast, int mode);
   void send_out_msg_queue_proof_broadcast(td::Ref<OutMsgQueueProofBroadcast> broadcats);
   void download_block(BlockIdExt id, td::uint32 priority, td::Timestamp timeout, td::Promise<ReceivedBlock> promise);
+  void download_next_block(BlockIdExt prev_id, td::uint32 priority, td::Timestamp timeout,
+                           td::Promise<ReceivedBlock> promise) override;
   void download_zero_state(BlockIdExt id, td::uint32 priority, td::Timestamp timeout,
                            td::Promise<td::BufferSlice> promise);
   void download_persistent_state(BlockIdExt id, BlockIdExt masterchain_block_id, PersistentStateType type,

--- a/validator/full-node.hpp
+++ b/validator/full-node.hpp
@@ -135,6 +135,9 @@ class FullNodeImpl : public FullNode {
 
   td::actor::ActorId<FullNodeShard> get_shard(AccountIdPrefixFull dst);
   td::actor::ActorId<FullNodeShard> get_shard(ShardIdFull shard, bool historical = false);
+  void download_archive_from_public_overlay(BlockSeqno masterchain_seqno, ShardIdFull shard_prefix,
+                                            std::string tmp_dir, td::Timestamp timeout,
+                                            td::Promise<std::string> promise);
   std::map<ShardIdFull, ShardInfo> shards_;
   int wc_monitor_min_split_ = 0;
 

--- a/validator/manager.cpp
+++ b/validator/manager.cpp
@@ -2147,7 +2147,7 @@ bool ValidatorManagerImpl::out_of_sync() {
   if (shard_client_handle_->id().seqno() + 16 < last_masterchain_seqno_) {
     return true;
   }
-  if (last_masterchain_block_handle_->unix_time() + 80 > td::Clocks::system()) {
+  if (last_masterchain_block_handle_->unix_time() + 8 > td::Clocks::system()) {
     return false;
   }
 

--- a/validator/net/download-archive-slice.cpp
+++ b/validator/net/download-archive-slice.cpp
@@ -35,7 +35,8 @@ DownloadArchiveSlice::DownloadArchiveSlice(
     overlay::OverlayIdShort overlay_id, adnl::AdnlNodeIdShort download_from, td::Timestamp timeout,
     td::actor::ActorId<ValidatorManagerInterface> validator_manager, td::actor::ActorId<adnl::AdnlSenderInterface> rldp,
     td::actor::ActorId<overlay::Overlays> overlays, td::actor::ActorId<adnl::Adnl> adnl,
-    td::actor::ActorId<adnl::AdnlExtClient> client, td::Promise<std::string> promise)
+    td::actor::ActorId<adnl::AdnlExtClient> client, td::Promise<std::string> promise,
+    std::vector<adnl::AdnlNodeIdShort> download_from_list, bool use_sender_for_prepare_query)
     : masterchain_seqno_(masterchain_seqno)
     , shard_prefix_(shard_prefix)
     , tmp_dir_(std::move(tmp_dir))
@@ -48,7 +49,12 @@ DownloadArchiveSlice::DownloadArchiveSlice(
     , overlays_(overlays)
     , adnl_(adnl)
     , client_(client)
-    , promise_(std::move(promise)) {
+    , promise_(std::move(promise))
+    , use_sender_for_prepare_query_(use_sender_for_prepare_query) {
+  if (!download_from.is_zero() || !download_from_list.empty()) {
+    original_zero_download_ = false;
+  }
+  download_from_list_ = std::move(download_from_list);
 }
 
 void DownloadArchiveSlice::abort_query(td::Status reason) {
@@ -86,7 +92,9 @@ void DownloadArchiveSlice::start_up() {
   fd_ = std::move(r.first);
   tmp_name_ = std::move(r.second);
 
-  if (download_from_.is_zero() && client_.empty()) {
+  if (!download_from_list_.empty()) {
+    got_node_to_download(std::move(download_from_list_));
+  } else if (download_from_.is_zero() && client_.empty()) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<std::vector<adnl::AdnlNodeIdShort>> R) {
       if (R.is_error()) {
         td::actor::send_closure(SelfId, &DownloadArchiveSlice::abort_query, R.move_as_error());
@@ -96,7 +104,7 @@ void DownloadArchiveSlice::start_up() {
           td::actor::send_closure(SelfId, &DownloadArchiveSlice::abort_query,
                                   td::Status::Error(ErrorCode::notready, "no nodes"));
         } else {
-          td::actor::send_closure(SelfId, &DownloadArchiveSlice::got_node_to_download, vec[0]);
+          td::actor::send_closure(SelfId, &DownloadArchiveSlice::got_node_to_download, std::move(vec));
         }
       }
     });
@@ -104,16 +112,37 @@ void DownloadArchiveSlice::start_up() {
     td::actor::send_closure(overlays_, &overlay::Overlays::get_overlay_random_peers, local_id_, overlay_id_, 1,
                             std::move(P));
   } else {
-    got_node_to_download(download_from_);
+    std::vector<adnl::AdnlNodeIdShort> tmp;
+    tmp.emplace_back(download_from_);
+    got_node_to_download(std::move(tmp));
   }
 }
 
-void DownloadArchiveSlice::got_node_to_download(adnl::AdnlNodeIdShort download_from) {
-  download_from_ = download_from;
+void DownloadArchiveSlice::got_node_to_download(std::vector<adnl::AdnlNodeIdShort> download_from) {
+  if (download_from.empty()) {
+    abort_query(td::Status::Error(ErrorCode::notready, "no nodes"));
+    return;
+  }
+  download_from_list_ = std::move(download_from);
+  try_download(0);
+}
 
-  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::BufferSlice> R) {
+void DownloadArchiveSlice::try_download(int index) {
+  download_from_ = download_from_list_[index];
+
+  if (index > 0) {
+    LOG(WARNING) << "Try to download archive slice from random node #" << index << " : " << download_from_;
+  }
+
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), index,
+                                       total_nodes = static_cast<int>(download_from_list_.size())](
+                                          td::Result<td::BufferSlice> R) {
     if (R.is_error()) {
-      td::actor::send_closure(SelfId, &DownloadArchiveSlice::abort_query, R.move_as_error());
+      if (index + 1 >= total_nodes) {
+        td::actor::send_closure(SelfId, &DownloadArchiveSlice::abort_query, R.move_as_error());
+      } else {
+        td::actor::send_closure(SelfId, &DownloadArchiveSlice::try_download, index + 1);
+      }
     } else {
       td::actor::send_closure(SelfId, &DownloadArchiveSlice::got_archive_info, R.move_as_ok());
     }
@@ -127,12 +156,18 @@ void DownloadArchiveSlice::got_node_to_download(adnl::AdnlNodeIdShort download_f
                                                                          create_tl_shard_id(shard_prefix_));
   }
   if (client_.empty()) {
-    td::actor::send_closure(overlays_, &overlay::Overlays::send_query, download_from_, local_id_, overlay_id_,
-                            "get_archive_info", std::move(P), td::Timestamp::in(3.0), std::move(q));
+    if (use_sender_for_prepare_query_) {
+      td::actor::send_closure(overlays_, &overlay::Overlays::send_query_via, download_from_, local_id_, overlay_id_,
+                              "get_archive_info", std::move(P), td::Timestamp::in(5.0), std::move(q),
+                              adnl::Adnl::huge_packet_max_size(), rldp_);
+    } else {
+      td::actor::send_closure(overlays_, &overlay::Overlays::send_query, download_from_, local_id_, overlay_id_,
+                              "get_archive_info", std::move(P), td::Timestamp::in(5.0), std::move(q));
+    }
   } else {
     td::actor::send_closure(client_, &adnl::AdnlExtClient::send_query, "get_archive_info",
                             create_serialize_tl_object_suffix<ton_api::tonNode_query>(std::move(q)),
-                            td::Timestamp::in(1.0), std::move(P));
+                            td::Timestamp::in(3.0), std::move(P));
   }
 }
 

--- a/validator/net/download-archive-slice.cpp
+++ b/validator/net/download-archive-slice.cpp
@@ -36,7 +36,8 @@ DownloadArchiveSlice::DownloadArchiveSlice(
     td::actor::ActorId<ValidatorManagerInterface> validator_manager, td::actor::ActorId<adnl::AdnlSenderInterface> rldp,
     td::actor::ActorId<overlay::Overlays> overlays, td::actor::ActorId<adnl::Adnl> adnl,
     td::actor::ActorId<adnl::AdnlExtClient> client, td::Promise<std::string> promise,
-    std::vector<adnl::AdnlNodeIdShort> download_from_list, bool use_sender_for_prepare_query)
+    std::vector<adnl::AdnlNodeIdShort> download_from_list, bool use_sender_for_prepare_query,
+    bool use_sender_for_slice_query, bool resolve_peers_before_download)
     : masterchain_seqno_(masterchain_seqno)
     , shard_prefix_(shard_prefix)
     , tmp_dir_(std::move(tmp_dir))
@@ -50,7 +51,9 @@ DownloadArchiveSlice::DownloadArchiveSlice(
     , adnl_(adnl)
     , client_(client)
     , promise_(std::move(promise))
-    , use_sender_for_prepare_query_(use_sender_for_prepare_query) {
+    , use_sender_for_prepare_query_(use_sender_for_prepare_query)
+    , use_sender_for_slice_query_(use_sender_for_slice_query)
+    , resolve_peers_before_download_(resolve_peers_before_download) {
   if (!download_from.is_zero() || !download_from_list.empty()) {
     original_zero_download_ = false;
   }
@@ -124,6 +127,58 @@ void DownloadArchiveSlice::got_node_to_download(std::vector<adnl::AdnlNodeIdShor
     return;
   }
   download_from_list_ = std::move(download_from);
+  if (resolve_peers_before_download_ && client_.empty()) {
+    resolve_download_peers();
+    return;
+  }
+  try_download(0);
+}
+
+void DownloadArchiveSlice::resolve_download_peers() {
+  resolved_download_from_list_.clear();
+  resolving_peers_ = download_from_list_.size();
+  if (resolving_peers_ == 0) {
+    abort_query(td::Status::Error(ErrorCode::notready, "no nodes"));
+    return;
+  }
+
+  LOG(INFO) << "Resolving " << resolving_peers_ << " archive download peers via DHT for slice #"
+            << masterchain_seqno_ << " " << shard_prefix_.to_str();
+  for (const auto &peer : download_from_list_) {
+    td::actor::send_closure(
+        adnl_, &adnl::Adnl::get_peer_node, local_id_, peer,
+        [SelfId = actor_id(this), peer](td::Result<adnl::AdnlNode> R) mutable {
+          td::actor::send_closure(SelfId, &DownloadArchiveSlice::got_resolved_download_peer, peer, std::move(R));
+        });
+  }
+}
+
+void DownloadArchiveSlice::got_resolved_download_peer(adnl::AdnlNodeIdShort peer,
+                                                      td::Result<adnl::AdnlNode> result) {
+  if (result.is_ok()) {
+    auto node = result.move_as_ok();
+    LOG(INFO) << "Resolved archive download peer " << peer << " addr_count=" << node.addr_list().size()
+              << " for slice #" << masterchain_seqno_ << " " << shard_prefix_.to_str();
+    resolved_download_from_list_.push_back(peer);
+  } else {
+    LOG(INFO) << "Failed to resolve archive download peer " << peer << " for slice #" << masterchain_seqno_ << " "
+              << shard_prefix_.to_str() << ": " << result.move_as_error();
+  }
+
+  CHECK(resolving_peers_ > 0);
+  --resolving_peers_;
+  if (resolving_peers_ != 0) {
+    return;
+  }
+
+  if (resolved_download_from_list_.empty()) {
+    abort_query(td::Status::Error(ErrorCode::notready, "no resolved custom archive peers"));
+    return;
+  }
+
+  download_from_list_ = std::move(resolved_download_from_list_);
+  LOG(INFO) << "Trying archive slice #" << masterchain_seqno_ << " " << shard_prefix_.to_str() << " from "
+            << download_from_list_.size() << " resolved peers";
   try_download(0);
 }
 
@@ -207,9 +262,14 @@ void DownloadArchiveSlice::get_archive_slice() {
 
   auto q = create_serialize_tl_object<ton_api::tonNode_getArchiveSlice>(archive_id_, offset_, slice_size());
   if (client_.empty()) {
-    td::actor::send_closure(overlays_, &overlay::Overlays::send_query_via, download_from_, local_id_, overlay_id_,
-                            "get_archive_slice", std::move(P), td::Timestamp::in(15.0), std::move(q),
-                            slice_size() + 1024, rldp_);
+    if (use_sender_for_slice_query_) {
+      td::actor::send_closure(overlays_, &overlay::Overlays::send_query_via, download_from_, local_id_, overlay_id_,
+                              "get_archive_slice", std::move(P), td::Timestamp::in(15.0), std::move(q),
+                              slice_size() + 1024, rldp_);
+    } else {
+      td::actor::send_closure(overlays_, &overlay::Overlays::send_query, download_from_, local_id_, overlay_id_,
+                              "get_archive_slice", std::move(P), td::Timestamp::in(15.0), std::move(q));
+    }
   } else {
     td::actor::send_closure(client_, &adnl::AdnlExtClient::send_query, "get_archive_slice",
                             create_serialize_tl_object_suffix<ton_api::tonNode_query>(std::move(q)),

--- a/validator/net/download-archive-slice.hpp
+++ b/validator/net/download-archive-slice.hpp
@@ -18,6 +18,8 @@
 */
 #pragma once
 
+#include <vector>
+
 #include "adnl/adnl-ext-client.h"
 #include "overlay/overlays.h"
 #include "td/utils/port/FileFd.h"
@@ -38,17 +40,20 @@ class DownloadArchiveSlice : public td::actor::Actor {
                        td::actor::ActorId<ValidatorManagerInterface> validator_manager,
                        td::actor::ActorId<adnl::AdnlSenderInterface> rldp,
                        td::actor::ActorId<overlay::Overlays> overlays, td::actor::ActorId<adnl::Adnl> adnl,
-                       td::actor::ActorId<adnl::AdnlExtClient> client, td::Promise<std::string> promise);
+                       td::actor::ActorId<adnl::AdnlExtClient> client, td::Promise<std::string> promise,
+                       std::vector<adnl::AdnlNodeIdShort> download_from_list = {},
+                       bool use_sender_for_prepare_query = false);
 
   void abort_query(td::Status reason);
   void alarm() override;
   void finish_query();
 
   void start_up() override;
-  void got_node_to_download(adnl::AdnlNodeIdShort node);
+  void got_node_to_download(std::vector<adnl::AdnlNodeIdShort> node);
   void got_archive_info(td::BufferSlice data);
   void get_archive_slice();
   void got_archive_slice(td::BufferSlice data);
+  void try_download(int index);
 
   static constexpr td::uint32 slice_size() {
     return 1 << 21;
@@ -64,8 +69,10 @@ class DownloadArchiveSlice : public td::actor::Actor {
   overlay::OverlayIdShort overlay_id_;
   td::uint64 offset_ = 0;
   td::uint64 archive_id_;
+  bool original_zero_download_ = true;
 
   adnl::AdnlNodeIdShort download_from_ = adnl::AdnlNodeIdShort::zero();
+  std::vector<adnl::AdnlNodeIdShort> download_from_list_;
 
   td::Timestamp timeout_;
   td::actor::ActorId<ValidatorManagerInterface> validator_manager_;
@@ -74,6 +81,7 @@ class DownloadArchiveSlice : public td::actor::Actor {
   td::actor::ActorId<adnl::Adnl> adnl_;
   td::actor::ActorId<adnl::AdnlExtClient> client_;
   td::Promise<std::string> promise_;
+  bool use_sender_for_prepare_query_ = false;
 
   td::uint64 prev_logged_sum_ = 0;
   td::Timer prev_logged_timer_;

--- a/validator/net/download-archive-slice.hpp
+++ b/validator/net/download-archive-slice.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "adnl/adnl-ext-client.h"
+#include "adnl/adnl-node.h"
 #include "overlay/overlays.h"
 #include "td/utils/port/FileFd.h"
 #include "ton/ton-types.h"
@@ -42,7 +43,8 @@ class DownloadArchiveSlice : public td::actor::Actor {
                        td::actor::ActorId<overlay::Overlays> overlays, td::actor::ActorId<adnl::Adnl> adnl,
                        td::actor::ActorId<adnl::AdnlExtClient> client, td::Promise<std::string> promise,
                        std::vector<adnl::AdnlNodeIdShort> download_from_list = {},
-                       bool use_sender_for_prepare_query = false);
+                       bool use_sender_for_prepare_query = false, bool use_sender_for_slice_query = true,
+                       bool resolve_peers_before_download = false);
 
   void abort_query(td::Status reason);
   void alarm() override;
@@ -54,6 +56,8 @@ class DownloadArchiveSlice : public td::actor::Actor {
   void get_archive_slice();
   void got_archive_slice(td::BufferSlice data);
   void try_download(int index);
+  void resolve_download_peers();
+  void got_resolved_download_peer(adnl::AdnlNodeIdShort peer, td::Result<adnl::AdnlNode> result);
 
   static constexpr td::uint32 slice_size() {
     return 1 << 21;
@@ -82,6 +86,10 @@ class DownloadArchiveSlice : public td::actor::Actor {
   td::actor::ActorId<adnl::AdnlExtClient> client_;
   td::Promise<std::string> promise_;
   bool use_sender_for_prepare_query_ = false;
+  bool use_sender_for_slice_query_ = true;
+  bool resolve_peers_before_download_ = false;
+  size_t resolving_peers_ = 0;
+  std::vector<adnl::AdnlNodeIdShort> resolved_download_from_list_;
 
   td::uint64 prev_logged_sum_ = 0;
   td::Timer prev_logged_timer_;

--- a/validator/shard-client.cpp
+++ b/validator/shard-client.cpp
@@ -131,6 +131,11 @@ void ShardClient::saved_to_db() {
   if (!started_) {
     return;
   }
+  waiting_ = true;
+  if (try_apply_pending_masterchain_block()) {
+    return;
+  }
+  waiting_ = false;
   if (masterchain_block_handle_->inited_next_left()) {
     new_masterchain_block_id(masterchain_block_handle_->one_next(true));
   } else {
@@ -228,20 +233,51 @@ void ShardClient::downloaded_shard_state(td::Ref<ShardState> state, td::Promise<
 }
 
 void ShardClient::new_masterchain_block_notification(BlockHandle handle, td::Ref<MasterchainState> state) {
-  if (!waiting_) {
+  if (!masterchain_block_handle_ || handle->id().id.seqno <= masterchain_block_handle_->id().id.seqno) {
     return;
   }
-  if (handle->id().id.seqno <= masterchain_block_handle_->id().id.seqno) {
-    return;
+  pending_masterchain_notifications_[handle->id().id.seqno] = std::make_pair(std::move(handle), std::move(state));
+  prune_pending_masterchain_notifications();
+  if (waiting_) {
+    try_apply_pending_masterchain_block();
   }
-  LOG_CHECK(masterchain_block_handle_->inited_next_left()) << handle->id() << " " << masterchain_block_handle_->id();
-  LOG_CHECK(masterchain_block_handle_->one_next(true) == handle->id())
-      << handle->id() << " " << masterchain_block_handle_->id();
-  masterchain_block_handle_ = std::move(handle);
-  masterchain_state_ = std::move(state);
-  waiting_ = false;
+}
 
+bool ShardClient::try_apply_pending_masterchain_block() {
+  if (!waiting_ || !masterchain_block_handle_ || !masterchain_block_handle_->inited_next_left()) {
+    return false;
+  }
+  auto next_id = masterchain_block_handle_->one_next(true);
+  auto it = pending_masterchain_notifications_.find(next_id.id.seqno);
+  if (it == pending_masterchain_notifications_.end()) {
+    return false;
+  }
+  if (it->second.first->id() != next_id) {
+    LOG(WARNING) << "dropping buffered masterchain notification " << it->second.first->id().to_str()
+                 << ", expected " << next_id.to_str();
+    pending_masterchain_notifications_.erase(it);
+    return false;
+  }
+  VLOG(VALIDATOR_DEBUG) << "using buffered masterchain notification " << next_id.to_str();
+  masterchain_block_handle_ = std::move(it->second.first);
+  masterchain_state_ = std::move(it->second.second);
+  pending_masterchain_notifications_.erase(it);
+  waiting_ = false;
   apply_all_shards();
+  return true;
+}
+
+void ShardClient::prune_pending_masterchain_notifications() {
+  if (masterchain_block_handle_) {
+    auto current_seqno = masterchain_block_handle_->id().id.seqno;
+    while (!pending_masterchain_notifications_.empty() &&
+           pending_masterchain_notifications_.begin()->first <= current_seqno) {
+      pending_masterchain_notifications_.erase(pending_masterchain_notifications_.begin());
+    }
+  }
+  while (pending_masterchain_notifications_.size() > MAX_PENDING_MASTERCHAIN_NOTIFICATIONS) {
+    pending_masterchain_notifications_.erase(std::prev(pending_masterchain_notifications_.end()));
+  }
 }
 
 void ShardClient::get_processed_masterchain_block(td::Promise<BlockSeqno> promise) {

--- a/validator/shard-client.hpp
+++ b/validator/shard-client.hpp
@@ -35,7 +35,7 @@ class ShardClient : public td::actor::Actor {
     BlockIdExt shard;
     td::uint32 split_depth;
   };
-  static constexpr std::size_t MAX_PENDING_MASTERCHAIN_NOTIFICATIONS = 16;
+  static constexpr std::size_t MAX_PENDING_MASTERCHAIN_NOTIFICATIONS = 64;
 
   td::Ref<ValidatorManagerOptions> opts_;
 

--- a/validator/shard-client.hpp
+++ b/validator/shard-client.hpp
@@ -18,6 +18,9 @@
 */
 #pragma once
 
+#include <cstddef>
+#include <iterator>
+#include <map>
 #include <set>
 
 #include "interfaces/validator-manager.h"
@@ -32,11 +35,13 @@ class ShardClient : public td::actor::Actor {
     BlockIdExt shard;
     td::uint32 split_depth;
   };
+  static constexpr std::size_t MAX_PENDING_MASTERCHAIN_NOTIFICATIONS = 16;
 
   td::Ref<ValidatorManagerOptions> opts_;
 
   BlockHandle masterchain_block_handle_;
   td::Ref<MasterchainState> masterchain_state_;
+  std::map<BlockSeqno, std::pair<BlockHandle, td::Ref<MasterchainState>>> pending_masterchain_notifications_;
 
   std::vector<td::actor::ActorOwn<ShardClient>> children_;
 
@@ -86,6 +91,8 @@ class ShardClient : public td::actor::Actor {
   void saved_to_db();
 
   void new_masterchain_block_notification(BlockHandle handle, td::Ref<MasterchainState> state);
+  bool try_apply_pending_masterchain_block();
+  void prune_pending_masterchain_notifications();
 
   void get_processed_masterchain_block(td::Promise<BlockSeqno> promise);
   void get_processed_masterchain_block_id(td::Promise<BlockIdExt> promise);


### PR DESCRIPTION
## Summary

This PR makes custom overlays usable for validator recovery and catch-up, not only for live block broadcasts.

The main goal is to let operators with trusted/private archive nodes recover faster after restart while preserving the public overlay as the fallback path. A node can first try custom overlay peers for archive slices, block downloads, and next-block catch-up; if that path is unavailable or returns an error, the existing public overlay path remains available.

## What changed

- Custom overlays now answer archive and block sync queries:
  - `getArchiveInfo`, `getShardArchiveInfo`, `getArchiveSlice`
  - `downloadBlockFull`, `downloadNextBlockFull`
  - block proof/proof-link preparation and download queries
- Full node recovery now tries custom overlay peers for:
  - archive slice download
  - block download
  - next-block catch-up
  - block proof/proof-link downloads
- Custom archive recovery can resolve configured ADNL peers through DHT before downloading, so a custom overlay config with short ADNL ids can still be used for direct peer downloads.
- Public overlay fallback is kept for unsupported shards, unavailable custom actors, failed custom downloads, or missing peers.
- Shard client now buffers masterchain notifications that arrive while it is busy, then applies the exact next pending notification after saving state to DB. This avoids dropping live MC notifications during archive-to-live handoff.
- Archive recovery stays closer to live before handoff (`80s` freshness window reduced to `8s`) to reduce the post-archive live sync gap.

## Why

Before this change, custom overlays could carry live block broadcasts but could not serve archive recovery queries. A restarted node could see fresh private-overlay broadcasts but still had to fill historical gaps through public overlay peers. During the handoff from archive recovery to live sync, shard-client could also drop fresh masterchain notifications while busy and later rediscover them through the slower state-wait path.

With this PR, private/custom overlay peers can participate in the full restart recovery path, while public overlay behavior remains the safety net.

## Safety

- Custom overlay downloads only change peer selection and transport path.
- Downloaded archives, blocks, proofs, and states still go through the existing validation/import paths.
- Shard-client pending notification storage is bounded and only applies the exact next masterchain block id.
- Public overlay fallback remains available when custom sync is not possible.

## Validation

Built locally from `testnet` with:

```bash
SDKROOT=$(xcrun --show-sdk-path) LC_ALL=C LANG=C cmake -S . -B build-testnet-baseline -DCMAKE_BUILD_TYPE=Release -DTON_USE_JEMALLOC=OFF
SDKROOT=$(xcrun --show-sdk-path) LC_ALL=C LANG=C cmake --build build-testnet-baseline --target validator-engine validator -j6
```

Both `validator-engine` and `validator` built successfully before and after the patch.
