### PR TITLE
http: reject CR/LF in request url and response reason phrase

### DIFF
--- a/http/http.cpp
+++ b/http/http.cpp
@@ -146,6 +146,16 @@ td::Result<std::unique_ptr<HttpRequest>> HttpRequest::create(std::string method,
     return td::Status::Error(PSTRING() << "unsupported http method '" << method << "'");
   }
 
+  // The request line is later re-serialized verbatim ("method url proto\r\n").
+  // CR/LF in the url would let an upstream-supplied value inject extra request
+  // lines into the downstream connection (request smuggling), so reject them
+  // here - the same way HttpHeader::basic_check() guards header values.
+  for (const auto &c : url) {
+    if (c == '\r' || c == '\n') {
+      return td::Status::Error("bad character in url");
+    }
+  }
+
   return std::make_unique<HttpRequest>(std::move(method), std::move(url), std::move(proto_version));
 }
 
@@ -762,6 +772,17 @@ td::Result<std::unique_ptr<HttpResponse>> HttpResponse::create(std::string proto
 
   if (code < 100 || code > 999) {
     return td::Status::Error(PSTRING() << "bad status code '" << code << "'");
+  }
+
+  // The status line is later re-serialized verbatim ("proto code reason\r\n").
+  // CR/LF in the reason phrase would let an upstream-supplied value inject
+  // extra header/response lines into the downstream connection (response
+  // splitting), so reject them here - as HttpHeader::basic_check() does for
+  // header values.
+  for (const auto &c : reason) {
+    if (c == '\r' || c == '\n') {
+      return td::Status::Error("bad character in reason phrase");
+    }
   }
 
   return std::make_unique<HttpResponse>(std::move(proto_version), code, std::move(reason), force_no_payload, keep_alive,

--- a/test/test-http.cpp
+++ b/test/test-http.cpp
@@ -302,6 +302,31 @@ int main(int argc, char *argv[]) {
     dump_reader(ro);
   }
 
+  {
+    // The request-line url and the response reason phrase are re-serialized
+    // verbatim into the first line, so CR/LF in them must be rejected at
+    // creation time, otherwise an upstream-supplied value could smuggle extra
+    // request/response lines into the downstream connection.
+    using ton::http::HttpRequest;
+    using ton::http::HttpResponse;
+
+    // Clean values are still accepted.
+    HttpRequest::create("GET", "/index.html", "HTTP/1.1").ensure();
+    HttpResponse::create("HTTP/1.1", 200, "OK", false, true).ensure();
+
+    // CR/LF in the url is rejected (request smuggling).
+    HttpRequest::create("GET", "/x\r\nGET /admin HTTP/1.1", "HTTP/1.1").ensure_error();
+    HttpRequest::create("GET", "/x\nInjected: 1", "HTTP/1.1").ensure_error();
+    HttpRequest::create("GET", "/x\rInjected: 1", "HTTP/1.1").ensure_error();
+
+    // CR/LF in the reason phrase is rejected (response splitting).
+    HttpResponse::create("HTTP/1.1", 200, "OK\r\nSet-Cookie: x=1", false, true).ensure_error();
+    HttpResponse::create("HTTP/1.1", 200, "OK\nSet-Cookie: x=1", false, true).ensure_error();
+    HttpResponse::create("HTTP/1.1", 200, "OK\rSet-Cookie: x=1", false, true).ensure_error();
+
+    LOG(INFO) << "CR/LF rejection in request url and response reason: OK";
+  }
+
   std::_Exit(0);
   return 0;
 }


### PR DESCRIPTION
## What

Reject CR/LF in the HTTP request-line `url` and the response `reason` phrase at construction time.

## Why

`HttpRequest::store_http` / `HttpResponse::store_http` write `url` and `reason` verbatim into the first line of the serialized message (`METHOD url PROTO\r\n` and `PROTO code reason\r\n`). Header names and values are already checked for CR/LF in `HttpHeader::basic_check()`, but `url` and `reason` are not validated anywhere.

This matters because `rldp-http-proxy` rebuilds an `HttpRequest`/`HttpResponse` directly from the TL fields (`http_request.url` / `http_response.reason`) and re-serializes it onto a downstream plain-HTTP connection without ever re-parsing. A CR/LF in those upstream-supplied fields therefore injects extra request/response lines into the downstream connection - request smuggling on the gateway side, response splitting on the client side. The headers can't be abused this way because `basic_check()` already rejects CR/LF there; the request-line `url` and the status-line `reason` are the only unchecked fields on the first line.

## Change

- `HttpRequest::create` rejects CR/LF in `url`
- `HttpResponse::create` rejects CR/LF in `reason`
- both checks live in `create()` so every construction path (the line parser and the proxy's TL-based reconstruction) is covered, mirroring the existing header check
- test added in `test/test-http.cpp`

Legitimate traffic is unaffected: a url or reason phrase never contains a raw CR/LF, and the line parser strips the line terminator before calling `create()`.
