### PR TITLE
Replace QuicConnectionPImpl::PrivateTag with td::Badge

### DIFF
--- a/quic/quic-pimpl.cpp
+++ b/quic/quic-pimpl.cpp
@@ -43,8 +43,8 @@ static void apply_platform_pmtu_policy(ngtcp2_settings& settings) {
 td::Result<std::unique_ptr<QuicConnectionPImpl>> QuicConnectionPImpl::create_client(
     const td::IPAddress& local_address, const td::IPAddress& remote_address, const td::Ed25519::PrivateKey& client_key,
     td::Slice alpn, td::Slice sni, std::unique_ptr<Callback> callback, QuicConnectionOptions options) {
-  auto p_impl =
-      std::make_unique<QuicConnectionPImpl>(PrivateTag{}, local_address, remote_address, std::move(callback), options);
+  auto p_impl = std::make_unique<QuicConnectionPImpl>(td::Badge<QuicConnectionPImpl>{}, local_address, remote_address,
+                                                      std::move(callback), options);
 
   TRY_STATUS(p_impl->init_tls_client_rpk(client_key, alpn, sni));
   TRY_STATUS(p_impl->init_quic_client());
@@ -61,8 +61,8 @@ td::Result<std::unique_ptr<QuicConnectionPImpl>> QuicConnectionPImpl::create_ser
   CHECK(identities.not_null());
   CHECK(identities->has_default());
 
-  auto p_impl =
-      std::make_unique<QuicConnectionPImpl>(PrivateTag{}, local_address, remote_address, std::move(callback), options);
+  auto p_impl = std::make_unique<QuicConnectionPImpl>(td::Badge<QuicConnectionPImpl>{}, local_address, remote_address,
+                                                      std::move(callback), options);
 
   TRY_STATUS(p_impl->init_tls_server_rpk(std::move(identities), alpn));
   TRY_STATUS(p_impl->init_quic_server(initial));

--- a/quic/quic-pimpl.h
+++ b/quic/quic-pimpl.h
@@ -15,6 +15,7 @@
 #include "ngtcp2/ngtcp2.h"
 #include "ngtcp2/ngtcp2_crypto.h"
 #include "ngtcp2/ngtcp2_crypto_ossl.h"
+#include "td/utils/Badge.h"
 #include "td/utils/Time.h"
 #include "td/utils/port/UdpSocketFd.h"
 
@@ -162,10 +163,9 @@ struct QuicConnectionPImpl {
     virtual ~Callback() = default;
   };
 
-  struct PrivateTag {};
-
-  QuicConnectionPImpl(PrivateTag, const td::IPAddress& local_address, const td::IPAddress& remote_address,
-                      std::unique_ptr<Callback> callback, QuicConnectionOptions options)
+  QuicConnectionPImpl(td::Badge<QuicConnectionPImpl>, const td::IPAddress& local_address,
+                      const td::IPAddress& remote_address, std::unique_ptr<Callback> callback,
+                      QuicConnectionOptions options)
       : local_address_(local_address)
       , remote_address_(remote_address)
       , callback_(std::move(callback))


### PR DESCRIPTION
Apart from being strictly worse than td::Badge, the private tag wasn't actually private.