### PR TITLE
Do not constrain unknown flags to 0 in param 30

### DIFF
--- a/crypto/block/block.tlb
+++ b/crypto/block/block.tlb
@@ -787,11 +787,11 @@ consensus_config_v4#d9 flags:(## 6) { flags = 0 } use_quic:Bool new_catchain_ids
 _ CatchainConfig = ConfigParam 28;
 _ ConsensusConfig = ConfigParam 29;
 
-simplex_config#21 flags:(## 7) { flags = 0 } use_quic:Bool
+simplex_config#21 flags:(## 7) use_quic:Bool
   target_rate_ms:uint32 slots_per_leader_window:(## 32) { slots_per_leader_window >= 1 }
   first_block_timeout_ms:uint32 max_leader_window_desync:uint32 = NewConsensusConfig;
 simplex_config_v2#22
-  flags:(## 6) { flags = 0 }
+  flags:(## 6)
   enable_block_observers:Bool
   use_quic:Bool
   slots_per_leader_window:(## 32) { slots_per_leader_window >= 1 }


### PR DESCRIPTION
We would otherwise actively and "maliciously" break "view config" option in slightly outdated blockchain-explorer.