### PR TITLE
Tolk v1.4.2: rename TON to GRAM

### DIFF
--- a/crypto/smartcont/tolk-stdlib/common.tolk
+++ b/crypto/smartcont/tolk-stdlib/common.tolk
@@ -68,8 +68,8 @@ type intN = builtin
 /// overflow will happen at serialization to a cell/builder, NOT at assignment. 
 type uintN = builtin
 
-/// `coins` is a special primitive representing "nanotoncoins". One TON = 10^9 nanotoncoins.
-/// You can create coins with `ton()` function: `ton("0.05")` (actually, `int` 50000000 at runtime).
+/// `coins` is a special primitive representing "nanograms". One GRAM = 10^9 nanograms.
+/// You can create coins with `grams()` function: `grams("0.05")` (actually, `int` 50000000 at runtime).
 /// Arithmetic operations on `coins` degrade to 257-bit `int` type.
 type coins = builtin
 
@@ -279,9 +279,15 @@ fun T.fromTuple(packedObject: array<unknown>): T
     Mathematical primitives.
  */
 
-/// Converts a constant floating-point string to nanotoncoins.
-/// Example: `ton("0.05")` is equal to 50000000.
-/// Note, that `ton()` requires a constant string; `ton(some_var)` is an error.
+/// Converts a constant floating-point string to nanograms.
+/// Example: `grams("0.05")` is equal to 50000000.
+/// Note, that `grams()` requires a constant string; `grams(some_var)` is an error.
+@pure
+fun grams(floatString: string): coins
+    builtin
+
+/// Deprecated alias for [grams].
+/// From Tolk v1.5, it will become @deprecated("""use `grams("0.05")` instead of `ton("0.05")`""")
 @pure
 fun ton(floatString: string): coins
     builtin
@@ -358,7 +364,7 @@ struct contract
 fun contract.getAddress(): address
     asm "MYADDR"
 
-/// Returns the balance (in nanotoncoins) of the smart contract at the start of Computation Phase.
+/// Returns the balance (in nanograms) of the smart contract at the start of Computation Phase.
 @pure
 fun contract.getOriginalBalance(): coins
     asm "BALANCE" "FIRST"
@@ -1204,7 +1210,7 @@ fun slice.preloadUint(self, len: int): int
 fun slice.preloadBits(self, len: int): slice
     builtin
 
-/// Loads the serialized amount of nanotoncoins (any unsigned integer up to `2^120 - 1`).
+/// Loads the serialized amount of nanograms (any unsigned integer up to `2^120 - 1`).
 @pure
 fun slice.loadCoins(mutate self): coins
     asm( -> 1 0) "LDGRAMS"
@@ -1346,7 +1352,7 @@ fun builder.storeAddressAny(mutate self, addrAny: any_address): self
 fun builder.storeAddressNone(mutate self): self
     asm "b{00} STSLICECONST"
 
-/// Stores the amount of nanotoncoins into a builder.
+/// Stores the amount of nanograms into a builder.
 @pure
 fun builder.storeCoins(mutate self, x: coins): self
     builtin
@@ -1523,10 +1529,10 @@ fun slice.loadAddressAny(mutate self): any_address
 
 
 /**
-    Reserving Toncoins on balance and its flags.
+    Reserving GRAMs on balance and its flags.
  */
 
-/// mode = 0: Reserve exact amount of nanotoncoins
+/// mode = 0: Reserve exact amount of nanograms
 const RESERVE_MODE_EXACT_AMOUNT = 0
 /// +1: Actually reserves all but amount, meaning `currentContractBalance - amount`
 const RESERVE_MODE_ALL_BUT_AMOUNT = 1
@@ -1539,14 +1545,19 @@ const RESERVE_MODE_NEGATE_AMOUNT = 8
 /// +16: If this action fails, the transaction will be bounced.
 const RESERVE_MODE_BOUNCE_ON_ACTION_FAIL = 16
 
-/// Creates an output action which would reserve Toncoins on balance.
+/// Creates an output action which would reserve GRAMs on balance.
 /// For `reserveMode` consider constants above.
-fun reserveToncoinsOnBalance(nanoTonCoins: coins, reserveMode: int): void
+fun reserveGramsOnBalance(nanoGrams: coins, reserveMode: int): void
     asm "RAWRESERVE"
 
-/// Similar to [reserveToncoinsOnBalance], but also accepts a dictionary extraAmount (represented by a cell or null)
-/// with extra currencies. In this way currencies other than Toncoin can be reserved.
-fun reserveExtraCurrenciesOnBalance(nanoTonCoins: coins, extraAmount: dict, reserveMode: int): void
+/// Deprecated alias for [reserveGramsOnBalance].
+@deprecated("use `reserveGramsOnBalance` instead of `reserveToncoinsOnBalance`")
+fun reserveToncoinsOnBalance(nanoGrams: coins, reserveMode: int): void
+    asm "RAWRESERVE"
+
+/// Similar to [reserveGramsOnBalance], but also accepts a dictionary extraAmount (represented by a cell or null)
+/// with extra currencies. In this way currencies other than GRAM can be reserved.
+fun reserveExtraCurrenciesOnBalance(nanoGrams: coins, extraAmount: dict, reserveMode: int): void
     asm "RAWRESERVEX"
 
 
@@ -1579,7 +1590,7 @@ const SEND_MODE_ESTIMATE_FEE_ONLY = 1024
 /// +64 substitutes the entire balance of the incoming message as an outgoing value (slightly inaccurate, gas expenses that cannot be estimated before the computation is completed are not taken into account).
 /// +128 substitutes the value of the entire balance of the contract before the start of the computation phase (slightly inaccurate, since gas expenses that cannot be estimated before the completion of the computation phase are not taken into account).
 
-/// `ExtraCurrenciesMap` represents a dictionary of "extra currencies" other than TON coin.
+/// `ExtraCurrenciesMap` represents a dictionary of "extra currencies" other than GRAM.
 /// They can be attached to a message (incoming and outgoing) and stored on contract's balance.
 /// It's a dictionary `[currencyID => amount]` (amount is like `coins`, but encoded with a high precision). 
 type ExtraCurrenciesMap = map<int32, varuint32>
@@ -1688,7 +1699,7 @@ type OldBounceMode = bool
 struct CreateMessageOptions<TBody = void> {
     /// whether a message will bounce back on error, and what piece of outgoing `body` it will contain
     bounce: BounceMode | OldBounceMode
-    /// message value: attached tons (or tons + extra currencies)
+    /// message value: attached grams (or grams + extra currencies)
     value: coins | (coins, ExtraCurrenciesMap)
     /// destination is either a provided address, or is auto-calculated by stateInit
     dest: address               // either just send a message to some address
@@ -1704,7 +1715,7 @@ struct CreateMessageOptions<TBody = void> {
 /// ```
 /// val reply = createMessage({
 ///     bounce: BounceMode.NoBounce,
-///     value: ton("0.05"),
+///     value: grams("0.05"),
 ///     dest: senderAddress,
 ///     body: RequestedInfo { ... }    // note: no toCell! just pass an object
 /// });
@@ -1910,7 +1921,7 @@ fun sendRawMessage(msg: cell, mode: int): void
 /// ```
 struct InMessage {
     senderAddress: address          // an internal address from which the message arrived
-    valueCoins: coins               // ton amount attached to an incoming message
+    valueCoins: coins               // GRAM amount attached to an incoming message
     valueExtra: ExtraCurrenciesMap  // extra currencies attached to an incoming message
     originalForwardFee: coins       // fee that was paid by the sender
     createdLt: uint64               // logical time when a message was created
@@ -1931,7 +1942,7 @@ struct InMessage {
 /// ```
 struct InMessageBounced {
     senderAddress: address          // an internal address from which the message was bounced
-    valueCoins: coins               // ton amount attached to a message
+    valueCoins: coins               // GRAM amount attached to a message
     valueExtra: ExtraCurrenciesMap  // extra currencies attached to a message
     originalForwardFee: coins       // commission that the sender has paid to send this message
     createdLt: uint64               // logical time when a message was created (and bounced)
@@ -1967,7 +1978,7 @@ struct RichBounceComputePhaseInfo {
 /// ```
 /// createMessage({
 ///     bounce: BounceMode.RichBounce,
-///     value: ton("0.05")   // it will be `valueCoins` if this message is bounced
+///     value: grams("0.05")   // it will be `valueCoins` if this message is bounced
 /// ```
 struct RichBounceOriginalMsgInfo {
     valueCoins: coins

--- a/crypto/smartcont/tolk-stdlib/common.tolk
+++ b/crypto/smartcont/tolk-stdlib/common.tolk
@@ -670,21 +670,18 @@ fun slice.bitsHash(self): uint256
 fun cell.hashEqual(self, another: cell): bool
     asm "HASHCU" "SWAP" "HASHCU" "EQUAL"
 
-/// Checks the Ed25519-`signature` of a `hash` (uint256, usually computed as the hash of some data)
-/// using `publicKey` (also represented by a 256-bit unsigned integer).
+/// Checks an Ed25519 signature where the signed message is the 32-byte big-endian encoding of `hash`.
+/// Use this when off-chain code signed a 32-byte hash or digest value.
 /// The signature must contain at least 512 data bits; only the first 512 bits are used.
-/// Note that `CHKSIGNU` creates a 256-bit slice with the hash and calls `CHKSIGNS`.
-/// That is, if parameter `hash` is computed as the hash of some data, these data are hashed twice,
-/// the second hashing occurring inside `CHKSIGNS`.
 @pure
 fun isSignatureValid(hash: uint256, signature: slice, publicKey: uint256): bool
     asm "CHKSIGNU"
 
-/// Checks whether `signature` is a valid Ed25519-signature of the data portion of slice `data` using `publicKey`,
-/// similarly to [isSignatureValid].
+/// Checks an Ed25519 signature where the signed message is the data bytes of slice `data`.
+/// References of `data` are ignored.
 /// If the bit length of `data` is not divisible by eight, throws a cell underflow exception.
-/// The verification of Ed25519 signatures is the standard one,
-/// with sha256 used to reduce `data` to the 256-bit number that is actually signed.
+/// This function does not hash `data`; if off-chain code signed SHA-256(data), use
+/// `isSignatureValid(data.bitsHash(), signature, publicKey)` instead.
 @pure
 fun isSliceSignatureValid(data: slice, signature: slice, publicKey: int): bool
     asm "CHKSIGNS"

--- a/crypto/smartcont/tolk-stdlib/common.tolk
+++ b/crypto/smartcont/tolk-stdlib/common.tolk
@@ -1,7 +1,7 @@
 // Standard library for Tolk (LGPL licence).
 // It contains common functions that are available out of the box, the user doesn't have to import anything.
 // More specific functions are required to be imported explicitly, like "@stdlib/gas-payments".
-tolk 1.4.1
+tolk 1.4.2
 
 /**
     Built-in types.

--- a/crypto/smartcont/tolk-stdlib/exotic-cells.tolk
+++ b/crypto/smartcont/tolk-stdlib/exotic-cells.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 enum ExoticCellType: int8 {
     Ordinary = -1

--- a/crypto/smartcont/tolk-stdlib/gas-payments.tolk
+++ b/crypto/smartcont/tolk-stdlib/gas-payments.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 /**
   Gas and payment related primitives.

--- a/crypto/smartcont/tolk-stdlib/gas-payments.tolk
+++ b/crypto/smartcont/tolk-stdlib/gas-payments.tolk
@@ -32,7 +32,7 @@ fun setGasLimitToMaximum(): void
 fun setGasLimit(limit: int): void
     asm "SETGASLIMIT"
 
-/// Calculates fee (amount in nanotoncoins to be paid) for a transaction which consumed `gasUsed` gas units.
+/// Calculates fee (amount in nanograms to be paid) for a transaction which consumed `gasUsed` gas units.
 @pure
 fun calculateGasFee(workchain: int8, gasUsed: int): coins
     asm(gasUsed workchain) "GETGASFEE"
@@ -42,12 +42,12 @@ fun calculateGasFee(workchain: int8, gasUsed: int): coins
 fun calculateGasFeeWithoutFlatPrice(workchain: int8, gasUsed: int): coins
     asm(gasUsed workchain) "GETGASFEESIMPLE"
 
-/// Calculates amount of nanotoncoins you should pay for storing a contract of provided size for `seconds`.
+/// Calculates amount of nanograms you should pay for storing a contract of provided size for `seconds`.
 /// `bits` and `cells` represent contract state (code + data).
 fun calculateStorageFee(workchain: int8, seconds: int, bits: int, cells: int): coins
     asm(cells bits seconds workchain) "GETSTORAGEFEE"
 
-/// Calculates amount of nanotoncoins you should pay to send a message of a specified size.
+/// Calculates amount of nanograms you should pay to send a message of a specified size.
 @pure
 fun calculateForwardFee(workchain: int8, bits: int, cells: int): coins
     asm(cells bits workchain) "GETFORWARDFEE"
@@ -62,13 +62,13 @@ fun calculateForwardFeeWithoutLumpPrice(workchain: int8, bits: int, cells: int):
 fun calculateOriginalForwardFee(workchain: int8, incomingFwdFee: coins): coins
     asm(incomingFwdFee workchain) "GETORIGINALFWDFEE"
 
-/// Returns the amount of nanotoncoins current contract debts for storage. ("due" and "debt" are synonyms)
+/// Returns the amount of nanograms current contract debts for storage. ("due" and "debt" are synonyms)
 /// If it has no debt, `0` is returned.
 @pure
 fun contract.getStorageDuePayment(): coins
     asm "DUEPAYMENT"
 
-/// Returns the amount of nanotoncoins charged for storage.
+/// Returns the amount of nanograms charged for storage.
 /// (during the storage phase preceding the current computation phase)
 @pure
 fun contract.getStoragePaidPayment(): coins

--- a/crypto/smartcont/tolk-stdlib/lisp-lists.tolk
+++ b/crypto/smartcont/tolk-stdlib/lisp-lists.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 /**
     A lisp-style list is a set of nested 2-element TVM tuples:

--- a/crypto/smartcont/tolk-stdlib/reflection.tolk
+++ b/crypto/smartcont/tolk-stdlib/reflection.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 /**
     Reflection API.

--- a/crypto/smartcont/tolk-stdlib/strings.tolk
+++ b/crypto/smartcont/tolk-stdlib/strings.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 /**
     A string is a language primitive — a cell containing snake-formatted text data.

--- a/crypto/smartcont/tolk-stdlib/tvm-dicts.tolk
+++ b/crypto/smartcont/tolk-stdlib/tvm-dicts.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 /**
     Low-level API working with TVM dictionaries.

--- a/crypto/smartcont/tolk-stdlib/tvm-lowlevel.tolk
+++ b/crypto/smartcont/tolk-stdlib/tvm-lowlevel.tolk
@@ -1,5 +1,5 @@
 // A part of standard library for Tolk
-tolk 1.4.1
+tolk 1.4.2
 
 /// Usually `c3` has a continuation initialized by the whole code of the contract. It is used for function calls.
 /// The primitive returns the current value of `c3`.

--- a/crypto/smartcont/tolk-stdlib/tvm-lowlevel.tolk
+++ b/crypto/smartcont/tolk-stdlib/tvm-lowlevel.tolk
@@ -56,7 +56,7 @@ enum VmExitCode {
     ActionInvalid = 34              // action is invalid or not supported
     InvalidSourceAddress = 35       // invalid source address in outbound message
     InvalidDestAddress = 36         // invalid destination address in outbound message
-    NotEnoughToncoin = 37           // not enough Toncoin to send or pay fees
+    NotEnoughGrams = 37             // not enough GRAMs to send or pay fees
     NotEnoughExtraCurrencies = 38   // not enough extra currencies to send the specified amount
     MessageDoesNotFit = 39          // outbound message does not fit into a cell after rewriting
     CannotProcessMessage = 40       // not enough funds, message too large, or Merkle depth too big

--- a/tolk-tester/tests/abi-tests.tolk
+++ b/tolk-tester/tests/abi-tests.tolk
@@ -66,7 +66,7 @@ fun unusedAbiThrow() {
 fun unusedAbiOutgoing() {
     createMessage({
         bounce: BounceMode.NoBounce,
-        value: ton("0.1"),
+        value: grams("0.1"),
         dest: address("0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e"),
         body: UnusedOutgoing {}.toCell(),
     });
@@ -75,7 +75,7 @@ fun unusedAbiOutgoing() {
 fun realSend() {
     createMessage({
         bounce: BounceMode.NoBounce,
-        value: ton("0.1"),
+        value: grams("0.1"),
         dest: address("0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e"),
         body: SwapMM {}.toCell(),
     });

--- a/tolk-tester/tests/allow-post-modification.tolk
+++ b/tolk-tester/tests/allow-post-modification.tolk
@@ -165,6 +165,21 @@ fun test_create_list(): lisp_list<int> {
     return [ x, x += 2, x, eq(mul2(mutate x, 5)), x];
 }
 
+@method_id(31)
+fun test_assign_tensor_expression_result() {
+    var t = (1, 2);
+    var got = (t = (t.1, t.0));
+    return (got, t);
+}
+
+@method_id(32)
+fun test_destructuring_assignment_expression_result() {
+    var a = 1;
+    var b = 2;
+    var got = ((a, b) = (b, a));
+    return (got, a, b);
+}
+
 fun main() {
 }
 
@@ -191,6 +206,8 @@ fun main() {
 @testcase | 28 |     | 0 32 32
 @testcase | 29 |     | [ 1 3 3 10 10 ]
 @testcase | 30 |     | [ 1 [ 3 [ 3 [ 10 [ 10 (null) ] ] ] ] ]
+@testcase | 31 |     | 2 1 2 1
+@testcase | 32 |     | 2 1 2 1
 
 @fif_codegen
 """
@@ -204,5 +221,5 @@ fun main() {
   test_assign_tensor_global() PROC:<{   // x.0 x.1
 """
 
-@code_hash 111667756568862912577641874227144621753163521614440586561560498476829147651751
+@code_hash 17898199156000752763810513209526180010632285036368787784392835308293247365245
 */

--- a/tolk-tester/tests/assignment-tests.tolk
+++ b/tolk-tester/tests/assignment-tests.tolk
@@ -209,6 +209,55 @@ fun test124() {
     return (a1, a18);
 }
 
+@method_id(125)
+fun test125() {
+    var (a, [b, c]) = (10, [20, 30]);
+    return (a, b, c);
+}
+
+struct Small126 {
+    x: int
+}
+
+struct Large126 {
+    x: int
+    y: int
+}
+
+fun makeUnion126(useSmall: int): Small126 | Large126 {
+    return useSmall != 0 ? Small126 { x: 1 } : Large126 { x: 2, y: 3 };
+}
+
+@method_id(126)
+fun test126(useSmall: int) {
+    var u = makeUnion126(useSmall);
+    var other = 7;
+    if (u is Small126) {
+        (u, other) = (Small126 { x: 9 }, other);
+    }
+    return match (u) {
+        Small126 => (1, u.x, other, 0),
+        Large126 => (2, u.x, other, u.y),
+    };
+}
+
+@method_id(127)
+fun test127() {
+    val sh: [int, [int, [int, int]]] = [10, [20, [30, 40]]];
+    var [a, [b, [c, d]]] = sh;
+    var [e, (f, [g, h])] = [50, (60, [70, 80])];
+    return (a, b, c, d, e, f, g, h);
+}
+
+@method_id(128)
+fun test128() {
+    var (a, b, c, d) = (0, 0, 0, 0);
+    [a, [b, [c, d]]] = [11, [22, [33, 44]]];
+
+    var (e, f, g, h) = (0, 0, 0, 0);
+    [e, (f, [g, h])] = [55, (66, [77, 88])];
+    return (a, b, c, d, e, f, g, h);
+}
 
 fun main(value: int, ) {
     var (x: int?, y,) = (autoInferIntNull(value), autoInferIntNull(value * 2));
@@ -231,6 +280,10 @@ fun main(value: int, ) {
 @testcase | 122 |        | 0 10 0
 @testcase | 123 |        | 13
 @testcase | 124 |        | 1 18
+@testcase | 125 |        | 10 20 30
+@testcase | 126 | 1      | 1 9 7 0
+@testcase | 127 |        | 10 20 30 40 50 60 70 80
+@testcase | 128 |        | 11 22 33 44 55 66 77 88
 
 
 @fif_codegen

--- a/tolk-tester/tests/assignment-tests.tolk
+++ b/tolk-tester/tests/assignment-tests.tolk
@@ -259,6 +259,16 @@ fun test128() {
     return (a, b, c, d, e, f, g, h);
 }
 
+@method_id(129)
+fun test129() {
+    var `self` = 123;
+    {
+        var `self` = beginCell();
+        __expect_type(`self`, "builder");
+    }
+    return `self` + 6;
+}
+
 fun main(value: int, ) {
     var (x: int?, y,) = (autoInferIntNull(value), autoInferIntNull(value * 2));
     if (x == null && y == null) { return null; }
@@ -284,6 +294,7 @@ fun main(value: int, ) {
 @testcase | 126 | 1      | 1 9 7 0
 @testcase | 127 |        | 10 20 30 40 50 60 70 80
 @testcase | 128 |        | 11 22 33 44 55 66 77 88
+@testcase | 129 |        | 129
 
 
 @fif_codegen

--- a/tolk-tester/tests/calls-tests.tolk
+++ b/tolk-tester/tests/calls-tests.tolk
@@ -36,8 +36,8 @@ fun Point.incrementX(mutate self, deltaX: int = 1) {
     self.x += deltaX;
 }
 
-fun makeCost(cost: coins = ton("0.05")) {
-    return cost + ton("0.05") + ton("0.");
+fun makeCost(cost: coins = grams("0.05")) {
+    return cost + grams("0.05") + grams("0.");
 }
 
 fun makeUnion(v: int | slice = 0) {
@@ -109,7 +109,7 @@ fun test3() {
 fun test4() {
     return (
         makeCost(),
-        makeCost(ton("0.1")),
+        makeCost(grams("0.1")),
         makeUnion() is int,
         makeUnion(),
         makeUnion(makeCost()),

--- a/tolk-tester/tests/codegen-check-demo.tolk
+++ b/tolk-tester/tests/codegen-check-demo.tolk
@@ -34,7 +34,7 @@ Below, I just give examples of @fif_codegen tag:
 @fif_codegen
 """
 main() PROC:<{   // s
-  17 PUSHINT     //  s '1=17
+  17 PUSHINT     //  s z=17
   OVER           //  s z=17 t
   WHILE:<{
     ...

--- a/tolk-tester/tests/constants-tests.tolk
+++ b/tolk-tester/tests/constants-tests.tolk
@@ -39,7 +39,7 @@ const tens2: (int, int, (int8, int16)) = (tens1.1, tens1.0 << 2, tens1);
 
 const intOrN: int? = null;
 const int32Or64: int32 | int64 = 7 as int64;
-const int32OrCoins: int32 | coins = ton("0.05");
+const int32OrCoins: int32 | coins = grams("0.05");
 const intOrSlice = 5 as int|slice;
 const int32Or128 = (7 as int32) as int32 | int128;
 
@@ -99,14 +99,14 @@ struct SubParams {
 struct MyOptions {
     allowPenalty: bool = false
     closeTo: (int8, int8)? = null
-    sub: SubParams = { sub3: ton("0.05") }
+    sub: SubParams = { sub3: grams("0.05") }
     coeff: int16 = 2
 }
 
 const opts1 = MyOptions { allowPenalty: true }
 const opts2 = MyOptions { coeff: 3, sub: { sub1: false, sub3: 0 } }
 const opts3: MyOptions = { coeff: 0, closeTo: null, allowPenalty: true }
-const opts4: MyOptions = { sub: { sub3: ton("1") }, closeTo: (3, 4), coeff: 55 }
+const opts4: MyOptions = { sub: { sub3: grams("1") }, closeTo: (3, 4), coeff: 55 }
 
 @noinline
 fun MyOptions.equals(self, rhs: MyOptions = {}) {
@@ -117,8 +117,8 @@ struct Wrapper<T> {
     item: T
 }
 
-const wOneTon = Wrapper<coins> { item: ton("0.5") * 2 }
-const wNoTon: Wrapper<int> = { item: 0 }
+const wOneGram = Wrapper<coins> { item: grams("0.5") * 2 }
+const wNoGram: Wrapper<int> = { item: 0 }
 const wNoSubParams: Wrapper<SubParams>? = null
 
 struct Point {
@@ -133,7 +133,7 @@ const shape1_tens = (shape1.0, shape1.1);
 const nul_arr_i: array<int>? = [1]
 const nul_list_i: lisp_list<int>? = [1]
 const nul_list_i_n: lisp_list<int>? = null
-const coins_or_int8: coins | int8 = Wrapper { item: ton("0.05") }.item
+const coins_or_int8: coins | int8 = Wrapper { item: grams("0.05") }.item
 const arr_or_int: array<int> | int = []
 
 struct WithNullableArray {
@@ -256,14 +256,14 @@ fun test15() {
         opts1.equals({ closeTo: null, allowPenalty: true }),
         opts2.equals({ coeff: 3, sub: { sub1: false, sub3: 0 } }),
         opts3.equals({ closeTo: null, coeff: 0, allowPenalty: true }),
-        opts4.equals({ sub: { sub3: ton("1") }, coeff: 55, closeTo: (3, 4) })
+        opts4.equals({ sub: { sub3: grams("1") }, coeff: 55, closeTo: (3, 4) })
     )
 }
 
 @method_id(116)
 fun test16() {
-    __expect_type(wOneTon, "Wrapper<coins>");
-    return (wOneTon, wNoTon, wNoSubParams)
+    __expect_type(wOneGram, "Wrapper<coins>");
+    return (wOneGram, wNoGram, wNoSubParams)
 }
 
 @method_id(117)

--- a/tolk-tester/tests/constants-tests.tolk
+++ b/tolk-tester/tests/constants-tests.tolk
@@ -150,6 +150,12 @@ const objWithNullableArrayDef: WithNullableArrayDef = {}
 const emptyMapNullable: map<int8, int32>? = []
 const emptyMapAsNullableConst = [] as map<int8, int32>?
 
+const bigRshiftMid: int = (1000000000000000 + 3000000000000000) >> 1;
+
+@noinline
+fun isPositiveViaBigRshiftMid(a: int): bool {
+    return bigRshiftMid > (bigRshiftMid - a);
+}
 
 fun iget240(): MInt { return int240; }
 
@@ -327,6 +333,11 @@ fun test126() {
     return (emptyMapAsNullableConst == null, emptyMapAsNullableConst!.isEmpty());
 }
 
+@method_id(127)
+fun test127() {
+    return (bigRshiftMid, isPositiveViaBigRshiftMid(-1), isPositiveViaBigRshiftMid(1));
+}
+
 fun main() {
     var i1: int = iget1();
     var i2: int = iget2();
@@ -377,6 +388,7 @@ fun main() {
 @testcase | 124 |   | 0 50000000
 @testcase | 125 |   | 1 1 1 2
 @testcase | 126 |   | 0 -1
+@testcase | 127 |   | 2000000000000000 0 -1
 
-@code_hash 69450727578206805235623888457664461735127156131005024409888318254979905151137
+@code_hash 81510367501635395392010839907601337703375917009254151502636239169360844553617
 */

--- a/tolk-tester/tests/enums-tests.tolk
+++ b/tolk-tester/tests/enums-tests.tolk
@@ -12,7 +12,7 @@ enum InvertedColor {
     Red = Color.Blue,
     Green = Color.Green,
     Blue = Color.Red,
-    OneTon = ton("1"),
+    OneGram = grams("1"),
 }
 
 type ColorAlias = Color
@@ -261,7 +261,7 @@ fun test13(x: int) {
 @method_id(114)
 fun test14(x: InvertedColor) {
     __expect_type(InvertedColor.Red, "InvertedColor");
-    return (InvertedColor.Red, InvertedColor.Green, InvertedColor.Blue, InvertedColor.OneTon, x == InvertedColor.Red);
+    return (InvertedColor.Red, InvertedColor.Green, InvertedColor.Blue, InvertedColor.OneGram, x == InvertedColor.Red);
 }
 
 @method_id(115)

--- a/tolk-tester/tests/generics-2.tolk
+++ b/tolk-tester/tests/generics-2.tolk
@@ -46,7 +46,7 @@ fun wrap<T>(value: T): Wrapper<T> {
 }
 
 fun wrap2<T>(value: T) {
-    return WrapperAlias<T> { value };
+    return Wrapper<T> { value };
 }
 
 fun wrap0<T>(): Wrapper<T> {
@@ -174,9 +174,9 @@ fun createNestedWrapperOrNull<T>(setNull: bool, initVal: T) {
     }
     var c1 = Wrapper<Wrapper<T>> {value:{value:initVal}};
     var c2: Wrapper< Wrapper<(T)> > = {value:{value:initVal}};
-    var c3: Wrapper< Wrapper<((T | T))> > = WrapperAlias {value:{value:initVal}};
+    var c3: Wrapper< Wrapper<((T | T))> > = Wrapper {value:{value:initVal}};
     var c4: Wrapper< Wrapper<((T | T))> > = Wrapper<Wrapper<T>> {value:c3.value};
-    var c5: Wrapper< WrapperAlias<((T | T))> > = WrapperAlias<Wrapper<T>> {value:c3.value};
+    var c5: Wrapper< WrapperAlias<((T | T))> > = Wrapper<Wrapper<T>> {value:c3.value};
     var c6: WrapperAlias< WrapperAlias<((T | T))> > = Wrapper<Wrapper<T>> {value:c3.value};
     return c1;
 }
@@ -213,7 +213,7 @@ fun test8(lastNull: bool) {
 @method_id(109)
 fun test9() {
     var c1: WrappedInt = { value: 10 };
-    var c2: WrappedInt = WrappedInt { value: 20 };
+    var c2: WrappedInt = Wrapper { value: 20 };
     var c3: WrappedInt = Wrapper { value: 30 };
     var c4: Wrapper<int> = { value: 40 };
     c1 = c2 = c3 = c4;
@@ -230,7 +230,7 @@ fun test9() {
     c6 as Wrapper<WrappedInt>;
     c7 as Wrapper<Wrapper<int>>;
 
-    var p1: PairAlias<MyInt, WrappedInt> = { first: 42, second: WrappedInt { value: 200 } };
+    var p1: PairAlias<MyInt, WrappedInt> = { first: 42, second: Wrapper { value: 200 } };
     __expect_type(p1, "PairAlias<MyInt, WrappedInt>");
     __expect_type(p1 as Pair<int, Wrapper<int>>, "Pair<int, Wrapper<int>>");
     var p2: Pair<int, Wrapper<int>> = p1;
@@ -595,14 +595,14 @@ fun main(c: Wrapper<slice>, d: WrappedInt) {
     __expect_type(c!, "Wrapper<slice>");
     __expect_type(d, "WrappedInt");
     __expect_type(d.value, "int");
-    __expect_type(WrappedInt { value: 200 }, "Wrapper<int>");
+    __expect_type(Wrapper<int> { value: 200 } as WrappedInt, "WrappedInt");
     __expect_type(Wrapper<slice>{ value: c.value }, "Wrapper<slice>");
     __expect_type(Wrapper<bytes32>{ value: c.value as bytes32 }, "Wrapper<bytes32>");
     __expect_type(Wrapper<bytes32>{ value: Wrapper<bytes32> { value: (c.value as bytes32 as bytes32?)! }.value }, "Wrapper<bytes32>");
     __expect_type(Wrapper{ value: c.value }, "Wrapper<slice>");
     __expect_type(Wrapper{ value: c.value.loadInt(32) }, "Wrapper<int>");
-    __expect_type(WrapperAlias{ value: 10 }, "Wrapper<int>");
-    __expect_type(WrapperAlias{ value: 10 } as WrapperAlias<int>, "WrapperAlias<int>");
+    __expect_type(Wrapper{ value: 10 }, "Wrapper<int>");
+    __expect_type(Wrapper{ value: 10 } as WrapperAlias<int>, "WrapperAlias<int>");
     __expect_type(swap(Pair { first: 3, second: beginCell() }), "Pair<builder, int>");
 }
 

--- a/tolk-tester/tests/generics-3.tolk
+++ b/tolk-tester/tests/generics-3.tolk
@@ -110,14 +110,14 @@ struct WithDef<T> {
     f1: T? = null;
     f2: int? = null as int?;
     f3: T? = null as T?;
-    price: coins = ton("0.05"),
+    price: coins = grams("0.05"),
     slice: slice = stringHexToSlice("010203"),
 }
 
 @method_id(108)
 fun test8() {
     var w1: WithDef<slice> = {};
-    var w2: WithDef<Ok<int>> = { price: ton("0.1"), f3: { result: 12 } };
+    var w2: WithDef<Ok<int>> = { price: grams("0.1"), f3: { result: 12 } };
     return (w1.price, w1.f1, w1.f3, w2.price, w2.f3!.result, w2.f3, w2.slice.remainingBitsCount());
 }
 

--- a/tolk-tester/tests/generics-3.tolk
+++ b/tolk-tester/tests/generics-3.tolk
@@ -50,14 +50,14 @@ fun test3() {
     var r: Response<int, slice> = getResponse(true);
     r = Err { errPayload: createEmptySlice() };
     __expect_type(r, "Err<slice>");
-    r = OkAlias { result: 10 };
+    r = Ok { result: 10 };
     __expect_type(r, "Ok<int>");
     return (r, r is Ok, (r as Response<int,slice>) is Err);
 }
 
 @method_id(104)
 fun test4() {
-    var r1 = OkAlias { result: OkAlias { result: 10 } } as Response< Ok<int>, slice >;
+    var r1 = Ok { result: Ok { result: 10 } } as Response< Ok<int>, slice >;
     match (r1) {
         Ok => { __expect_type(r1, "Ok<Ok<int>>"); r1.result.result; }
         Err => {}

--- a/tolk-tester/tests/generics-4.tolk
+++ b/tolk-tester/tests/generics-4.tolk
@@ -9,8 +9,16 @@ struct Container1<T=int?> {
     item: T;
 }
 
+struct StaticDefaultBox<T = int32> {
+    item: T;
+}
+
 fun getItemOf<T=never>(v: Container1<T>) {
     return v.item;
+}
+
+fun StaticDefaultBox<T>.createDefault(): StaticDefaultBox<T> {
+    return { item: 0 };
 }
 
 struct WithDef1<T = null> {
@@ -127,6 +135,9 @@ fun test2() {
 
     __expect_type(getItemOf({item: null as slice?}), "slice?");
     __expect_type(getItemOf({item: null}), "null");
+
+    var static_default = StaticDefaultBox.createDefault();
+    __expect_type(static_default, "StaticDefaultBox<int32>");
 }
 
 @method_id(103)

--- a/tolk-tester/tests/generics-4.tolk
+++ b/tolk-tester/tests/generics-4.tolk
@@ -56,7 +56,7 @@ struct Parameters<TBody = void, TInit = void> {
 }
 
 fun createParameters<TBody = null, TInit = null>(bounce: bool, body: TBody, data: TInit): Parameters<TBody, TInit> {
-    return { bounce, body, init: { value: ton("0"), data } };
+    return { bounce, body, init: { value: grams("0"), data } };
 }
 
 fun void.assertIsVoid(self) {
@@ -194,7 +194,7 @@ fun test6() {
     var p: Parameters<int, cell> = {
         bounce: true,
         body: 123,
-        init: { value: ton("0"), data: beginCell().endCell() }
+        init: { value: grams("0"), data: beginCell().endCell() }
     };
     return (p.body is int, p.init is cell, p.init is MyInit, p.init is MyInit && p.init.data.depth() == 0);
 }
@@ -202,7 +202,7 @@ fun test6() {
 @method_id(107)
 fun test7() {
     __expect_type(Parameters{ bounce: false }, "Parameters<void, void>");
-    __expect_type(Parameters{ bounce: false, body: 123, init: { value: ton("0"), data: beginCell() }}, "Parameters<int, builder>");
+    __expect_type(Parameters{ bounce: false, body: 123, init: { value: grams("0"), data: beginCell() }}, "Parameters<int, builder>");
     __expect_type(Parameters{ bounce: false, body: 123 }.genericIntVoid<builder>(), "(slice?, builder?)");
     __expect_type(Parameters{ bounce: false, body: 123 }.genericIntVoid<builder, cell>(), "(cell?, builder?)");
     __expect_type(Parameters{ bounce: false }.body, "void");
@@ -214,7 +214,7 @@ fun test7() {
 
     var v1 = mySend({ bounce: true });
     var v2 = mySend({ bounce: false, body: 123, init: beginCell() });
-    var v3 = mySend({ bounce: false, body: 123, init: { value: ton("0"), data: beginCell() }});
+    var v3 = mySend({ bounce: false, body: 123, init: { value: grams("0"), data: beginCell() }});
     var v4 = mySend({ bounce: true, init: { value: 16, data: null as [int]? }});
     return (v1, v2, v3, v4);
 }

--- a/tolk-tester/tests/intN-tests.tolk
+++ b/tolk-tester/tests/intN-tests.tolk
@@ -7,8 +7,8 @@ const someN_u128: uint128 = 128;
 const someN_i32: int32 = 20 + (12 as int32) * (1 as uint8);
 const someN_coins = 10 as coins;
 
-const cost1 = ton("1.234");
-const cost2 = ton("0.05") + ton("0.001");
+const cost1 = grams("1.234");
+const cost2 = grams("0.05") + grams("0.001");
 
 fun rand(): uint256 { return random.uint256(); }
 
@@ -183,28 +183,34 @@ fun test9(c: coins, i: int8) {
 
 @method_id(110)
 fun test10() {
-    return (ton("0.05"), ton("0.05") + 100, cost1, cost2);
+    return (grams("0.05"), grams("0.05") + 100, cost1, cost2);
 }
 
 @method_id(111)
 fun test11() {
-    __expect_type(ton("0"), "coins");
-    __expect_type(ton("0") + ton("0"), "coins");
-    __expect_type(ton("0") * 20, "int");
+    __expect_type(grams("0"), "coins");
+    __expect_type(grams("0") + grams("0"), "coins");
+    __expect_type(grams("0") * 20, "int");
     return [
-        ton("1"),
-        ton("1.0"),
-        ton("1.00000"),
-        ton("-321.123456789"),
-        ton("+321.123456798"),
-        ton("0001.1000")
+        grams("1"),
+        grams("1.0"),
+        grams("1.00000"),
+        grams("-321.123456789"),
+        grams("+321.123456798"),
+        grams("0001.1000")
     ];
 }
 
 @method_id(112)
 fun test12() {
-    var a = ton("1") + ton("2");    // check absence in fif codegen
-    return ton("0.1");
+    var a = grams("1") + grams("2");    // check absence in fif codegen
+    return grams("0.1");
+}
+
+@method_id(113)
+fun test13_deprecatedTonAlias() {
+    __expect_type(ton("0"), "coins");
+    return ton("0.05");
 }
 
 fun test13(x1: int?, x2: int8?, x3: int, x4: int8): (int8?, int8?, int8?, int8?, int32?, int32?) {
@@ -236,6 +242,7 @@ fun main() {
 @testcase | 109 | 4  4 | 500 -1
 @testcase | 110 |      | 50000000 50000100 1234000000 51000000
 @testcase | 111 |      | [ 1000000000 1000000000 1000000000 -321123456789 321123456798 1100000000 ]
+@testcase | 113 |      | 50000000
 @testcase | 114 | 5    | (null) (null) 0
 @testcase | 114 | 15   | 15 2 typeid-1
 

--- a/tolk-tester/tests/invalid-declaration/err-1589.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1589.tolk
@@ -1,0 +1,11 @@
+struct B<T> { x: A<T> }
+type A<T> = B<T> | int
+
+contract Demo {}
+
+fun onInternalMessage(x: A<int>) {}
+
+/**
+@compilation_should_fail
+@stderr type `A<int>` circularly references itself
+ */

--- a/tolk-tester/tests/invalid-declaration/err-1880.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1880.tolk
@@ -1,5 +1,5 @@
 fun ok(): (int, slice) asm(->0b1 0b0) "NOP"
-fun not(): (int, slice) asm(->0xFFFFF) "NOP"
+fun not(): (int, slice) asm(->0xF0) "NOP"
 
 /**
 @compilation_should_fail

--- a/tolk-tester/tests/invalid-declaration/err-1985.tolk
+++ b/tolk-tester/tests/invalid-declaration/err-1985.tolk
@@ -1,0 +1,7 @@
+@inline_ref
+fun asmInlineRef(): int asm "1 PUSHINT"
+
+/**
+@compilation_should_fail
+@stderr inline annotations are not applicable to asm functions
+ */

--- a/tolk-tester/tests/invalid-semantics/err-4119.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-4119.tolk
@@ -5,7 +5,7 @@ struct Wrapper<T> {
 type WrapperAlias<T> = Wrapper<T>;
 
 fun main() {
-    var w1 = WrapperAlias<int16> { value: 10 } as WrapperAlias<int8> | int | Wrapper<int16>;
+    var w1 = Wrapper<int16> { value: 10 } as WrapperAlias<int8> | int | Wrapper<int16>;
     w1 is Wrapper;
 }
 

--- a/tolk-tester/tests/invalid-semantics/err-4190.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-4190.tolk
@@ -1,5 +1,5 @@
 struct A {
-    ok: coins = ton("0.05"),
+    ok: coins = grams("0.05"),
     err: int = blockchain.now(),
 }
 

--- a/tolk-tester/tests/invalid-semantics/err-4390.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-4390.tolk
@@ -1,0 +1,15 @@
+struct Box<T> {
+    value: T;
+}
+
+type Tagged<T> = Box<T>;
+
+fun main(v: uint8) {
+    return Tagged<uint8> { value: v };
+}
+
+/**
+@compilation_should_fail
+@stderr `Tagged<uint8>` does not name a struct
+@stderr { value: v }
+ */

--- a/tolk-tester/tests/invalid-semantics/err-borrow-checker.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-borrow-checker.tolk
@@ -119,7 +119,8 @@ fun mutateOverlapping(mutate x: int, mutate p: (int, int)): void {
     p = (3, 4);
 }
 
-// @stderr can not borrow `a19` for mutation once again, it is already being mutated by `mutateOverlapping`
+// @stderr can not mutate a temporary expression
+// @stderr mutateOverlapping(mutate a19, mutate (((a19, b19))))
 fun errCantBorrowInsideTensor(): (int, int) {
     var a19 = 10;
     var b19 = 20;

--- a/tolk-tester/tests/invalid-semantics/err-invalid-lvalue.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-invalid-lvalue.tolk
@@ -28,3 +28,44 @@ fun errTensorLiteralIndexedAssign() {
 fun errUnderscoreRValue() {
     return takeInt(_);
 }
+
+fun mutateArg<T>(mutate arg: T) {}
+fun T.mutateSelf(mutate self) {}
+
+// @stderr can not mutate a temporary expression
+// @stderr mutateArg(mutate (a, b))
+fun errMutateTensorLiteral() {
+    var a = 1;
+    var b = 2;
+    mutateArg(mutate (a, b));
+}
+
+// @stderr mutateArg(mutate [a, b])
+fun errMutateSquareLiteral() {
+    var a = 1;
+    var b = 2;
+    mutateArg(mutate [a, b]);
+}
+
+// @stderr (a, b).mutateSelf()
+fun errTensorLiteralMutatingMethod() {
+    var a = 1;
+    var b = 2;
+    (a, b).mutateSelf();
+}
+
+// @stderr [a, b].mutateSelf()
+fun errSquareLiteralMutatingMethod() {
+    var a = 1;
+    var b = 2;
+    [a, b].mutateSelf();
+}
+
+// @stderr mutateArg(mutate (u, other))
+fun errSmartCastUnionTensorLiteralMutate() {
+    var u: (int, int) | (int, int, int) = (1, 2);
+    var other = 0;
+    if (u is (int, int)) {
+        mutateArg(mutate (u, other));
+    }
+}

--- a/tolk-tester/tests/invalid-semantics/err-lazy-assign-to-lazy.tolk
+++ b/tolk-tester/tests/invalid-semantics/err-lazy-assign-to-lazy.tolk
@@ -1,0 +1,17 @@
+struct LazyAssignTrio {
+    a: uint8
+    b: uint8
+    c: uint8
+}
+
+fun main() {
+    var st = lazy LazyAssignTrio.fromSlice("010203".hexToSlice());
+    var other = lazy LazyAssignTrio.fromSlice("AABBCC".hexToSlice());
+    st = other;
+    return st.c;
+}
+
+/**
+@compilation_should_fail
+@stderr assigning one lazy variable to another is not supported
+ */

--- a/tolk-tester/tests/invalid-serialization/err-7311.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7311.tolk
@@ -18,7 +18,7 @@ fun main() {
         AskToTransfer => {
         }
         TransferNotificationForRecipient => {
-            m = AskToTransfer{jettonAmount: ton("0.1"), another: 0};
+            m = AskToTransfer{jettonAmount: grams("0.1"), another: 0};
             m.another = 1;
         }
     }

--- a/tolk-tester/tests/invalid-serialization/err-7833.tolk
+++ b/tolk-tester/tests/invalid-serialization/err-7833.tolk
@@ -1,0 +1,27 @@
+struct (0x01) A {}
+struct (0x02) B {}
+
+type U = A | B
+type AliasU = U
+
+fun AliasU.packToBuilder(self, mutate b: builder) {
+    b.storeUint(0, 1);
+}
+
+fun AliasU.unpackFromSlice(mutate s: slice): AliasU {
+    s.loadUint(1);
+    return A {};
+}
+
+fun main(s: slice): int {
+    val u: AliasU = lazy U.fromSlice(s);
+    return match (u) {
+        A => 1,
+        B => 2,
+    };
+}
+
+/**
+@compilation_should_fail
+@stderr `lazy` will not work here, because variable `u` is declared as `AliasU`, but lazy expression has type `U`
+ */

--- a/tolk-tester/tests/invalid-syntax/err-3001.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3001.tolk
@@ -2,6 +2,6 @@ tolk asdf;
 
 /**
 @compilation_should_fail
-@stderr semver expected
+@stderr expected semver, like `tolk 1.2`, got `asdf`
 @stderr tolk asdf;
  */

--- a/tolk-tester/tests/invalid-syntax/err-3002.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3002.tolk
@@ -1,0 +1,6 @@
+tolk
+
+/**
+@compilation_should_fail
+@stderr expected semver, like `tolk 1.2`, got ``
+ */

--- a/tolk-tester/tests/invalid-syntax/err-3003.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3003.tolk
@@ -1,0 +1,6 @@
+tolk 1.fun
+
+/**
+@compilation_should_fail
+@stderr expected semver, like `tolk 1.2`, got `fun`
+ */

--- a/tolk-tester/tests/invalid-syntax/err-3015.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3015.tolk
@@ -1,8 +1,8 @@
 fun main() {
-    return ton(123);
+    return grams(123);
 }
 
 /**
 @compilation_should_fail
-@stderr function `ton` requires a constant string, like `ton("0.05")`
+@stderr function `grams` requires a constant string, like `grams("0.05")`
  */

--- a/tolk-tester/tests/invalid-syntax/err-3319.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3319.tolk
@@ -2,5 +2,5 @@ fun t(): (int, int) asm (-> 1222222222222222222222222222222223 0) "NOP"
 
 /**
 @compilation_should_fail
-@stderr ret_order contains invalid integer, not in range 0 .. N
+@stderr invalid asm index
  */

--- a/tolk-tester/tests/invalid-syntax/err-3356.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3356.tolk
@@ -1,5 +1,5 @@
 fun main() {
-    return ton("-");
+    return grams("-");
 }
 
 /**

--- a/tolk-tester/tests/invalid-syntax/err-3357.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3357.tolk
@@ -1,5 +1,5 @@
 fun main() {
-    return ton("1000000000");
+    return grams("1000000000");
 }
 
 /**

--- a/tolk-tester/tests/invalid-syntax/err-3358.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3358.tolk
@@ -1,8 +1,8 @@
 fun main() {
-    return ton("0.1234567891");
+    return grams("0.1234567891");
 }
 
 /**
 @compilation_should_fail
-@stderr too many digits after a dot, nanotons are 10^9
+@stderr too many digits after a dot, nanograms are 10^9
  */

--- a/tolk-tester/tests/invalid-syntax/err-3359.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3359.tolk
@@ -1,5 +1,5 @@
 fun main() {
-    return ton("-.");
+    return grams("-.");
 }
 
 /**

--- a/tolk-tester/tests/invalid-syntax/err-3472.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3472.tolk
@@ -1,4 +1,4 @@
-const ss = ton("0.0.0");
+const ss = grams("0.0.0");
 
 /**
 @compilation_should_fail

--- a/tolk-tester/tests/invalid-syntax/err-3714.tolk
+++ b/tolk-tester/tests/invalid-syntax/err-3714.tolk
@@ -1,8 +1,8 @@
 fun main(am: slice) {
-    return ton(am);
+    return grams(am);
 }
 
 /**
 @compilation_should_fail
-@stderr function `ton` requires a constant string, like `ton("0.05")`
+@stderr function `grams` requires a constant string, like `grams("0.05")`
  */

--- a/tolk-tester/tests/invalid-typing/err-6120.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6120.tolk
@@ -1,0 +1,11 @@
+fun int.bad(self): self {
+    {
+        var `self` = beginCell();
+        return `self`;
+    }
+}
+
+/**
+@compilation_should_fail
+@stderr invalid return from `self` function
+ */

--- a/tolk-tester/tests/invalid-typing/err-6121.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6121.tolk
@@ -1,0 +1,11 @@
+fun int.bad(self): self {
+    {
+        var `self` = beginCell();
+        return self;
+    }
+}
+
+/**
+@compilation_should_fail
+@stderr invalid return from `self` function
+ */

--- a/tolk-tester/tests/invalid-typing/err-6493.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6493.tolk
@@ -1,0 +1,11 @@
+fun main(x: (int, int) | (slice, int)) {
+    if (x is (int, int)) {
+    }
+    return x.0;
+}
+
+/**
+@compilation_should_fail
+@stderr field `0` doesn't exist in type `(int, int) | (slice, int)`
+@stderr return x.0
+ */

--- a/tolk-tester/tests/invalid-typing/err-6993.tolk
+++ b/tolk-tester/tests/invalid-typing/err-6993.tolk
@@ -1,0 +1,20 @@
+struct A {
+    x: int
+}
+
+struct B {
+    x: int
+    y: int
+}
+
+const C: B = A { x: 1 }
+const Y = C.y
+
+fun main(): int {
+    return Y
+}
+
+/**
+@compilation_should_fail
+@stderr can not assign `A` to `B`
+ */

--- a/tolk-tester/tests/invalid-typing/err-type-check-1.tolk
+++ b/tolk-tester/tests/invalid-typing/err-type-check-1.tolk
@@ -39,8 +39,8 @@ fun errCallMethodNotSelf() {
 }
 
 // @stderr can not assign `coins` to `slice`
-// @stderr ton("0.04")
-fun invalidInDefault(x: slice = ton("0.04")) {
+// @stderr grams("0.04")
+fun invalidInDefault(x: slice = grams("0.04")) {
 }
 
 // @stderr can not pass `(Point) -> (int, int)` to `slice`

--- a/tolk-tester/tests/lazy-load-tests.tolk
+++ b/tolk-tester/tests/lazy-load-tests.tolk
@@ -1820,8 +1820,8 @@ fun demo410(s: slice) {
         CounterIncrement => { debug.print(1) }
         CounterDecrement => { debug.dumpStack() }
         CounterReset => { random.setSeed(10) }
-        CounterDecrementBy1 => { reserveToncoinsOnBalance(10, 1) }
-        else => { /* do nothing, "just accept tons" */ }
+        CounterDecrementBy1 => { reserveGramsOnBalance(10, 1) }
+        else => { /* do nothing, "just accept grams" */ }
     }
 }
 

--- a/tolk-tester/tests/lazy-load-tests.tolk
+++ b/tolk-tester/tests/lazy-load-tests.tolk
@@ -1570,7 +1570,7 @@ fun demo316() {
     var p2 = lazy Point3d{ x: 2, y: 3, z: 99 }.toCell().load();
     var p3 = lazy Point3d{ x: 2, y: 3, z: 99 }.toCell().load();
     __expect_lazy("[p1] load x y z");
-    val cp1 = (p1 = p1).toCell().load();
+    val cp1 = (p1 = Point3d{ x: 2, y: 3, z: 99 }).toCell().load();
     __expect_lazy("[p2] load x y z");
     val cp2 = Cell<Point3d>.load(((p2.x += 5, p2).1).toCell());
     __expect_lazy("[p3] load (bits32) y, save immutable (tail)");
@@ -1586,7 +1586,7 @@ fun demo317() {
     var wrapped = lazy StorageWithTail.fromCell(src);
     __expect_lazy("[wrapped] load a, save immutable (tail)");
     wrapped.a = 33;
-    val wrappedOut = StorageWithTail.fromCell((wrapped = wrapped).makeCell());
+    val wrappedOut = StorageWithTail.fromCell(wrapped.makeCell());
 
     return (
         wrappedOut.a,
@@ -1608,8 +1608,11 @@ fun LazyAssignTrio.hashInline(self): int {
 @method_id(318)
 fun demo318() {
     var st = lazy LazyAssignTrio.fromSlice("010203".hexToSlice());
-    var other = lazy LazyAssignTrio.fromSlice("AABBCC".hexToSlice());
-    return (st = other).hashInline() == other.toCell().hash();
+    val other = LazyAssignTrio { a: 170, b: 187, c: 204 };
+    val inlineCallSawOther = (st = other).hashInline() == other.toCell().hash();
+    val st2 = st.toCell().load();
+    val other2 = other.toCell().load();
+    return (inlineCallSawOther, st2.a, st2.b, st2.c, other2.a, other2.b, other2.c);
 }
 
 
@@ -2063,7 +2066,7 @@ fun main() {
 @testcase | 314 |                 | 11 20 [ 8 [ 8 8 ] ] [ 8 [ 11 20 ] ] 32 [ 8 [ 8 9 ] ]
 @testcase | 315 |                 | 8 8 66 44 [ [ (null) (null) 0 ] ]
 @testcase | 316 |                 | 2 3 99 7 3 99 100 2 100 99
-@testcase | 318 |                 | -1
+@testcase | 318 |                 | -1 170 187 204 170 187 204
 
 @testcase | 400 |                             | 5
 @testcase | 401 | x{0110} -1                  | 50

--- a/tolk-tester/tests/maps-tests.tolk
+++ b/tolk-tester/tests/maps-tests.tolk
@@ -204,9 +204,9 @@ fun test8() {
 @method_id(109)
 fun test9() {
     var m = [] as map<int8, (coins, ())>;
-    m.set(1, (ton("1"), ()));
-    val replaced = m.replaceIfExists(1, (ton("0.05"), ()));
-    val prev = m.replaceAndGetPrevious(1, (ton("0.01"), ()));
+    m.set(1, (grams("1"), ()));
+    val replaced = m.replaceIfExists(1, (grams("0.05"), ()));
+    val prev = m.replaceAndGetPrevious(1, (grams("0.01"), ()));
     return (replaced, prev.loadValue(), m.replaceAndGetPrevious(2, (0,())), m.mustGet(1).0);
 }
 
@@ -340,8 +340,8 @@ fun test22() {
 @method_id(123)
 fun test23() {
     var m: map<Point, DataWithCell> = createEmptyMap();
-    val p1 = m.setAndGetPrevious({x:1,y:1}, {a: null, v: ton("0.05"), p: Point{x:10,y:10}.toCell(), payload: null});
-    val p2 = m.setAndGetPrevious({x:1,y:1}, {a: null, v: ton("0.1"), p: null, payload: createEmptyCell()});
+    val p1 = m.setAndGetPrevious({x:1,y:1}, {a: null, v: grams("0.05"), p: Point{x:10,y:10}.toCell(), payload: null});
+    val p2 = m.setAndGetPrevious({x:1,y:1}, {a: null, v: grams("0.1"), p: null, payload: createEmptyCell()});
     return (p1.isFound, p2.isFound, p2.loadValue().p!.load(), m.mustGet({x:1,y:1}).a == null, m.get({x:1,y:1}).loadValue().payload.depth());
 }
 
@@ -349,9 +349,9 @@ fun test23() {
 fun test24() {
     var m = map<Point, DataWithCell> [];
     val p1 = m.deleteAndGetDeleted({x: 1, y: 1});
-    m.set({x: 3, y: 3}, {a: null, v: ton("0.05"), p: Point{x:30,y:30}.toCell(), payload: createEmptyCell()});
-    m.set({x: 1, y: 1}, {a: null, v: ton("0.05"), p: Point{x:10,y:10}.toCell(), payload: null});
-    m.set({x: 2, y: 2}, {a: null, v: ton("0.05"), p: null, payload: null});
+    m.set({x: 3, y: 3}, {a: null, v: grams("0.05"), p: Point{x:30,y:30}.toCell(), payload: createEmptyCell()});
+    m.set({x: 1, y: 1}, {a: null, v: grams("0.05"), p: Point{x:10,y:10}.toCell(), payload: null});
+    m.set({x: 2, y: 2}, {a: null, v: grams("0.05"), p: null, payload: null});
     val k2 = m.findKeyGreaterOrEqual({x: 2, y: 2}).getKey();
     var r = m.findFirst();
     var t = [];

--- a/tolk-tester/tests/match-by-expr-tests.tolk
+++ b/tolk-tester/tests/match-by-expr-tests.tolk
@@ -62,14 +62,14 @@ fun test5(x: int) {
 fun test6(x: coins) {
     var result1 = 0;
     match (x) {
-        ton("0.05") => { result1 = 5; }
-        ton("0.1") => { result1 = 10; }
+        grams("0.05") => { result1 = 5; }
+        grams("0.1") => { result1 = 10; }
         else => { result1 = 20; }
     }
     var result2 = 0;
     match (x) {
-        ton("0.05") => { result2 = 5 }
-        ton("0.1") => { result2 = 10 }
+        grams("0.05") => { result2 = 5 }
+        grams("0.1") => { result2 = 10 }
     }
     return (result1, result2);
 }

--- a/tolk-tester/tests/methods-tests.tolk
+++ b/tolk-tester/tests/methods-tests.tolk
@@ -344,6 +344,20 @@ fun test20(v1: int?) {
     return ((getI1(v1, 5) ?? getI1(100, 10)).double(), callOrder)
 }
 
+fun int.eqSelfShadowed(self): self {
+    var expect = self;
+    {
+        var `self` = beginCell();
+        assert (`self`.bitsCount() == expect) throw 123;
+    }
+    return self;
+}
+
+@method_id(121)
+fun test21(zero: int) {
+    return zero.eqSelfShadowed().eqSelfShadowed();
+}
+
 fun main() {}
 
 /**
@@ -367,6 +381,7 @@ fun main() {}
 @testcase | 119 |        | [ 5 ] 3
 @testcase | 120 | 6      | 12 [ 6 ] 
 @testcase | 120 | null   | 10 [ (null) ] 
+@testcase | 121 | 0      | 0
 
 @fif_codegen DECLPROC Pair<int16,`int8>.createFrom<int,`coins>()
 @fif_codegen DECLPROC Pair<int8,`int16>.compareWith<int16,`int8>()

--- a/tolk-tester/tests/mutate-methods.tolk
+++ b/tolk-tester/tests/mutate-methods.tolk
@@ -172,9 +172,12 @@ fun testMutableTensor() {
     updateTwoItems(mutate t, 10);
     t107_1 = 1;
     t107_2 = 2;
-    (t107_1, t107_2).updateTwoItems(10);
-    updateTwoItems(mutate (t107_1, t107_2), 10);
-    return (t, t107_1, t107_2);
+    var globalsPair = (t107_1, t107_2);
+    globalsPair.updateTwoItems(10);
+    updateTwoItems(mutate globalsPair, 10);
+    val before = t107_1;
+    (t107_1, t107_2) = globalsPair;
+    return (t, before, t107_1, t107_2);
 }
 
 @pure
@@ -443,7 +446,7 @@ fun main(){
 @testcase | 104 |    | 1 2 3
 @testcase | 105 |    | 5 5 110
 @testcase | 106 |    | 160 110
-@testcase | 107 |    | 60 70 21 22
+@testcase | 107 |    | 60 70 1 21 22
 @testcase | 110 |    | 320
 @testcase | 111 |    | 55 55
 @testcase | 112 |    | [ 1 13 3 23 33 ]

--- a/tolk-tester/tests/overloads-tests.tolk
+++ b/tolk-tester/tests/overloads-tests.tolk
@@ -72,6 +72,7 @@ fun test4() {
     __expect_type((5 as int).unionMix(), "bool");
     __expect_type((createEmptySlice().unionMix()), "slice");
     __expect_type(((5 as int|slice).unionMix()), "slice");
+    __expect_type(((5 as slice|int).unionMix()), "slice");
 }
 
 fun WrapA<T>.dup(self): WrapA<T> { return self }
@@ -372,6 +373,48 @@ fun test19() {
     __expect_type(throughAlias.which(), "int1");
 }
 
+type TaggedCellForPick<T> = cell
+
+fun TaggedCellForPick<(T, T)>.pickSpecialized(self): int22 {
+    return 22;
+}
+
+fun TaggedCellForPick<T | (U, V)>.pickSpecialized(self): int33 {
+    return 33;
+}
+
+@method_id(120)
+fun test20(): int {
+    val c: TaggedCellForPick<(int, int)> = createEmptyCell();
+    __expect_type(c.pickSpecialized(), "int22");
+    return c.pickSpecialized();
+}
+
+struct BoxForPick<T> { value: T }
+
+fun (T | BoxForPick<T>).pickT(self): int { return 111; }
+
+@method_id(121)
+fun test21(): int {
+    val order1 = 7 as int | BoxForPick<int>;
+    val order2 = 7 as BoxForPick<int> | int;
+    __expect_type(order2.pickT(), "int");
+    return order1.pickT() + order2.pickT();
+}
+
+struct OkRes<T> { v: T }
+struct ErrRes<E> { e: E }
+
+fun (OkRes<T> | ErrRes<E>).tagRes(self): int { return 222; }
+
+@method_id(122)
+fun test22(): int {
+    val order1 = ErrRes<slice>{ e: createEmptySlice() } as OkRes<int> | ErrRes<slice>;
+    val order2 = OkRes<int>{ v: 9 } as ErrRes<slice> | OkRes<int>;
+    __expect_type(order2.tagRes(), "int");
+    return order1.tagRes() + order2.tagRes();
+}
+
 fun main() {
     // besides these positive tests, there are many negative resulting in "ambiguous call"
     return 0
@@ -382,6 +425,9 @@ fun main() {
 @testcase | 113 |   | [ 1 2 258 1 2 -777 ]
 @testcase | 116 |   | 111222
 @testcase | 118 |   | 123
+@testcase | 120 |   | 22
+@testcase | 121 |   | 222
+@testcase | 122 |   | 444
 
 @fif_codegen
 """

--- a/tolk-tester/tests/pack-unpack-1.tolk
+++ b/tolk-tester/tests/pack-unpack-1.tolk
@@ -12,6 +12,11 @@ struct TwoU {
     b: uint8
 }
 
+struct MyType<T = RemainingBitsAndRefs> {
+    first: int8
+    next: T
+}
+
 @method_id(101)
 fun test1(value: int) {
     var t: JustInt32 = { value };
@@ -112,6 +117,14 @@ fun test9() {
     return (loaded.value, loadedInner.value, loadedTail, loadedInner.withCell == null);
 }
 
+@method_id(110)
+fun test10() {
+    val value1 = MyType.fromSlice("010203".hexToSlice());
+    __expect_type(value1, "MyType<RemainingBitsAndRefs>");
+    val value2 = MyType<int8>.fromSlice("010203".hexToSlice(), { assertEndAfterReading: false });
+    return value1.next.remainingBitsCount() + value2.next;
+}
+
 fun main(c: cell) {
     c as Cell<Point>;
     (c as Cell<Point>) as cell;
@@ -133,6 +146,7 @@ fun main(c: cell) {
 @testcase | 107 | x{0234}       | 6 16
 @testcase | 108 |               | 5 1
 @testcase | 109 |               | 20 10 30 -1
+@testcase | 110 |               | 18
 
 @fif_codegen
 """

--- a/tolk-tester/tests/pack-unpack-2.tolk
+++ b/tolk-tester/tests/pack-unpack-2.tolk
@@ -724,7 +724,7 @@ fun test_RestIsBuilderOrRemaining() {
         .storeRef(JustAddress { addr: address("9:527964d55cfa6eb731f4bfc07e9d025098097ef8505519e853986279bd8400d8") }.toCell());
     var w: ReadWriteRest<builder> = {
         f1: 60,
-        f2: ton("0.05"),
+        f2: grams("0.05"),
         rest: remainingB
     };
     var r: ReadRest_Remaining = w.toCell().beginParse().loadAny();
@@ -739,7 +739,7 @@ fun test_MidIsBuilderOrBitsN() {
     var typedCell = ReadWriteMid {
         f1: 5,
         mid: bits40_b,
-        f3: ton("0.05")
+        f3: grams("0.05")
     }.toCell();
     __expect_type(typedCell, "Cell<ReadWriteMid<builder>>");
     var r = ReadWriteMid<bits40>.fromCell(typedCell);

--- a/tolk-tester/tests/pack-unpack-8.tolk
+++ b/tolk-tester/tests/pack-unpack-8.tolk
@@ -152,7 +152,9 @@ fun test10() {
 fun test11() {
     var (r1, r2) = (-1 as Role, -1 as Role);
     val before = (r1 == Role.Admin, r2 == Role.Admin);
-    (r1, r2).decode(stringHexToSlice("0001"));
+    var roles = (r1, r2);
+    roles.decode(stringHexToSlice("0001"));
+    (r1, r2) = roles;
     return (before, r1, r2, r1 == Role.Admin, r2 == Role.Admin, r1 == Role.User, r2 == Role.User)
 }
 

--- a/tolk-tester/tests/pack-unpack-8.tolk
+++ b/tolk-tester/tests/pack-unpack-8.tolk
@@ -60,12 +60,12 @@ enum EOfCrc32: uint32 {
 }
 
 enum Amounts: coins {
-    zero = ton("0"),
-    nanoton = 1,
-    small = ton("0.0001"),
-    more = ton("0.05"),
+    zero = grams("0"),
+    nanogram = 1,
+    small = grams("0.0001"),
+    more = grams("0.05"),
     more1,
-    one = ton("1"),
+    one = grams("1"),
 }
 
 
@@ -184,7 +184,7 @@ fun test14() {
         beginCell().storeAny(Amounts.zero).bitsCount(),
         beginCell().storeAny(Amounts.more).bitsCount(),
         Amounts.fromSlice(stringHexToSlice("402faf080")) as int64,
-        Amounts.fromSlice(stringHexToSlice("402faf080")) as coins == ton("0.05"),
+        Amounts.fromSlice(stringHexToSlice("402faf080")) as coins == grams("0.05"),
         Amounts.fromSlice(stringHexToSlice("402faf080")) == Amounts.more,
         Amounts.more1,
         ex,

--- a/tolk-tester/tests/pack-unpack-9.tolk
+++ b/tolk-tester/tests/pack-unpack-9.tolk
@@ -170,8 +170,8 @@ fun test7() {
 fun test8() {
     var arr: ArrayOfLotsCoins = [
         { nums: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0) },
-        { nums: (ton("10"), ton("10"), ton("10"), ton("10"), ton("10"), ton("10"), ton("10"), ton("10"), ton("10"), ton("10")) },
-        { nums: (0, 0, 0, 0, 0, 0, 0, 0, 0, ton("0.05")) },
+        { nums: (grams("10"), grams("10"), grams("10"), grams("10"), grams("10"), grams("10"), grams("10"), grams("10"), grams("10"), grams("10")) },
+        { nums: (0, 0, 0, 0, 0, 0, 0, 0, 0, grams("0.05")) },
     ];
     arr = ArrayOfLotsCoins.fromCell(arr.toCell());
     return (
@@ -190,7 +190,7 @@ fun test9() {
         createEmptySlice(),
         array<int32> [1,2].toCell().beginParse(),
         "hello".literalSlice(),
-        array<(coins, coins, coins, coins, cell)> [(0,ton("0.05"),0,0,createEmptyCell()), (1,1,1,1,createEmptyCell()), (2,2,2,2,createEmptyCell())].toCell().beginParse(),
+        array<(coins, coins, coins, coins, cell)> [(0,grams("0.05"),0,0,createEmptyCell()), (1,1,1,1,createEmptyCell()), (2,2,2,2,createEmptyCell())].toCell().beginParse(),
     ];
     var back = array<RemainingBitsAndRefs>.fromCell(a1.toCell());
     var last = array<(coins, coins, coins, coins, cell)>.fromSlice(back.last());

--- a/tolk-tester/tests/self-keyword.tolk
+++ b/tolk-tester/tests/self-keyword.tolk
@@ -221,6 +221,27 @@ fun test112() {
     return (1.asmSelfId(), 2.asmSelfId().asmSelfId());
 }
 
+type PairShape = [int, int];
+
+fun PairShape.incFirst(mutate self): self {
+    self.0 += 1;
+    return self;
+}
+
+@method_id(113)
+fun test113() {
+    var viaDot: [PairShape] = [[1, 2]];
+    viaDot.0.incFirst().incFirst();
+
+    var viaQualified: [PairShape] = [[1, 2]];
+    val returned = PairShape.incFirst(mutate viaQualified.0).incFirst();
+
+    var singleQualified: [PairShape] = [[5, 6]];
+    PairShape.incFirst(mutate singleQualified.0);
+
+    return (viaDot.0.0, viaQualified.0.0, returned.0, singleQualified.0.0);
+}
+
 fun main() { }
 
 /**
@@ -244,6 +265,7 @@ fun main() { }
 @testcase | 110 | 0   | 24 [ 2 13 ]
 @testcase | 111 |     | 10 3 [ 1 2 3 ]
 @testcase | 112 |     | 1 2
+@testcase | 113 |     | 3 3 3 6
 
 @fif_codegen
 """

--- a/tolk-tester/tests/send-msg-1.tolk
+++ b/tolk-tester/tests/send-msg-1.tolk
@@ -394,7 +394,7 @@ fun test12_manual(data32: uint32) {
     return beginCell()
         .storeUint(0x18, 6)         // bounce
         .storeUint(0b100, 3).storeInt(MASTERCHAIN, 8).storeUint(StateInit.calcHashCodeData(init.code, init.data), 256)
-        .storeCoins(ton("0.05"))
+        .storeCoins(grams("0.05"))
         // 1 state init exists, 0 either left (state init embedded), 00110 (code and data), 0 either left (body inline)
         .storeUint(0b10001100, 1 + 4 + 4 + 64 + 32 + (1 + 1 + 5 + 1))
         .storeRef(init.code)
@@ -414,7 +414,7 @@ fun test12(data32: uint32) {
         bounce: true,
         body: data32,
         dest: { workchain: MASTERCHAIN, stateInit: init },
-        value: ton("0.05"),
+        value: grams("0.05"),
     });
     assert(b.hash() == test12_manual(data32).hash(), 112);
     return b.hash();
@@ -483,7 +483,7 @@ fun test15_manual(stateInitCell: cell, bd: Body15) {
     return beginCell()
         .storeUint(0x10, 6)         // no bounce
         .storeAddress(nftAddress)
-        .storeCoins(ton("100.0004"))
+        .storeCoins(grams("100.0004"))
         // 1 state init exists, 1 either right (state init ref), 1 either right (body ref)
         .storeUint(0b111, 1 + 4 + 4 + 64 + 32 + (1 + 1 + 1))
         .storeRef(stateInitCell)
@@ -512,7 +512,7 @@ fun test15(tens0: int, tens1: int) {
         bounce: false,
         dest: { workchain: MASTERCHAIN, stateInit: stateInitCell },
         body: bd,
-        value: ton("100.0004"),
+        value: grams("100.0004"),
     });
     assert(b.hash() == test15_manual(stateInitCell, bd).hash(), 115);
     return b.hash();
@@ -550,7 +550,7 @@ fun test19_manual(bd: uint64) {
     return beginCell()
         .storeUint(0x10, 6)         // no bounce
         .storeBuilder(destB)
-        .storeCoins(ton("0.059"))
+        .storeCoins(grams("0.059"))
         .storeUint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)  // ... + 0 init + 0 body (not ref)
         .storeUint(bd, 64)
         .endCell();
@@ -563,7 +563,7 @@ fun test19(bd: uint64) {
         bounce: 10 < 3,
         body: bd,
         dest: destB,
-        value: ton("0.059"),
+        value: grams("0.059"),
     });
     assert(b.hash() == test19_manual(bd).hash(), 119);
     return b.hash();
@@ -604,7 +604,7 @@ fun test21_manual(bd: Body21) {
     return beginCell()
         .storeUint(0x10, 6)            // no bounce
         .storeAddress(address("EQAUzE-Nef80O9dLZy91HfPiOb6EEQ8YqyWKyIU-KeaYLNUi"))
-        .storeCoins(ton("0.1"))     // value.grams
+        .storeCoins(grams("0.1"))     // value.grams
         .storeDict(createEmptyDict())
         .storeUint(1, 4 + 4 + 64 + 32 + 1 + 1)  // ... + 0 init + 1 body (ref)
         .storeRef(bd.toCell())      // stored as ref due to remainder of unpredictable size
@@ -618,7 +618,7 @@ fun test21(queryId: uint64) {
     var b = createMessage({
         bounce: false,
         dest: address("EQAUzE-Nef80O9dLZy91HfPiOb6EEQ8YqyWKyIU-KeaYLNUi"),
-        value: (ton("0.1"), createEmptyMap<int32, varuint32>()),
+        value: (grams("0.1"), createEmptyMap<int32, varuint32>()),
         body,
     });
     assert(b.hash() == test21_manual(body).hash(), 121);
@@ -630,7 +630,7 @@ fun test22_manual(unsafeB: builder) {
     return beginCell()
         .storeUint(0x18, 6)            // bounce
         .storeAddress(address("0:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFfffffffffffffffffffffffffffff"))
-        .storeCoins(ton("0.08"))
+        .storeCoins(grams("0.08"))
         .storeUint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)  // ... + 0 init + 0 body (no ref)
         .storeBuilder(unsafeB)
         .endCell();
@@ -642,7 +642,7 @@ fun test22(op: uint32, queryId: uint64) {
     var b = createMessage({
         bounce: true,
         dest: address("0:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFfffffffffffffffffffffffffffff"),
-        value: ton("0.08"),
+        value: grams("0.08"),
         body: UnsafeBodyNoRef {
             forceInline: bodyB
         },
@@ -666,7 +666,7 @@ fun test23_manual(state32: uint32, body: Body23Unlimited) {
     return beginCell()
         .storeUint(0x18, 6)         // bounce
         .storeUint(0b100, 3).storeInt(9, 8).storeUint(StateInit.calcHashCodeData(init.code, init.data), 256)
-        .storeCoins(ton("0.10009"))
+        .storeCoins(grams("0.10009"))
         // 1 state init exists, 0 either left (state init embedded), 00110 (code and data), 0 either left (body inline)
         .storeUint(0b10001100, 1 + 4 + 4 + 64 + 32 + (1 + 1 + 5 + 1))
         .storeRef(init.code)
@@ -694,7 +694,7 @@ fun test23(state32: uint32) {
             forceInline: bd,
         },
         dest: { workchain: 9, stateInit: init },
-        value: ton("0.10009"),
+        value: grams("0.10009"),
     });
     assert(b.hash() == test23_manual(state32, bd).hash(), 123);
     return b.hash();
@@ -705,7 +705,7 @@ fun test24_manual(addrHash: uint256) {
     return beginCell()
         .storeUint(0x18, 6)            // bounce
         .storeUint(0b100, 3).storeInt(MASTERCHAIN, 8).storeUint(addrHash, 256)
-        .storeCoins(ton("0.6"))
+        .storeCoins(grams("0.6"))
         .storeUint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)  // ... + 0 init + 0 body (not ref)
         .storeUint(0x12345678, 32)
         .storeUint(800, 64)
@@ -719,7 +719,7 @@ fun test24() {
         body: MyBody { queryId: 800 },
         bounce: true,
         dest: (MASTERCHAIN, addrHash),
-        value: ton("0.6"),
+        value: grams("0.6"),
     });
     assert(b.hash() == test24_manual(addrHash).hash(), 124);
     return b.hash();

--- a/tolk-tester/tests/send-msg-2.tolk
+++ b/tolk-tester/tests/send-msg-2.tolk
@@ -115,7 +115,7 @@ fun test1_manual(toAddress: address, masterMsg: cell, jettonWalletCode: cell) {
     return beginCell()
         .storeUint(0x18, 6)     // bounceable
         .storeAddress(toWalletAddress) // dest
-        .storeCoins(ton("0.05"))
+        .storeCoins(grams("0.05"))
         // 1 state init exists, 0 either left (state init embedded), 1 either left (fixed_prefix_length exists)
         .storeUint(0b101, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
         .storeUint(SHARD_DEPTH, 5)
@@ -145,7 +145,7 @@ fun test1() {
             }
         },
         body: masterMsg,
-        value: ton("0.05"),
+        value: grams("0.05"),
     });
     assert(b.hash() == test1_manual(toAddress, masterMsg, jettonWalletCode).hash(), 101);
     return b.hash()
@@ -160,7 +160,7 @@ fun test2_manual(toAddress: address, masterMsg: cell, jettonWalletCode: cell) {
     return beginCell()
         .storeUint(0x18, 6)     // bounceable
         .storeAddress(toWalletAddress) // dest
-        .storeCoins(ton("0.05"))
+        .storeCoins(grams("0.05"))
         .storeUint(0, 1)    // no extra currencies
         .storeCoins(1)          // extra_flags for bounces
         .storeUint(0b111, 4 + 64 + 32 + 1 + 1 + 1)  // 1 state init exists + 1 state init ref + 1 body ref
@@ -187,7 +187,7 @@ fun test2() {
             }
         },
         body: masterMsg,
-        value: ton("0.05"),
+        value: grams("0.05"),
     });
     assert(b.hash() == test2_manual(toAddress, masterMsg, jettonWalletCode).hash(), 102);
     return b.hash()
@@ -204,7 +204,7 @@ fun test3_manual(myCode: cell, myData: cell, msgBody: Test3Body) {
     return beginCell()
         .storeUint(0x18, 6)     // bounceable
         .storeBuilder(addrInShard) // dest
-        .storeCoins(ton("0.001"))
+        .storeCoins(grams("0.001"))
         .storeUint(0, 1)    // no extra currencies
         .storeCoins(3)          // extra_flags for bounces
         .storeUint(0b10, 4 + 64 + 32 + 1 + 1)  // 1 state init exists + 1 state init inline
@@ -238,7 +238,7 @@ fun test3() {
             }
         },
         body,
-        value: ton("0.001"),
+        value: grams("0.001"),
     });
     assert(b.hash() == test3_manual(myCode, myData, body).hash(), 103);
     return b.hash()
@@ -268,7 +268,7 @@ fun test4() {
             }
         },
         body,
-        value: ton("0.1"),
+        value: grams("0.1"),
     });
     return b.hash()
 }
@@ -300,7 +300,7 @@ fun test5() {
             }
         },
         body: UnsafeBodyNoRef { forceInline: body },
-        value: ton("0.1"),
+        value: grams("0.1"),
     });
     return b.hash()
 }
@@ -326,7 +326,7 @@ fun test6(shardLen: int) {
             }
         },
         body: body,
-        value: ton("0.1"),
+        value: grams("0.1"),
     });
     return b.hash()
 }

--- a/tolk-tester/tests/send-msg-3.tolk
+++ b/tolk-tester/tests/send-msg-3.tolk
@@ -78,7 +78,7 @@ fun test3(eventId: int) {
     val someRef = MyBody { queryId: 800 }.toCell();
     var b = createExternalLogMessage({
         body: UnsafeBodyNoRef { 
-            forceInline: Body3 { bodyAddress, someRef, amount: ton("0.05") } 
+            forceInline: Body3 { bodyAddress, someRef, amount: grams("0.05") } 
         },
         dest: { topic: eventId },
     });

--- a/tolk-tester/tests/smart-cast-tests.tolk
+++ b/tolk-tester/tests/smart-cast-tests.tolk
@@ -900,6 +900,23 @@ fun test82(case: int) {
     return case == 1 ? classifyWithVoidField(w1) : classifyWithVoidField(w2);
 }
 
+type TensorLcaFirstSlotSmart = (int, int) | (slice, int)
+
+@method_id(183)
+fun test83(case: int) {
+    var x: TensorLcaFirstSlotSmart = case == 0 ? (10, 1) : ("00000020".hexToSlice(), 2);
+    if (x is (int, int)) {
+        __expect_type(x, "(int, int)");
+    } else {
+        __expect_type(x, "(slice, int)");
+    }
+    __expect_type(x, "TensorLcaFirstSlotSmart");
+    return match (x) {
+        (int, int) => x.0 + x.1,
+        (slice, int) => x.0.loadInt(32) + x.1,
+    };
+}
+
 fun main(x: int?): int {
     // mark used to codegen them
     test55;
@@ -942,6 +959,8 @@ fun main(x: int?): int {
 @testcase | 181 | 2     | -20
 @testcase | 182 | 1     | 107
 @testcase | 182 | 0     | 8
+@testcase | 183 | 0     | 11
+@testcase | 183 | 1     | 34
 
 @stderr warning: expression of type `int` can never be `null`, this condition is always true
 

--- a/tolk-tester/tests/some-tests-2.tolk
+++ b/tolk-tester/tests/some-tests-2.tolk
@@ -155,8 +155,8 @@ fun test96(p: Point) {
     3 PUSHINT	    //  g_next '12=3
     4 PUSHINT	    //  g_next '12=3 '13=4
     5 PUSHINT	    //  g_next '12=3 '13=4 '14=5
-    3 TUPLE	        //  g_cur g_next
-    SWAP            //  g_next g_cur
+    3 TUPLE	        //  g_cur '16
+    SWAP            //  '16 g_cur
     $cur SETGLOB    //  g_next
     $next SETGLOB   //
     $cur GETGLOB    //  g_cur

--- a/tolk-tester/tests/struct-tests.tolk
+++ b/tolk-tester/tests/struct-tests.tolk
@@ -91,15 +91,15 @@ fun test1() {
 
 @method_id(102)
 fun test2() {
-    var i1 = JustIntAlias2 { value: 1 };
-    var i2: JustInt = JustIntAlias2 { value: 2, };
+    var i1 = JustInt { value: 1 };
+    var i2: JustInt = JustInt { value: 2, };
     var i3: JustIntAlias2 = { `value`: 3 };
     __expect_type(i1.value, "int");
     __expect_type(i1.value + i2.value + i3.value, "int");
     __expect_type(i3, "JustIntAlias2");
     __expect_type([i2, i3], "array<JustInt>");
     __expect_type([i2] as [JustIntAlias], "[JustIntAlias]");
-    return (i1, i2, i3, [i1, JustIntAlias{value:5}]);
+    return (i1, i2, i3, [i1, JustInt{value:5}]);
 }
 
 @method_id(103)
@@ -120,7 +120,7 @@ fun test4() {
 
 @method_id(105)
 fun test5() {
-    var b = PointAlias { y: 20, x: 10 };
+    var b = Point { y: 20, x: 10 };
     var p: PointAlias = Point { x: b.x, y: b.y };
     p.x += 5;
     return (sumCoords(p), p.y += 10, p.sumCoords());
@@ -172,7 +172,7 @@ fun test8() {
     __expect_type(o6, "OuterEmpty");
     __expect_type(o8, "OuterEmpty?");
     __expect_type(EmptyGeneric2<slice>{}, "EmptyGeneric2<slice>");
-    return (e1, Empty{}, EmptyAlias{}, o2, o1, 777, o3, 777, o4, 777, o5, 777, o6, 777, o7, 777, o8, 777, o3!, 777);
+    return (e1, Empty{}, Empty{}, o2, o1, 777, o3, 777, o4, 777, o5, 777, o6, 777, o7, 777, o8, 777, o3!, 777);
 }
 
 fun maxCoord(p: Point): int8 {
@@ -687,7 +687,7 @@ fun test50(p1set: bool, p2set: bool) {
 
 
 fun main(x: int8, y: MInt) {
-    __expect_type(PointAlias{x,y}, "Point");
+    __expect_type(Point{x,y} as PointAlias, "PointAlias");
     __expect_type(Point{x,y} as Point, "Point");
     __expect_type(test3(), "Point");
     __expect_type(maxCoord, "(Point) -> int8");

--- a/tolk-tester/tests/ternary-tests.tolk
+++ b/tolk-tester/tests/ternary-tests.tolk
@@ -79,7 +79,7 @@ fun test108(calcMin: bool) {
 
 @method_id(109)
 fun test109(bigCost: bool) {
-    return bigCost ? ton("0.05") : (ton("0.001"));
+    return bigCost ? grams("0.05") : (grams("0.001"));
 }
 
 @method_id(110)

--- a/tolk-tester/tests/try-catch-tests.tolk
+++ b/tolk-tester/tests/try-catch-tests.tolk
@@ -350,6 +350,33 @@ fun testMultipleCallsInline(f1: bool, f2: bool) {
   );
 }
 
+@method_id(120)
+fun testAssertWithTooBigThrow(x: int) {
+  assert (x != 0) throw 100500;
+  return true;
+}
+
+@inline
+fun chooseInlineReturnInsideTry(flag: int): int {
+  __expect_inline(false);   // inlining deferred to Fift due to returns in the middle
+  try {
+    if (flag == 1) {
+      return 10;
+    }
+    if (flag == 2) {
+      throw 7;
+    }
+  } catch {
+    return 20;
+  }
+  return 30;
+}
+
+@method_id(121)
+fun testInlineReturnInsideTry(flag: int): int {
+  return chooseInlineReturnInsideTry(flag);
+}
+
 
 
 fun main() {
@@ -394,8 +421,12 @@ fun main() {
 @testcase | 118 | 0     | 4
 @testcase | 118 | 5     | 9
 @testcase | 119 | 0 -1  | 10 77
+@testcase | 120 | 3     | -1
+@testcase | 121 | 1     | 10
+@testcase | 121 | 2     | 20
+@testcase | 121 | 3     | 30
 
-@code_hash 34012631818098475279658441364753721171324163142039669737611375109698815455069
+@code_hash 17473387520586690375058520669959417766875699647034456359443028989383748791753
 
 @fif_codegen
 """
@@ -458,9 +489,32 @@ CONT:<{
 
 @fif_codegen
 """
+  chooseInlineReturnInsideTry() PROCINLINE:<{
+    ...
+          10 PUSHINT
+          RETALT
+    ...
+      30 PUSHINT
+    ...
+  }>
+"""
+
+@fif_codegen
+"""
 foo_inline() PROCINLINE:<{
   CONT:<{
     c2 SAVE
     SAMEALTSAVE
+"""
+
+@fif_codegen
+"""
+  testAssertWithTooBigThrow() PROC:<{   //  x
+    IFNOTJMP:<{                 //
+      100500 PUSHINT            //  '3=100500
+      THROWANY
+    }>                          //
+    TRUE                        //  '4
+  }>
 """
 */

--- a/tolk-tester/tests/type-aliases-tests.tolk
+++ b/tolk-tester/tests/type-aliases-tests.tolk
@@ -54,9 +54,8 @@ fun test1(x: MInt): MVoid {
     __expect_type(x as MInt?, "MInt?");
     __expect_type(x as MIntN, "MIntN");
 
-    __expect_type(PointAlias{x:0,y:0}, "Point");
-    __expect_type(PointAlias2{x:0,y:0}, "Point");
     __expect_type(Point{x:0,y:0} as PointAlias, "PointAlias");
+    __expect_type(Point{x:0,y:0} as PointAlias2, "PointAlias2");
 
     if (x != 0) { return; }
 }

--- a/tolk-tester/tests/union-types-tests.tolk
+++ b/tolk-tester/tests/union-types-tests.tolk
@@ -980,6 +980,24 @@ fun test74(case: int) {
     return a + 0;
 }
 
+type TensorLcaSecondSlotUnion = (int, slice) | (int | int8, builder);
+
+@method_id(175)
+fun test75(case: int) {
+    var x: TensorLcaSecondSlotUnion = case == 1 ? (5, getSlice32()) : (8 as int8, beginCell());
+    if (x !is (int, slice)) {
+        __expect_type(x, "(int | int8, builder)");
+    }
+    __expect_type(x, "TensorLcaSecondSlotUnion");
+    return match (x) {
+        (int, slice) => x.0 + x.1.loadInt(32),
+        (int | int8, builder) => match (x.0) {
+            int => { __expect_type(x.0, "int"); throw 123 }
+            int8 => x.0 + x.1.bitsCount(),
+        }
+    };
+}
+
 
 fun main() {
     return 0;
@@ -1076,6 +1094,8 @@ fun main() {
 @testcase | 173 |           | -1 0 -1 0
 @testcase | 174 | 0         | 7
 @testcase | 174 | 1         | 42
+@testcase | 175 | 0         | 8
+@testcase | 175 | 1         | 37
 
 
 @fif_codegen

--- a/tolk/abi.cpp
+++ b/tolk/abi.cpp
@@ -71,9 +71,11 @@ static ParsedDocComment parse_doc_comment(const DocCommentLines& doc_lines) {
 }
 
 static TypePtr normalize_createMessage_ty(TypePtr body_ty) {
-  if (const TypeDataStruct* t_struct = body_ty->unwrap_alias()->try_as<TypeDataStruct>()) {
-    if (t_struct->struct_ref->is_instantiation_of_CellT() || t_struct->struct_ref->is_instantiation_of_UnsafeBodyNoRef()) {
-      body_ty = t_struct->struct_ref->substitutedTs->typeT_at(0);
+  if (!get_custom_pack_unpack_function(body_ty)) {
+    if (const TypeDataStruct* t_struct = body_ty->unwrap_alias()->try_as<TypeDataStruct>()) {
+      if (t_struct->struct_ref->is_instantiation_of_CellT() || t_struct->struct_ref->is_instantiation_of_UnsafeBodyNoRef()) {
+        body_ty = t_struct->struct_ref->substitutedTs->typeT_at(0);
+      }
     }
   }
   return body_ty;
@@ -175,14 +177,12 @@ void ContractABI::register_emitted_event(TypePtr body_ty) {
 
 void ContractABI::register_thrown_error(GlobalConstPtr const_ref) {
   ConstValExpression val = eval_and_cache_const_init_val(const_ref);
-  while (std::holds_alternative<ConstValCastToType>(val)) {     // unwrap `const A: int32 = 5`
-    val = std::get<ConstValCastToType>(val).inner.front();   // (it's "cast 5 to int32" in a const-expr tree)
-  }
-  if (!std::holds_alternative<ConstValInt>(val)) {
+  td::RefInt256 err_code = unwrap_const_val_to_int(std::move(val));
+  if (err_code.is_null()) {
     return;
   }
 
-  register_thrown_error(ABIThrownErrorKind::constant, std::get<ConstValInt>(val).int_val, const_ref->name, get_abi_description(const_ref->doc_lines));
+  register_thrown_error(ABIThrownErrorKind::constant, err_code, const_ref->name, get_abi_description(const_ref->doc_lines));
   json_types.register_used_type(const_ref->inferred_type);
 }
 

--- a/tolk/ast-from-tokens.cpp
+++ b/tolk/ast-from-tokens.cpp
@@ -1694,8 +1694,11 @@ static AnyV parse_asm_func_body(Lexer& lex, V<ast_identifier> name_ident, V<ast_
     if (lex.tok() == tok_arrow) {
       lex.next();
       while (lex.tok() == tok_int_const) {
-        int ret_idx = static_cast<int>(parse_tok_int_const(lex.cur_str(), lex.cur_range())->to_long());
-        ret_order.push_back(ret_idx);
+        td::RefInt256 ret_idx = parse_tok_int_const(lex.cur_str(), lex.cur_range());
+        if (ret_idx < 0 || ret_idx >= 256) {
+          err("invalid asm index").fire(lex.cur_range());
+        }
+        ret_order.push_back(static_cast<int>(ret_idx->to_long()));
         lex.next();
       }
     }
@@ -1814,12 +1817,21 @@ static AnyV parse_function_declaration(Lexer& lex, AnnotationsAbove& annotations
   for (auto v_annotation : annotations.above) {
     switch (v_annotation->kind) {
       case AnnotationKind::inline_simple:
+        if (v_body->kind == ast_asm_body) {
+          err("inline annotations are not applicable to asm functions").fire(v_annotation);
+        }
         inline_mode = FunctionInlineMode::inlineViaFif;   // maybe will be replaced by inlineInPlace later
         break;
       case AnnotationKind::inline_ref:
+        if (v_body->kind == ast_asm_body) {
+          err("inline annotations are not applicable to asm functions").fire(v_annotation);
+        }
         inline_mode = FunctionInlineMode::inlineRef;
         break;
       case AnnotationKind::noinline:
+        if (v_body->kind == ast_asm_body) {
+          err("inline annotations are not applicable to asm functions").fire(v_annotation);
+        }
         inline_mode = FunctionInlineMode::noInline;
         break;
       case AnnotationKind::pure:
@@ -2081,19 +2093,44 @@ static AnyV parse_enum_declaration(Lexer& lex, AnnotationsAbove& annotations) {
   return createV<ast_enum_declaration>(range, v_ident, colon_type, doc_lines, body);
 }
 
+// for `tolk 1.4.0`, check for every "1","4","0" that it's a decimal token, not "0x..."
+static bool is_decimal_semver_part(std::string_view str) {
+  bool all_digits = true;
+  for (char c : str) {
+    all_digits &= c >= '0' && c <= '9';
+  }
+  return all_digits;
+}
+
 static AnyV parse_tolk_required_version(Lexer& lex) {
   SrcRange range = lex.range_start();
-  lex.next_special(tok_semver, "semver");   // syntax: "tolk 0.6"
+  lex.expect(tok_tolk, "`tolk`");
+
+  if (lex.tok() != tok_int_const || !is_decimal_semver_part(lex.cur_str())) {
+    lex.unexpected("semver, like `tolk 1.2`");
+  }
+
   std::string semver = static_cast<std::string>(lex.cur_str());
   range.end(lex.cur_range());
   lex.next();
+  while (lex.tok() == tok_dot) {      // allow `tolk 1.4`, `tolk 1.4.1`, etc.
+    lex.next();
+    if (lex.tok() != tok_int_const || !is_decimal_semver_part(lex.cur_str())) {
+      lex.unexpected("semver, like `tolk 1.2`");
+    }
+
+    semver += '.';
+    semver += lex.cur_str();
+    range.end(lex.cur_range());
+    lex.next();
+  }
 
   // for simplicity, there is no syntax ">= version" and so on, just strict compare
   if (TOLK_VERSION != semver && TOLK_VERSION != semver + ".0") {    // 0.6 = 0.6.0
     err("the contract is written in Tolk v{}, but you use Tolk compiler v{}; probably, it will lead to compilation errors or hash changes", semver, TOLK_VERSION).warning(range, nullptr);
   }
 
-  return createV<ast_tolk_required_version>(range, semver);  // semicolon is not necessary
+  return createV<ast_tolk_required_version>(range, std::move(semver));
 }
 
 static AnyV parse_import_directive(Lexer& lex) {

--- a/tolk/ast.h
+++ b/tolk/ast.h
@@ -1509,11 +1509,11 @@ template<>
 // example: `tolk 0.6`
 // when compiler version mismatches, it means, that another compiler was earlier for that sources, a warning is emitted
 struct Vertex<ast_tolk_required_version> final : ASTOtherLeaf {
-  std::string_view semver;
+  std::string semver;
 
-  Vertex(SrcRange range, std::string_view semver)
+  Vertex(SrcRange range, std::string semver)
     : ASTOtherLeaf(ast_tolk_required_version, range)
-    , semver(semver) {}
+    , semver(std::move(semver)) {}
 };
 
 template<>

--- a/tolk/ast.h
+++ b/tolk/ast.h
@@ -157,7 +157,7 @@ enum class AnnotationKind {
 };
 
 enum class MatchArmKind {    // for `match` expression, each of arms `pattern => body` can be:
-  const_expression,          // `-1 => body` / `SOME_CONST + ton("0.05") => body` (any expr at parsing, resulting in const)
+  const_expression,          // `-1 => body` / `SOME_CONST + grams("0.05") => body` (any expr at parsing, resulting in const)
   exact_type,                // `int => body` / `User | slice => body`
   else_branch,               // `else => body`
 };

--- a/tolk/builtins.cpp
+++ b/tolk/builtins.cpp
@@ -1389,10 +1389,10 @@ std::vector<var_idx_t> generate_reflect_stackSizeOf(FunctionPtr called_f, CodeBl
 }
 
 
-// fun ton(amount: slice): coins; ton("0.05") replaced by 50000000 at compile-time
+// fun grams(amount: slice): coins; grams("0.05") replaced by 50000000 at compile-time
 // same for stringCrc32(constString: slice) and others
 static AsmOp compile_time_only_function(std::vector<VarDescr>&, std::vector<VarDescr>&, AnyV origin) {
-  // all ton() invocations are constants, replaced by integers; no dynamic values allowed, no work at runtime
+  // all grams() invocations are constants, replaced by integers; no dynamic values allowed, no work at runtime
   tolk_assert(false);
   return AsmOp::Nop(origin);
 }
@@ -1655,7 +1655,10 @@ void define_builtins() {
 
   // compile-time only functions, evaluated essentially at compile-time, no runtime implementation
   // they are placed in stdlib and marked as `builtin`
-  // note their parameter being `unknown`: in order to `ton(1)` pass type inferring but fire a more gentle error later
+  // note their parameter being `unknown`: in order to `grams(1)` pass type inferring but fire a more gentle error later
+  define_builtin_func("grams", {TypeDataUnknown::create()}, TypeDataCoins::create(), nullptr,
+                              compile_time_only_function,
+                                FunctionData::flagMarkedAsPure | FunctionData::flagCompileTimeVal);
   define_builtin_func("ton", {TypeDataUnknown::create()}, TypeDataCoins::create(), nullptr,
                               compile_time_only_function,
                                 FunctionData::flagMarkedAsPure | FunctionData::flagCompileTimeVal);

--- a/tolk/codegen.cpp
+++ b/tolk/codegen.cpp
@@ -720,6 +720,7 @@ bool Op::generate_code_step(Stack& stack, const OpList& parent_ops, size_t self_
         stack.mode &= ~Stack::_InlineFunc;
         stack.o << AsmOp::Custom(origin, is0 ? "IF:<{" : "IFNOT:<{");
         Stack stack_copy{stack};
+        stack_copy.mode |= (blk_other.is_noreturn() || next_op.noreturn()) ? 0 : Stack::_NeedRetAlt;
         blk_noreturn.generate_code_all(stack_copy);
         stack.o << AsmOp::Custom(NULL_ORIGIN, "}>ELSE<{");
         stack.save_stack_comment();

--- a/tolk/constant-evaluator.cpp
+++ b/tolk/constant-evaluator.cpp
@@ -118,8 +118,8 @@ static void parse_any_std_address(std::string_view str, SrcRange range, unsigned
   td::bitstring::bits_memcpy(*data, 3 + 8, addr.bits().ptr, 0, ton::StdSmcAddress::size());
 }
 
-// internal helper: for `ton("0.05")`, parse string literal "0.05" to 50000000
-static td::RefInt256 parse_nanotons_as_floating_string(SrcRange range, std::string_view str) {
+// internal helper: for `grams("0.05")`, parse string literal "0.05" to 50000000
+static td::RefInt256 parse_nanograms_as_floating_string(SrcRange range, std::string_view str) {
   bool is_negative = false;
   size_t i = 0;
 
@@ -154,7 +154,7 @@ static td::RefInt256 parse_nanotons_as_floating_string(SrcRange range, std::stri
     } else if (c >= '0' && c <= '9') {
       fractional_part = fractional_part * 10 + (c - '0');
       if (++fractional_digits > 9) {
-        err("too many digits after a dot, nanotons are 10^9").fire(range);
+        err("too many digits after a dot, nanograms are 10^9").fire(range);
       }
     } else {
       err("argument is not a valid number like \"0.05\"").fire(range);
@@ -261,7 +261,11 @@ static bool extract_string_literal_from_v(AnyExprV v, std::string& out) {
   return false;
 }
 
-// given `ton("0.05")` evaluate it to 50000000
+static bool is_grams_amount_function(std::string_view f_name) {
+  return f_name == "grams" || f_name == "ton";
+}
+
+// given `grams("0.05")` evaluate it to 50000000
 // given `stringCrc32("some_str")` or `"some_str".crc32()` evaluate it
 // etc.
 static ConstValExpression parse_vertex_call_to_compile_time_function(V<ast_function_call> v, std::string_view f_name) {
@@ -364,15 +368,15 @@ static ConstValExpression parse_vertex_call_to_compile_time_function(V<ast_funct
 
   std::string str;
   if (!extract_string_literal_from_v(v_arg, str)) {
-    // ton(SOME_CONST) is not supported
-    // ton(0.05) is not supported (it can't be represented in AST even)
+    // grams(SOME_CONST) is not supported
+    // grams(0.05) is not supported (it can't be represented in AST even)
     // stringCrc32(SOME_CONST) / stringCrc32(some_var) also, it's compile-time literal-only
-    err_const_string_required(f_name, f_name == "ton" ? "0.05" : "some_str").fire(v);
+    err_const_string_required(f_name, is_grams_amount_function(f_name) ? "0.05" : "some_str").fire(v);
   }
 
-  if (f_name == "ton") {
+  if (is_grams_amount_function(f_name)) {
     return create_const_cast(   // insert "50000000 as coins"
-      ConstValInt{parse_nanotons_as_floating_string(v_arg->range, str)},
+      ConstValInt{parse_nanograms_as_floating_string(v_arg->range, str)},
       TypeDataCoins::create()
     );
   }
@@ -527,7 +531,7 @@ class ConstExpressionEvaluator {
     return create_const_cast_for_declared(std::move(val), cast_from, cast_to);
   }
 
-  // `ton("0.05")` and other compile-time functions
+  // `grams("0.05")` and other compile-time functions
   static ConstValExpression handle_function_call(V<ast_function_call> v) {
     FunctionPtr fun_ref = v->fun_maybe;
     if (!fun_ref || !fun_ref->is_compile_time_const_val()) {
@@ -757,7 +761,7 @@ td::RefInt256 unwrap_const_val_to_int(ConstValExpression const_expr) {
   return const_int == nullptr ? td::RefInt256{} : const_int->int_val;
 }
 
-// for any constant expression: `1 + 2` / `ton("0.05")` / `SOME_STR.crc32()`, consteval them;
+// for any constant expression: `1 + 2` / `grams("0.05")` / `SOME_STR.crc32()`, consteval them;
 // a non-constant expression: `a + b` / `foo()`, will fire (and can be wrapped by try/catch)
 ConstValExpression eval_expression_if_const_or_fire(AnyExprV v) {
   return ConstExpressionEvaluator::eval_any_v_or_fire(v);

--- a/tolk/constant-evaluator.cpp
+++ b/tolk/constant-evaluator.cpp
@@ -19,6 +19,7 @@
 #include "compilation-errors.h"
 #include "compiler-state.h"
 #include "generics-helpers.h"
+#include "recursion-guard.h"
 #include "type-system.h"
 #include "openssl/digest.hpp"
 #include "crypto/common/util.h"
@@ -233,7 +234,7 @@ static td::RefInt256 operator<<(td::RefInt256 x, const td::RefInt256& y) {
   if (y < 0 || y > 256) {
     x.write().invalidate();
   } else {
-    x.write() <<= static_cast<int>(y->to_long());
+    (x.write() <<= static_cast<int>(y->to_long())).normalize();
   }
   return x;
 }
@@ -243,7 +244,7 @@ static td::RefInt256 operator>>(td::RefInt256 x, const td::RefInt256& y) {
   if (y < 0 || y > 256) {
     x.write().invalidate();
   } else {
-    x.write() >>= static_cast<int>(y->to_long());
+    (x.write() >>= static_cast<int>(y->to_long())).normalize();
   }
   return x;
 }
@@ -518,11 +519,12 @@ class ConstExpressionEvaluator {
   static ConstValExpression handle_cast_as_operator(V<ast_cast_as_operator> v) {
     ConstValExpression val = eval_any_v_or_fire(v->get_expr());
 
+    TypePtr cast_from = v->get_expr()->inferred_type;
     TypePtr cast_to = v->inferred_type;
-    if (cast_to == TypeDataUnknown::create()) {   // `unknown` is forbidden in constants
+    if (cast_to == TypeDataUnknown::create() || cast_from == TypeDataUnknown::create()) {   // `unknown` is forbidden in constants
       err("not a constant expression").fire(v);
     }
-    return create_const_cast_for_declared(std::move(val), v->get_expr()->inferred_type, cast_to);
+    return create_const_cast_for_declared(std::move(val), cast_from, cast_to);
   }
 
   // `ton("0.05")` and other compile-time functions
@@ -547,12 +549,12 @@ class ConstExpressionEvaluator {
   // `anotherConst.0` or `Color.Red`
   static ConstValExpression handle_dot_access(V<ast_dot_access> v) {
     if (v->is_target_indexed_access()) {    // anotherConst.0
-      int index_at = std::get<int>(v->target);
+      size_t index_at = std::get<int>(v->target);
       ConstValExpression lhs = unwrap_const_cast(eval_any_v_or_fire(v->get_obj()));
-      if (ConstValTensor* lhs_tensor = std::get_if<ConstValTensor>(&lhs)) {
-        return lhs_tensor->items[index_at];   // an index exists: constant evaluation happens after
-      }                                          // type inferring and type checking
-      if (ConstValShapedTuple* lhs_shaped = std::get_if<ConstValShapedTuple>(&lhs)) {
+      if (ConstValTensor* lhs_tensor = std::get_if<ConstValTensor>(&lhs); lhs_tensor && index_at < lhs_tensor->items.size()) {
+        return lhs_tensor->items[index_at];
+      }
+      if (ConstValShapedTuple* lhs_shaped = std::get_if<ConstValShapedTuple>(&lhs); lhs_shaped && index_at < lhs_shaped->items.size()) {
         return lhs_shaped->items[index_at];
       }
     }
@@ -560,6 +562,9 @@ class ConstExpressionEvaluator {
       ConstValExpression lhs = unwrap_const_cast(eval_any_v_or_fire(v->get_obj()));
       if (ConstValObject* lhs_obj = std::get_if<ConstValObject>(&lhs)) {
         StructFieldPtr field = std::get<StructFieldPtr>(v->target);
+        if (field->field_idx >= static_cast<int>(lhs_obj->fields.size())) {
+          return ConstValNullLiteral{};   // can occur on type mismatch (already collected error)
+        }
         return lhs_obj->fields[field->field_idx];
       }
     }
@@ -675,11 +680,13 @@ ConstValExpression eval_and_cache_const_init_val(GlobalConstPtr const_ref) {
     err("const `{}` appears, directly or indirectly, in its own initializer", const_ref).fire(const_ref->ident_anchor);
   }
   called_stack.push_back(const_ref);
+  RecursionGuard guard([&] {
+    called_stack.pop_back();
+  });
 
   ConstValExpression v = ConstExpressionEvaluator::eval_any_v_or_fire(const_ref->init_value);
   // for `const A: coins = 10` or `const A: lisp_list<int> = []` insert a cast for correctness
   v = create_const_cast_for_declared(std::move(v), const_ref->init_value->inferred_type, const_ref->declared_type);
-  called_stack.pop_back();
   computed_constants_cache[const_ref] = v;
   return v;
 }
@@ -693,9 +700,11 @@ ConstValExpression eval_field_default_value(StructFieldPtr field_ref) {
     err("field `{}` default value circularly references itself", field_ref).fire(field_ref->ident_anchor);
   }
   called_stack.push_back(field_ref);
+  RecursionGuard guard([&] {
+    called_stack.pop_back();
+  });
 
   ConstValExpression def_val = ConstExpressionEvaluator::eval_any_v_or_fire(field_ref->default_value);
-  called_stack.pop_back();
   return def_val;
 }
 
@@ -712,6 +721,9 @@ std::vector<td::RefInt256> calculate_enum_members_with_values(EnumDefPtr enum_re
   std::vector<td::RefInt256> values;
   values.reserve(enum_ref->members.size());
   called_stack.push_back(enum_ref);
+  RecursionGuard guard([&] {
+    called_stack.pop_back();
+  });
 
   td::RefInt256 prev_value = td::make_refint(-1);
   for (EnumMemberPtr member_ref : enum_ref->members) {
@@ -732,8 +744,17 @@ std::vector<td::RefInt256> calculate_enum_members_with_values(EnumDefPtr enum_re
     prev_value = std::move(cur_value);
   }
 
-  called_stack.pop_back();
   return values;
+}
+
+// unwrap `const A: int32 = 5` to integer `5`
+// returns an empty RefInt256 if const_expr is not an integer, to be checked for `is_valid` / `is_null`
+td::RefInt256 unwrap_const_val_to_int(ConstValExpression const_expr) {
+  while (std::holds_alternative<ConstValCastToType>(const_expr)) {
+    const_expr = std::get<ConstValCastToType>(const_expr).inner.front();
+  }
+  const ConstValInt* const_int = std::get_if<ConstValInt>(&const_expr);
+  return const_int == nullptr ? td::RefInt256{} : const_int->int_val;
 }
 
 // for any constant expression: `1 + 2` / `ton("0.05")` / `SOME_STR.crc32()`, consteval them;

--- a/tolk/constant-evaluator.h
+++ b/tolk/constant-evaluator.h
@@ -100,6 +100,7 @@ ConstValExpression eval_field_default_value(StructFieldPtr field_ref);
 ConstValExpression eval_expression_if_const_or_fire(AnyExprV v);
 
 std::vector<td::RefInt256> calculate_enum_members_with_values(EnumDefPtr enum_ref);
+td::RefInt256 unwrap_const_val_to_int(ConstValExpression const_expr);
 
 void check_expression_is_constant_or_fire(AnyExprV v_expr);
 

--- a/tolk/generics-helpers.cpp
+++ b/tolk/generics-helpers.cpp
@@ -21,6 +21,7 @@
 #include "type-system.h"
 #include "compiler-state.h"
 #include "pipeline.h"
+#include "recursion-guard.h"
 
 namespace tolk {
 
@@ -497,15 +498,17 @@ FunctionPtr instantiate_generic_function(FunctionPtr fun_ref, GenericsSubstituti
   V<ast_function_declaration> new_root = ASTReplicator::clone_function_ast(orig_root);
 
   static thread_local int instantiation_depth = 0;
-  if (++instantiation_depth > 64) {
-    instantiation_depth = 0;
+  instantiation_depth++;
+  RecursionGuard guard([&] {
+    instantiation_depth--;
+  });
+  if (instantiation_depth > 64) {
     err_instantiate_recursive(fun_ref).fire(fun_ref->ident_anchor);
   }
 
   FunctionPtr new_fun_ref = pipeline_register_instantiated_generic_function(fun_ref, new_root, std::move(new_name), allocatedTs);
   run_pipeline_for_cloned_function(new_fun_ref);
 
-  instantiation_depth--;
   return new_fun_ref;
 }
 
@@ -527,8 +530,11 @@ StructPtr instantiate_generic_struct(StructPtr struct_ref, GenericsSubstitutions
   V<ast_struct_declaration> new_root = ASTReplicator::clone_struct_ast(orig_root, new_name_ident);
 
   static thread_local int instantiation_depth = 0;
-  if (++instantiation_depth > 64) {
-    instantiation_depth = 0;
+  instantiation_depth++;
+  RecursionGuard guard([&] {
+    instantiation_depth--;
+  });
+  if (instantiation_depth > 64) {
     err_instantiate_recursive(struct_ref).fire(struct_ref->ident_anchor);
   }
 
@@ -539,7 +545,6 @@ StructPtr instantiate_generic_struct(StructPtr struct_ref, GenericsSubstitutions
   // don't call type inferring here (unlike for generic functions), it's invalid before type resolving finishes;
   // type inferring for generic struct instantiations will automatically be run instead
 
-  instantiation_depth--;
   return new_struct_ref;
 }
 
@@ -550,6 +555,9 @@ AliasDefPtr instantiate_generic_alias(AliasDefPtr alias_ref, GenericsSubstitutio
   std::string new_name = generate_instantiated_name(alias_ref->name, substitutedTs);
   if (const Symbol* existing_sym = lookup_global_symbol(new_name)) {
     if (AliasDefPtr a = existing_sym->try_as<AliasDefPtr>(); a && a->base_alias_ref == alias_ref) {
+      if (a->underlying_type == nullptr) {
+        err("type `{}` circularly references itself", a).fire(a->ident_anchor);
+      }
       return a;
     }
     err_instantiated_name_conflict(new_name).fire(alias_ref->ident_anchor);
@@ -561,8 +569,11 @@ AliasDefPtr instantiate_generic_alias(AliasDefPtr alias_ref, GenericsSubstitutio
   V<ast_type_alias_declaration> new_root = ASTReplicator::clone_type_alias_ast(orig_root, new_name_ident);
 
   static thread_local int instantiation_depth = 0;
-  if (++instantiation_depth > 64) {
-    instantiation_depth = 0;
+  instantiation_depth++;
+  RecursionGuard guard([&] {
+    instantiation_depth--;
+  });
+  if (instantiation_depth > 64) {
     err_instantiate_recursive(alias_ref).fire(alias_ref->ident_anchor);
   }
 
@@ -570,7 +581,6 @@ AliasDefPtr instantiate_generic_alias(AliasDefPtr alias_ref, GenericsSubstitutio
   tolk_assert(new_alias_ref);
   pipeline_resolve_types_and_aliases(new_alias_ref);
 
-  instantiation_depth--;
   return new_alias_ref;
 }
 

--- a/tolk/generics-helpers.cpp
+++ b/tolk/generics-helpers.cpp
@@ -230,8 +230,24 @@ void GenericSubstitutionsDeducing::consider_next_condition(TypePtr param_type, T
       if (is_sub_correct && p_generic.size() == 1 && a_sub_p.size() > 1) {
         consider_next_condition(p_generic[0], TypeDataUnion::create(std::move(a_sub_p)));
       } else if (is_sub_correct && p_generic.size() == a_sub_p.size()) {
-        for (int i = 0; i < static_cast<int>(p_generic.size()); ++i) {
-          consider_next_condition(p_generic[i], a_sub_p[i]);
+        // pair each generic variant with the arg variant it deduces into; a bare `T` matches
+        // ANY arg variant, so it must be matched last — only after concrete shapes have claimed theirs;
+        // example: param `T | Box<T>`, arg `Box<int> | int` (mind reorder), deduce T=int
+        for (int pass = 0; pass < 2; ++pass) {    // pass 0: concrete variants like `Box<T>`; pass 1: a bare `T`
+          for (TypePtr p_variant : p_generic) {
+            if ((p_variant->try_as<TypeDataGenericT>() != nullptr) != (pass == 1)) {
+              continue;
+            }
+            for (auto it = a_sub_p.begin(); it != a_sub_p.end(); ++it) {
+              GenericSubstitutionsDeducing trial = *this;
+              // a pairing fits when deducing makes the variant exactly equal to its arg
+              if (trial.auto_deduce_from_argument(p_variant, *it)->equal_to(*it)) {
+                consider_next_condition(p_variant, *it);
+                a_sub_p.erase(it);
+                break;
+              }
+            }
+          }
         }
       }
     }
@@ -281,6 +297,12 @@ void GenericSubstitutionsDeducing::consider_next_condition(TypePtr param_type, T
       tolk_assert(p_instAl->size() == a_alias->alias_ref->substitutedTs->size());
       for (int i = 0; i < p_instAl->size(); ++i) {
         consider_next_condition(p_instAl->type_arguments[i], a_alias->alias_ref->substitutedTs->typeT_at(i));
+      }
+    } else if (const auto* a_instAl = arg_type->try_as<TypeDataGenericTypeWithTs>(); a_instAl && a_instAl->alias_ref == p_instAl->alias_ref) {
+      // `arg: WrapperAlias<T>` matched against another still-generic `WrapperAlias<X>` while comparing receivers
+      tolk_assert(p_instAl->size() == a_instAl->size());
+      for (int i = 0; i < p_instAl->size(); ++i) {
+        consider_next_condition(p_instAl->type_arguments[i], a_instAl->type_arguments[i]);
       }
     } else {
       // `arg: WrapperAlias<T>` called as `f(someWrapperInt)` => T is int

--- a/tolk/lexer.cpp
+++ b/tolk/lexer.cpp
@@ -385,25 +385,6 @@ struct ChunkSkipWhitespace final : ChunkLexerBase {
   }
 };
 
-// Here we handle corner cases of grammar that are requested on demand.
-// E.g., for 'tolk >0.5.0', '0.5.0' should be parsed specially to emit tok_semver.
-// See TolkLanguageGrammar::parse_next_chunk_special().
-struct ChunkSpecialParsing {
-  static bool parse_semver(Lexer* lex) {
-    const char* str_begin = lex->c_str();
-    while (std::isdigit(lex->char_at()) || lex->char_at() == '.') {
-      lex->skip_chars(1);
-    }
-
-    std::string_view str_val(str_begin, lex->c_str() - str_begin);
-    if (str_val.empty()) {
-      return false;
-    }
-    lex->add_token(tok_semver, str_val);
-    return true;
-  }
-};
-
 // Anything starting from a valid identifier beginning symbol is parsed as an identifier.
 // But if a resulting string is a keyword, a corresponding token is emitted instead of tok_identifier.
 struct ChunkIdentifierOrKeyword final : ChunkLexerBase {
@@ -529,16 +510,6 @@ struct TolkLanguageGrammar {
     return best && best->parse(lex);
   }
 
-  static bool parse_next_chunk_special(Lexer* lex, TokenType parse_next_as) {
-    switch (parse_next_as) {
-      case tok_semver:
-        return ChunkSpecialParsing::parse_semver(lex);
-      default:
-        tolk_assert(false);
-        return false;
-    }
-  }
-
   static void register_token(const char* str, int len, TokenType tp) {
     trie.add_prefix(str, new ChunkSimpleToken(tp, len));
   }
@@ -647,16 +618,6 @@ void Lexer::next() {
   }
   if (is_eof()) {
     add_token(tok_eof, "");
-  }
-  cur_token = tokens_circularbuf[++cur_token_idx & 7];
-}
-
-void Lexer::next_special(TokenType parse_next_as, const char* str_expected) {
-  tolk_assert(cur_token_idx == last_token_idx);
-  skip_spaces();
-  update_location();
-  if (!TolkLanguageGrammar::parse_next_chunk_special(this, parse_next_as)) {
-    error(std::string(str_expected) + " expected");
   }
   cur_token = tokens_circularbuf[++cur_token_idx & 7];
 }

--- a/tolk/lexer.h
+++ b/tolk/lexer.h
@@ -130,7 +130,6 @@ enum TokenType {
   tok_double_question,
 
   tok_tolk,
-  tok_semver,
   tok_import,
   tok_export,
 
@@ -214,7 +213,6 @@ public:
   SrcRange range_start() const { return SrcRange::unclosed_range(file_id, cur_token_offset); }
 
   void next();
-  void next_special(TokenType parse_next_as, const char* str_expected);
 
   SavedPositionForLookahead save_parsing_position() const;
   void restore_position(SavedPositionForLookahead saved);

--- a/tolk/pipe-ast-to-legacy.cpp
+++ b/tolk/pipe-ast-to-legacy.cpp
@@ -1430,7 +1430,7 @@ static std::vector<var_idx_t> process_function_call(V<ast_function_call> v, Code
     code.add_indirect_invoke(v, rvect, std::move(args_vars));
     return transition_to_target_type(std::move(rvect), code, target_type, v);
   }
-  // `ton("0.05")` and others, we even don't need to calculate ir_idx for arguments, just replace with constexpr
+  // `grams("0.05")` and others, we even don't need to calculate ir_idx for arguments, just replace with constexpr
   if (fun_ref->is_compile_time_const_val()) {
     ConstValExpression value = eval_expression_if_const_or_fire(v);
     auto [type, rvect] = pre_compile_constant_expression(value, code, v);

--- a/tolk/pipe-ast-to-legacy.cpp
+++ b/tolk/pipe-ast-to-legacy.cpp
@@ -597,43 +597,46 @@ static std::vector<var_idx_t> pre_compile_tensor(CodeBlob& code, const std::vect
   return pre_compile_tensor_merging(code, args, lval_ctx_for_arg, target_types, origin_for_loc_marks, origin_overrides);
 }
 
-static std::vector<var_idx_t> pre_compile_let(CodeBlob& code, AnyExprV lhs, AnyExprV rhs) {
-  // [lhs] = rhs; it's un-tuple to N left vars
-  if (lhs->kind == ast_square_brackets) {
-    const TypeDataShapedTuple* l_shaped = lhs->inferred_type->unwrap_alias()->try_as<TypeDataShapedTuple>();
-    const TypeDataShapedTuple* r_shaped = rhs->inferred_type->unwrap_alias()->try_as<TypeDataShapedTuple>();
-    tolk_assert(l_shaped && r_shaped && l_shaped->size() == r_shaped->size());
-    std::vector ir_right = pre_compile_expr(rhs, code);
-    std::vector rvect = code.create_tmp_var(TypeDataTensor::create(std::vector(r_shaped->size(), TypeDataUnknown::create())), rhs, "(unpack-tuple)");
-    code.add_un_tuple(lhs, rvect, ir_right);
-    code.add_extra_mark_location(lhs->range);
-    LValContext local_lval;
-    std::vector ir_left = pre_compile_tensor(code, lhs->as<ast_square_brackets>()->get_items(), &local_lval);
-    vars_modification_watcher.trigger_callbacks(ir_left, lhs);
+static void pre_compile_let(CodeBlob& code, AnyExprV lhs, std::vector<var_idx_t> rhs_ir, TypePtr rhs_type, AnyV rhs_origin) {
+  if (auto lhs_tensor = lhs->try_as<ast_tensor>()) {
+    const TypeDataTensor* rhs_tensor = rhs_type->unwrap_alias()->try_as<TypeDataTensor>();
+    tolk_assert(rhs_tensor && rhs_tensor->size() == lhs_tensor->size());
+
     int stack_offset = 0;
-    for (int i = 0; i < l_shaped->size(); ++i) {
-      int ith_w = l_shaped->items[i]->get_width_on_stack();
-      std::vector ith_lvect(ir_left.begin() + stack_offset, ir_left.begin() + stack_offset + ith_w);
-      std::vector ith_rvect = transition_to_target_type({rvect[i]}, code, TypeDataUnknown::create(), r_shaped->items[i], rhs);
-      ith_rvect = transition_to_target_type(std::move(ith_rvect), code, r_shaped->items[i], l_shaped->items[i], rhs);
-      code.add_let(lhs, ith_lvect, ith_rvect);
-      stack_offset += ith_w;
+    for (int i = 0; i < lhs_tensor->size(); ++i) {
+      TypePtr ith_rhs_type = rhs_tensor->items[i];
+      int ith_width = ith_rhs_type->get_width_on_stack();
+      std::vector ith_rhs_ir(rhs_ir.begin() + stack_offset, rhs_ir.begin() + stack_offset + ith_width);
+      pre_compile_let(code, lhs_tensor->get_item(i), std::move(ith_rhs_ir), ith_rhs_type, rhs_origin);
+      stack_offset += ith_width;
     }
-    local_lval.after_let(std::move(ir_left), code, lhs);
-    return ir_right;
+    tolk_assert(stack_offset == static_cast<int>(rhs_ir.size()));
+    return;
   }
-  // lhs = rhs (resulting IR vars is rhs)
-  // note, that we calculate RHS at first; earlier lhs was calculated first, to support "someF().field = calc()",
-  // but since lvalues are restricted to strict paths (v.0.nested, etc.), function calls not allowed in lhs
-  std::vector ir_right = pre_compile_expr(rhs, code, nullptr);
-  std::vector ir_assignable = transition_to_target_type(std::vector(ir_right), code, rhs->inferred_type, lhs->inferred_type, rhs);
+
+  if (auto lhs_square = lhs->try_as<ast_square_brackets>()) {
+    const TypeDataShapedTuple* rhs_shaped = rhs_type->unwrap_alias()->try_as<TypeDataShapedTuple>();
+    tolk_assert(rhs_shaped && rhs_shaped->size() == lhs_square->size() && rhs_ir.size() == 1);
+
+    std::vector unpacked_ir = code.create_tmp_var(TypeDataTensor::create(std::vector(rhs_shaped->size(), TypeDataUnknown::create())), lhs, "(unpack-tuple)");
+    code.add_un_tuple(lhs, unpacked_ir, rhs_ir);
+    code.add_extra_mark_location(lhs->range);
+    for (int i = 0; i < lhs_square->size(); ++i) {
+      TypePtr ith_rhs_type = rhs_shaped->items[i];
+      std::vector<var_idx_t> ith_rhs_ir{unpacked_ir[i]};
+      ith_rhs_ir = transition_to_target_type(std::move(ith_rhs_ir), code, TypeDataUnknown::create(), ith_rhs_type, rhs_origin);
+      pre_compile_let(code, lhs_square->get_item(i), std::move(ith_rhs_ir), ith_rhs_type, rhs_origin);
+    }
+    return;
+  }
+
+  std::vector ir_assignable = transition_to_target_type(std::move(rhs_ir), code, rhs_type, lhs->inferred_type, rhs_origin);
   code.add_extra_mark_location(lhs->range);
   LValContext local_lval;
   std::vector ir_left = pre_compile_expr(lhs, code, nullptr, &local_lval);
   vars_modification_watcher.trigger_callbacks(ir_left, lhs);
   code.add_let(lhs, ir_left, std::move(ir_assignable));
   local_lval.after_let(std::move(ir_left), code, lhs);
-  return ir_right;
 }
 
 std::vector<var_idx_t> pre_compile_is_type(CodeBlob& code, TypePtr expr_type, TypePtr cmp_type, const std::vector<var_idx_t>& expr_ir_idx, AnyV origin, const char* debug_desc) {
@@ -967,11 +970,22 @@ static std::vector<var_idx_t> process_assignment(V<ast_assign> v, CodeBlob& code
   AnyExprV lhs = v->get_lhs();
   AnyExprV rhs = v->get_rhs();
 
-  if (auto lhs_decl = lhs->try_as<ast_local_vars_declaration>()) {
-    lhs = lhs_decl->get_expr();
+  bool lhs_is_declaration = lhs->kind == ast_local_vars_declaration;
+  if (lhs_is_declaration) {
+    lhs = lhs->as<ast_local_vars_declaration>()->get_expr();
   }
 
-  std::vector rvect = pre_compile_let(code, lhs, rhs);
+  // calculate RHS first; earlier lhs was calculated first to support `someF().field = calc()`,
+  // but since lvalues are restricted to strict paths (`v.0.nested`, etc.), function calls are not allowed in lhs
+  std::vector rvect = pre_compile_expr(rhs, code);
+  // prevent rhs slots overlapping: for destructuring `(a, b) = (0, a)` and tensor-assignment `t = (t.1, t.0)`
+  if (!lhs_is_declaration && rvect.size() > 1) {
+    std::vector ir_assignable = code.create_tmp_var(rhs->inferred_type, rhs, "(assign-rhs)");
+    code.add_let(rhs, ir_assignable, rvect);
+    rvect = ir_assignable;
+  }
+
+  pre_compile_let(code, lhs, std::vector(rvect), rhs->inferred_type, rhs);
   // rvect is IR of rhs: for example, `nullablePoint = null` then rhs is size=1 (just `null`),
   // but the assignment worked correctly, because `null` was transitioned to `Point?` inside;
   // now also transition rhs is the assignment is used as an expression: `f(lhs = rhs)` or `a = b = rhs`
@@ -1352,7 +1366,7 @@ static std::vector<var_idx_t> process_dot_access(V<ast_dot_access> v, CodeBlob& 
       std::vector rvect = code.create_tmp_var(t_shaped->items[index_at], v, "(tuple-field)");
       code.add_call(v, rvect, {tuple_ir_idx[0], index_ir_idx[0]}, lookup_function("array<T>.get"));
       if (lval_ctx) {
-        tolk_assert(is_valid_lvalue_path(v));
+        tolk_assert(is_valid_mutation_path(v));
         lval_ctx->capture_shaped_tuple_index_modification(v->get_obj(), index_at, rvect);
       }
       // a tuple index might be smart cast at this point, for example we're in `if (shapeOfPoints.1 != null)`
@@ -1542,7 +1556,7 @@ static std::vector<var_idx_t> process_function_call(V<ast_function_call> v, Code
   // if it's a global variable or a tuple index, re-evaluate it to bind modifications capturing
   AnyExprV obj_leftmost = self_lval.get_mutated_self_obj();   // nullptr if none
   if (fun_ref->does_mutate_self() && obj_leftmost) {
-    tolk_assert(is_valid_lvalue_path(obj_leftmost));
+    tolk_assert(is_valid_mutation_path(obj_leftmost));
     int orig_self_i = rev_arg_order.empty() ? 0 : rev_arg_order[0];
     vars_per_arg[orig_self_i] = pre_compile_expr(obj_leftmost, code, fun_ref->parameters[0].declared_type, &self_lval);
   }
@@ -1578,7 +1592,7 @@ static std::vector<var_idx_t> process_function_call(V<ast_function_call> v, Code
     int orig_self_i = rev_arg_order.empty() ? 0 : rev_arg_order[0];
     rvect = return_self_snapshot.empty() ? vars_per_arg[orig_self_i] : std::move(return_self_snapshot);
     if (fun_ref->does_mutate_self()) {
-      if (obj_leftmost == nullptr && v->get_self_obj() && is_valid_lvalue_path(v->get_self_obj())) {
+      if (obj_leftmost == nullptr && v->get_self_obj() && is_valid_mutation_path(v->get_self_obj())) {
         obj_leftmost = v->get_self_obj();
       }
       if (lval_ctx && obj_leftmost) {
@@ -1615,9 +1629,8 @@ static std::vector<var_idx_t> process_tensor(V<ast_tensor> v, CodeBlob& code, Ty
 }
 
 static std::vector<var_idx_t> process_square_brackets(V<ast_square_brackets> v, CodeBlob& code, TypePtr target_type, LValContext* lval_ctx) {
-  if (v->is_lvalue) {       // todo some time, make "var (a, [b,c]) = (1, [2,3])" work
-    err("[...] can not be used as lvalue here").fire(v);
-  }
+  // destructuring patterns like `var (a, [b,c]) = rhs` are handled by pre_compile_let()
+  tolk_assert(!v->is_lvalue && !lval_ctx);
   std::vector rvect = code.create_tmp_var(v->inferred_type, v, "(pack-tuple)");
 
   // note that for every constructor of `[...]` (array, lisp_list, etc.) we still make a shape at low-level,

--- a/tolk/pipe-ast-to-legacy.cpp
+++ b/tolk/pipe-ast-to-legacy.cpp
@@ -978,6 +978,9 @@ static std::vector<var_idx_t> process_assignment(V<ast_assign> v, CodeBlob& code
   // calculate RHS first; earlier lhs was calculated first to support `someF().field = calc()`,
   // but since lvalues are restricted to strict paths (`v.0.nested`, etc.), function calls are not allowed in lhs
   std::vector rvect = pre_compile_expr(rhs, code);
+  if (!lhs_is_declaration && code.get_lazy_variable(lhs) && code.get_lazy_variable(rhs)) {
+    err("assigning one lazy variable to another is not supported").fire(v, code.fun_ref);
+  }
   // prevent rhs slots overlapping: for destructuring `(a, b) = (0, a)` and tensor-assignment `t = (t.1, t.0)`
   if (!lhs_is_declaration && rvect.size() > 1) {
     std::vector ir_assignable = code.create_tmp_var(rhs->inferred_type, rhs, "(assign-rhs)");
@@ -1504,12 +1507,15 @@ static std::vector<var_idx_t> process_function_call(V<ast_function_call> v, Code
   // e.g. `a.mix(mutate b.inc().v)` — inner `b.inc()` sets mutated_self_obj to `b`,
   // but we want `obj_leftmost` below to be `a` for `a.mix()`
   LValContext self_lval;
-  bool has_mutate_self = delta_self && fun_ref->does_mutate_self();
+  AnyExprV self_obj = v->get_self_obj();
+  if (!self_obj && fun_ref->does_accept_self()) {
+    self_obj = v->get_arg(0)->get_expr();    // static call `Name.method(mutate obj)`, self=obj
+  }
   std::vector<LValContext*> lval_ctx_for_arg(fun_ref->get_num_params(), nullptr);
   for (int i = 0; i < fun_ref->get_num_params(); ++i) {
     if (fun_ref->parameters[i].is_mutate_parameter()) {
       int orig_i = rev_arg_order.empty() ? i : rev_arg_order[i];
-      lval_ctx_for_arg[orig_i] = has_mutate_self && i == 0 ? &self_lval : &local_lval;
+      lval_ctx_for_arg[orig_i] = fun_ref->does_mutate_self() && i == 0 ? &self_lval : &local_lval;
     }
   }
 
@@ -1546,7 +1552,7 @@ static std::vector<var_idx_t> process_function_call(V<ast_function_call> v, Code
   if (fun_ref->is_compile_time_special_gen()) {
     rvect = gen_compile_time_code_instead_of_fun_call(code, v, vars_per_arg);
   } else if (fun_ref->is_inlined_in_place() && fun_ref->is_code_function()) {
-    rvect = gen_inline_fun_call_in_place(code, op_call_type, call_origin, v->fun_maybe, v->get_self_obj(), v == stmt_before_immediate_return, vars_per_arg);
+    rvect = gen_inline_fun_call_in_place(code, op_call_type, call_origin, v->fun_maybe, self_obj, v == stmt_before_immediate_return, vars_per_arg);
   } else {
     rvect = code.create_tmp_var(op_call_type, v, "(fun-call)");
     code.add_call(call_origin, rvect, std::move(args_vars), fun_ref, arg_order_already_equals_asm);
@@ -1592,8 +1598,8 @@ static std::vector<var_idx_t> process_function_call(V<ast_function_call> v, Code
     int orig_self_i = rev_arg_order.empty() ? 0 : rev_arg_order[0];
     rvect = return_self_snapshot.empty() ? vars_per_arg[orig_self_i] : std::move(return_self_snapshot);
     if (fun_ref->does_mutate_self()) {
-      if (obj_leftmost == nullptr && v->get_self_obj() && is_valid_mutation_path(v->get_self_obj())) {
-        obj_leftmost = v->get_self_obj();
+      if (obj_leftmost == nullptr && self_obj && is_valid_mutation_path(self_obj)) {
+        obj_leftmost = self_obj;
       }
       if (lval_ctx && obj_leftmost) {
         lval_ctx->set_mutated_self_obj(obj_leftmost);
@@ -2013,7 +2019,11 @@ static void process_block_statement(V<ast_block_statement> v, CodeBlob& code) {
 
 static void process_assert_statement(V<ast_assert_statement> v, CodeBlob& code) {
   bool excno_is_const = true;
-  try { eval_expression_if_const_or_fire(v->get_thrown_code()); }
+  try {
+    ConstValExpression val = eval_expression_if_const_or_fire(v->get_thrown_code());
+    td::RefInt256 err_code = unwrap_const_val_to_int(std::move(val));
+    excno_is_const = !err_code.is_null() && err_code->unsigned_fits_bits(16);
+  }
   catch (...) { excno_is_const = false; }
 
   if (excno_is_const) {

--- a/tolk/pipe-check-const-expr.cpp
+++ b/tolk/pipe-check-const-expr.cpp
@@ -32,11 +32,11 @@ namespace tolk {
 class ConstantExpressionsChecker final : public ASTVisitorFunctionBody {
 
   void visit(V<ast_function_call> v) override {
-    // check `ton("0.05")` and others for correctness (not `ton(local_var)`, etc.)
+    // check `grams("0.05")` and others for correctness (not `grams(local_var)`, etc.)
     if (v->fun_maybe && v->fun_maybe->is_compile_time_const_val()) {
       // on invalid usage, this call will fire
       eval_expression_if_const_or_fire(v);
-      // note that in AST tree, it's still left as `ton("0.05")`, `stringCrc32("...")`, etc.
+      // note that in AST tree, it's still left as `grams("0.05")`, `stringCrc32("...")`, etc.
       // later, when transforming to IR, such compile-time functions are handled specially
     }
 

--- a/tolk/pipe-check-inferred-types.cpp
+++ b/tolk/pipe-check-inferred-types.cpp
@@ -580,7 +580,7 @@ class CheckInferredTypesVisitor final : public ASTVisitorFunctionBody {
     parent::visit(v->get_return_value());
 
     if (cur_f->does_return_self()) {
-      if (!is_expr_valid_as_return_self(v->get_return_value())) {
+      if (!is_expr_valid_as_return_self(cur_f, v->get_return_value())) {
         err("invalid return from `self` function").collect(v, cur_f);
       }
       return;
@@ -592,18 +592,18 @@ class CheckInferredTypesVisitor final : public ASTVisitorFunctionBody {
     }
   }
 
-  static bool is_expr_valid_as_return_self(AnyExprV return_expr) {
+  static bool is_expr_valid_as_return_self(FunctionPtr cur_f, AnyExprV return_expr) {
     // `return self`
-    if (return_expr->kind == ast_reference && return_expr->as<ast_reference>()->get_name() == "self") {
-      return true;
+    if (auto v_ref = return_expr->try_as<ast_reference>()) {
+      return v_ref->sym == &cur_f->parameters[0];
     }
     // `return self.someMethod()`
     if (auto v_call = return_expr->try_as<ast_function_call>(); v_call && v_call->get_self_obj()) {
-      return v_call->fun_maybe && v_call->fun_maybe->does_return_self() && is_expr_valid_as_return_self(v_call->get_self_obj());
+      return v_call->fun_maybe && v_call->fun_maybe->does_return_self() && is_expr_valid_as_return_self(cur_f, v_call->get_self_obj());
     }
     // `return cond ? ... : ...`
     if (auto v_ternary = return_expr->try_as<ast_ternary_operator>()) {
-      return is_expr_valid_as_return_self(v_ternary->get_when_true()) && is_expr_valid_as_return_self(v_ternary->get_when_false());
+      return is_expr_valid_as_return_self(cur_f, v_ternary->get_when_true()) && is_expr_valid_as_return_self(cur_f, v_ternary->get_when_false());
     }
     return false;
   }

--- a/tolk/pipe-check-rvalue-lvalue.cpp
+++ b/tolk/pipe-check-rvalue-lvalue.cpp
@@ -28,7 +28,7 @@
  *     1) LHS of assignment: `lhs = rhs`, `lhs += rhs`
  *     2) `mutate` argument: `f(mutate lhs)`
  *     3) `mutate self` method: `lhs.mutatingMethod()`
- *   For each source, is_valid_lvalue_path(lhs) is checked.
+ *   For each source, lvalue/destructuring syntax is checked.
  *   Additionally, readonly fields and immutable variables are checked.
  */
 
@@ -140,8 +140,9 @@ class CheckRValueLvalueVisitor final : public ASTVisitorFunctionBody {
     AnyExprV lhs = v->get_lhs();
     tolk_assert(lhs->is_lvalue);
 
-    // allow `v.field = rhs`, but not `v.method().field = rhs`
-    if (!is_valid_lvalue_path(lhs)) {
+    // allow `v.field = rhs` and destructuring `(a, [b, c]) = rhs`,
+    // but not `v.method().field = rhs`
+    if (!is_valid_assignment_lhs(lhs)) {
       err("can not assign to a temporary expression").collect(lhs, cur_f);
     }
     parent::visit(v);
@@ -152,7 +153,7 @@ class CheckRValueLvalueVisitor final : public ASTVisitorFunctionBody {
     tolk_assert(lhs->is_lvalue);
 
     // allow `v.field += rhs`, but not `v.method().field += rhs`
-    if (!is_valid_lvalue_path(lhs)) {
+    if (!is_valid_assignment_lhs(lhs)) {
       err("can not assign to a temporary expression").collect(lhs, cur_f);
     }
     parent::visit(v);
@@ -181,7 +182,7 @@ class CheckRValueLvalueVisitor final : public ASTVisitorFunctionBody {
     // (but still allow `beginCell().storeUint()`, because `beginCell()` is NOT marked lvalue previously)
     AnyExprV self_obj = v->get_self_obj();
     if (v->fun_maybe && v->fun_maybe->does_mutate_self() && self_obj && self_obj->is_lvalue) {
-      if (!is_valid_lvalue_path(self_obj)) {
+      if (!is_valid_mutation_path(self_obj)) {
         err("can not mutate a temporary expression").collect(self_obj, cur_f);
       }
     }
@@ -192,7 +193,7 @@ class CheckRValueLvalueVisitor final : public ASTVisitorFunctionBody {
     // allow `f(mutate v)`, but not `f(mutate v.id())`
     for (int i = 0; i < v->get_num_args(); ++i) {
       auto ith_arg = v->get_arg(i);
-      if (ith_arg->passed_as_mutate && !is_valid_lvalue_path(ith_arg->get_expr())) {
+      if (ith_arg->passed_as_mutate && !is_valid_mutation_path(ith_arg->get_expr())) {
         err("can not mutate a temporary expression").collect(ith_arg, cur_f);
       }
       parent::visit(ith_arg);

--- a/tolk/pipe-infer-types-and-calls.cpp
+++ b/tolk/pipe-infer-types-and-calls.cpp
@@ -21,6 +21,7 @@
 #include "generics-helpers.h"
 #include "overload-resolution.h"
 #include "pack-unpack-api.h"
+#include "recursion-guard.h"
 #include "type-system.h"
 #include "smart-casts-cfg.h"
 #include <charconv>
@@ -1903,9 +1904,11 @@ static void infer_and_save_return_type_of_function(FunctionPtr fun_ref) {
   // dig into g's body; it's safe, since the compiler is single-threaded
   // on finish, fun_ref->inferred_return_type is filled, and won't be called anymore
   called_stack.push_back(fun_ref);
+  RecursionGuard guard([&] {
+    called_stack.pop_back();
+  });
   InferTypesAndCallsAndFieldsVisitor visitor;
   visitor.start_visiting_function(fun_ref, fun_ref->ast_root->as<ast_function_declaration>());
-  called_stack.pop_back();
 }
 
 // infer constant type "on demand"
@@ -1921,9 +1924,11 @@ static void infer_and_save_type_of_constant(GlobalConstPtr const_ref) {
   }
 
   called_stack.push_back(const_ref);
+  RecursionGuard guard([&] {
+    called_stack.pop_back();
+  });
   InferTypesAndCallsAndFieldsVisitor visitor;
   visitor.start_visiting_constant(const_ref);
-  called_stack.pop_back();
 }
 
 void pipeline_infer_types_and_calls_and_fields() {

--- a/tolk/pipe-infer-types-and-calls.cpp
+++ b/tolk/pipe-infer-types-and-calls.cpp
@@ -1018,6 +1018,10 @@ class InferTypesAndCallsAndFieldsVisitor final {
         if (const TypeDataAlias* r_aliasT = receiver_type->try_as<TypeDataAlias>(); r_aliasT && r_aliasT->alias_ref->is_generic_alias()) {
           if (TypePtr hinted_receiver = hint ? try_pick_instantiated_generic_from_hint(hint, r_aliasT->alias_ref) : nullptr) {
             receiver_type = hinted_receiver;   // assigned to `var v: Maybe<int> = Maybe.none()` or an alias-equivalent hint
+          } else if (r_aliasT->alias_ref->genericTs->size_no_defaults() == 0) {
+            std::vector<TypePtr> type_arguments;    // `SomeAlias.staticMethod()` where `SomeAlias<T=default>`
+            r_aliasT->alias_ref->genericTs->append_defaults(type_arguments);
+            receiver_type = TypeDataAlias::create(instantiate_generic_alias(r_aliasT->alias_ref, GenericsSubstitutions(r_aliasT->alias_ref->genericTs, type_arguments)));
           } else {
             err_cannot_deduce_genericT(r_aliasT).fire(v->get_obj(), cur_f);
           }
@@ -1026,6 +1030,10 @@ class InferTypesAndCallsAndFieldsVisitor final {
         if (const TypeDataStruct* r_structT = receiver_type->unwrap_alias()->try_as<TypeDataStruct>(); r_structT && r_structT->struct_ref->is_generic_struct()) {
           if (const TypeDataStruct* hint_same = hint ? hint->unwrap_alias()->try_as<TypeDataStruct>() : nullptr; hint_same && hint_same->struct_ref->base_struct_ref == r_structT->struct_ref) {
             receiver_type = hint;   // assigned to `var p: Pair<int, bool> = Pair.create(...)`
+          } else if (r_structT->struct_ref->genericTs->size_no_defaults() == 0) {
+            std::vector<TypePtr> type_arguments;    // `SomeStruct.staticMethod()` where `SomeStruct<T=default>`
+            r_structT->struct_ref->genericTs->append_defaults(type_arguments);
+            receiver_type = TypeDataStruct::create(instantiate_generic_struct(r_structT->struct_ref, GenericsSubstitutions(r_structT->struct_ref->genericTs, type_arguments)));
           } else {
             err_cannot_deduce_genericT(r_structT).fire(v->get_obj(), cur_f);
           }

--- a/tolk/pipe-infer-types-and-calls.cpp
+++ b/tolk/pipe-infer-types-and-calls.cpp
@@ -1470,13 +1470,13 @@ class InferTypesAndCallsAndFieldsVisitor final {
     // either by lhs hint `var u: User = { ... }, or by explicitly provided ref `User { ... }`
     StructPtr struct_ref = nullptr;
 
-    // `User { ... }` / `UserAlias { ... }` / `Wrapper { ... }` / `Wrapper<int> { ... }`
+    // `User { ... }` / `Wrapper { ... }` / `Wrapper<int> { ... }`
     if (v->type_node) {
-      TypePtr provided_type = v->type_node->resolved_type->unwrap_alias();
+      TypePtr provided_type = v->type_node->resolved_type;
       if (const TypeDataStruct* hint_struct = provided_type->try_as<TypeDataStruct>()) {
         struct_ref = hint_struct->struct_ref;     // `Wrapper` / `Wrapper<int>`
       } else if (const TypeDataGenericTypeWithTs* hint_instTs = provided_type->try_as<TypeDataGenericTypeWithTs>()) {
-        struct_ref = hint_instTs->struct_ref;     // if `type WAlias<T> = Wrapper<T>`, here `Wrapper` (generic struct)
+        struct_ref = hint_instTs->struct_ref;     // `Wrapper<T>` inside a generic function
       }
       if (!struct_ref) {
         err("`{}` does not name a struct", v->type_node->resolved_type).fire(v->type_node, cur_f);

--- a/tolk/pipe-lazy-load-insertions.cpp
+++ b/tolk/pipe-lazy-load-insertions.cpp
@@ -654,7 +654,7 @@ class CollectUsagesInStatementVisitor final : public ASTVisitorFunctionBody {
     SinkExpression dot_s_expr = extract_sink_expression_from_vertex(v);
     bool check_for_child = lazy_expr->fields.empty();   // treat accessing `obj.tensor.0` is like `obj.tensor`
     if (dot_s_expr == s_expr || (check_for_child && dot_s_expr.is_child_of(s_expr))) {
-      bool is_subj_of_dot = parent_dot && parent_dot->is_target_struct_field() && parent_dot->get_obj() == v;
+      bool is_subj_of_dot = parent_dot && parent_dot->is_target_struct_field() && parent_dot->get_obj() == v && extract_sink_expression_from_vertex(parent_dot);
       if (!is_subj_of_dot) {
         lazy_expr->on_used_rw(v->is_lvalue);
       }
@@ -697,6 +697,9 @@ class CollectUsagesInStatementVisitor final : public ASTVisitorFunctionBody {
           ExprUsagesWhileCollecting inner_usages = collect_expr_usages_in_block(lazy_expr->name_str + "(=self)", SinkExpression(&fun_ref->parameters[0]), lazy_expr->expr_type, v_body_block);
           inner_usages.treat_match_like_read();   // nested lazy match in inlined functions doesn't work, it's not wrapped into aux vertex
           lazy_expr->merge_with_sub_block(inner_usages);
+          if (dot_obj->kind == ast_assign) {
+            parent::visit(v->get_callee());
+          }
           parent::visit(v->get_arg_list());
           return;
         }
@@ -900,7 +903,7 @@ class CollectAllLazyObjectsAndFieldsVisitor final : public ASTVisitorFunctionBod
         auto lhs_var = lhs_var_decl->get_expr()->try_as<ast_local_var_lhs>();
         // collect usages of a lazy var inside the same block statement where it's declared
         LocalVarPtr var_ref = lhs_var->var_ref;
-        if (!var_ref->declared_type->equal_to(rhs_lazy->inferred_type)) {
+        if (!var_ref->declared_type->equal_to(rhs_lazy->inferred_type) || get_custom_pack_unpack_function(var_ref->declared_type)) {
           err("`lazy` will not work here, because variable `{}` is declared as `{}`, but lazy expression has type `{}`",
               var_ref, var_ref->declared_type, rhs_lazy->inferred_type).fire(rhs_lazy->keyword_range(), cur_f);
         }
@@ -1069,6 +1072,7 @@ public:
 };
 
 void pipeline_lazy_load_insertions() {
+  functions_with_lazy_vars.clear();
   CollectAllLazyObjectsAndFieldsVisitor collector;
   visit_ast_of_all_functions(collector);
   LazyLoadInsertionsReplacer replacer;

--- a/tolk/pipe-mini-borrow-checker.cpp
+++ b/tolk/pipe-mini-borrow-checker.cpp
@@ -37,7 +37,7 @@
  *   > d.mutatingMethod(d.nested.field = 10)    // error, can not borrow `d.nested.field`, because `d` already borrowed
  *   > p.x += (p.mut().x = 5)                   // error, can not borrow `p`, because `p.x` already borrowed
  *
- *   To track which variables/fields are being mutated, we use is_valid_lvalue_path() with sink collection:
+ *   To track which variables/fields are being mutated, we use is_valid_assignment_lhs() with sink collection:
  * it traverses the lvalue path and collects SinkExpression for each "leaf" variable being mutated.
  * For tensors like `(a, b)`, both `a` and `b` are collected.
  * Tensor literal projections like `(a, b).0` are not valid lvalue paths.
@@ -51,7 +51,7 @@ struct BorrowedVarOrField {
 };
 
 // to fire on `x.inc().addOther(mutate x)`, having `addOther()` call, detect `x` on the left;
-// without this, a chain of mutate-self will not fire, since `x.inc()` is not is_valid_lvalue_path
+// without this, a chain of mutate-self will not fire, since `x.inc()` is not is_valid_mutation_path
 static AnyExprV get_leftmost_chained_mutate_self(AnyExprV v) {
   auto as_call = v->try_as<ast_function_call>();
   if (!as_call || !as_call->fun_maybe || !as_call->dot_obj_is_self ||
@@ -60,7 +60,7 @@ static AnyExprV get_leftmost_chained_mutate_self(AnyExprV v) {
   }
 
   AnyExprV self_obj = as_call->get_self_obj();
-  return is_valid_lvalue_path(self_obj) ? self_obj : get_leftmost_chained_mutate_self(self_obj);
+  return is_valid_mutation_path(self_obj) ? self_obj : get_leftmost_chained_mutate_self(self_obj);
 }
 
 class BorrowedForWriteCtx {
@@ -100,7 +100,7 @@ public:
   void borrow_all_from_lvalue(FunctionPtr cur_f, AnyExprV lhs, FunctionPtr called_f) {
     // for `v = rhs`, sinks = [v]; for `(a, b.field) = rhs`, sinks = [a, b.field]
     std::vector<SinkExpression> sinks;
-    is_valid_lvalue_path(lhs, &sinks);    // not assert, it may be false (an error is already collected)
+    is_valid_assignment_lhs(lhs, &sinks);    // not assert, it may be false (an error is already collected)
     for (const SinkExpression& s : sinks) {
       borrow_or_fire_if_twice(cur_f, s, lhs, called_f);
     }

--- a/tolk/pipe-register-symbols.cpp
+++ b/tolk/pipe-register-symbols.cpp
@@ -121,8 +121,8 @@ static AliasDefPtr register_type_alias(V<ast_type_alias_declaration> v, AliasDef
   if (name.empty()) {
     name = v_ident->name;
   }
-  if (name == "T") {
-    err("`T` is a reserved system name for generics").fire(v_ident);
+  if (name == "T" || name == "K" || name == "V") {
+    err("`{}` is a reserved system name for generics", name).fire(v_ident);
   }
   const GenericsDeclaration* genericTs = nullptr;   // at registering it's null; will be assigned after types resolving
   AliasDefData* a_sym = new AliasDefData(std::move(name), v_ident, v->underlying_type_node, DocCommentLines(v->doc_lines), genericTs, substitutedTs, v);
@@ -208,6 +208,10 @@ static StructPtr register_struct(V<ast_struct_declaration> v, StructPtr base_str
   if (name.empty()) {
     name = v_ident->name;
   }
+  if (name == "T" || name == "K" || name == "V") {
+    err("`{}` is a reserved system name for generics", name).fire(v_ident);
+  }
+
   const GenericsDeclaration* genericTs = nullptr;   // at registering it's null; will be assigned after types resolving
   StructData* s_sym = new StructData(std::move(name), v_ident, std::move(fields), opcode, v->overflow1023_policy, DocCommentLines(v->doc_lines), genericTs, substitutedTs, v);
   s_sym->base_struct_ref = base_struct_ref;   // for `Container<int>`, here is `Container<T>`

--- a/tolk/pipe-resolve-types.cpp
+++ b/tolk/pipe-resolve-types.cpp
@@ -20,6 +20,7 @@
 #include "compiler-state.h"
 #include "generics-helpers.h"
 #include "contract-directive.h"
+#include "recursion-guard.h"
 #include "type-system.h"
 #include <charconv>
 
@@ -280,9 +281,11 @@ class TypeNodesVisitorResolver {
           err("type `{}` circularly references itself", struct_ref).fire(struct_ref->ident_anchor);
         }
         called_stack.push_back(struct_ref);
+        RecursionGuard guard([&] {
+          called_stack.pop_back();
+        });
         const GenericsDeclaration* genericTs = construct_genericTs(nullptr, v_genericsT_list);
         struct_ref->mutate()->assign_resolved_genericTs(genericTs);
-        called_stack.pop_back();
       }
     }
   }
@@ -789,10 +792,12 @@ class InfiniteStructSizeDetector {
     }
 
     called_stack.push_back(struct_ref);
+    RecursionGuard guard([&] {
+      called_stack.pop_back();
+    });
     for (StructFieldPtr field_ref : struct_ref->fields) {
       visit_type_deeply(field_ref->declared_type);
     }
-    called_stack.pop_back();
   }
 
 public:

--- a/tolk/recursion-guard.h
+++ b/tolk/recursion-guard.h
@@ -1,0 +1,48 @@
+/*
+    This file is part of TON Blockchain Library.
+
+    TON Blockchain Library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    TON Blockchain Library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with TON Blockchain Library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <utility>
+
+namespace tolk {
+
+// RecursionGuard is used to detect when a type/expansion circularly references itself.
+// Example:
+// > if (called_stack.includes(fun_ref)) fire();
+// > called_stack.push_back(fun_ref);
+// > RecursionGuard guard([&] {
+// >   called_stack.pop_back();
+// > });
+// > analyze(fun_ref); // may enter the same execution point
+// We intentionally use the destructor to roll the state back on potential `err(...).fire()` inside.
+template<typename F>
+class RecursionGuard {
+  F on_destroy;
+
+public:
+  explicit RecursionGuard(F on_destroy)
+    : on_destroy(std::move(on_destroy)) {}
+
+  RecursionGuard(const RecursionGuard&) = delete;
+  RecursionGuard& operator=(const RecursionGuard&) = delete;
+
+  ~RecursionGuard() {
+    on_destroy();
+  }
+};
+
+} // namespace tolk

--- a/tolk/smart-casts-cfg.cpp
+++ b/tolk/smart-casts-cfg.cpp
@@ -512,18 +512,18 @@ SinkExpression extract_sink_expression_from_vertex(AnyExprV v) {
   return {};
 }
 
-// is_valid_lvalue_path checks whether an expression is a valid target for writing (assignment / mutate).
+// is_valid_mutation_path checks whether an expression is a valid target for mutation.
 // Its main property: "safe to be re-evaluated" while transforming AST to IR.
-// Valid: `v` / `v.field` / `v.0!.nested` / `(a, b)`
-//        (all can be used as `lvalue = rhs` / `f(mutate lvalue)` / `lvalue.mutatingMethod()`)
-// Invalid: `v.id().field` / `(v = rhs).field` / `Point{x,y}.x` / `(a, b).0`
-//        (none can be used as lvalue, for example `Point{x,y}.x = 100` is denied)
+// Valid: `v` / `v.field` / `v.0!.nested`
+//        (all can be used as `f(mutate lvalue)` / `lvalue.mutatingMethod()`)
+// Invalid: `v.id().field` / `(v = rhs).field` / `Point{x,y}.x` / `(a, b)` / `[a, b]`
+//        (all are denied: `f(mutate Point{x,y}.x)` / `f(mutate (a,b))` / `v.id().increment()`)
 //
 // It's conceptually similar to extract_sink_expression_from_vertex, but NOT the same:
 // - "sink" is ONE local variable or field, used for smart casts and cfg
-// - "lvalue path" may contain MANY targets (each is sink) (both `a` and `b` for `(a,b) = (1,2)`)
-// When `out_sinks` is provided, collects SinkExpression for each "leaf" variable/field being mutated.
-bool is_valid_lvalue_path(AnyExprV v, std::vector<SinkExpression>* out_sinks, bool inside_dot_obj) {
+// - "lvalue path" is an atomically re-evaluable path to one target
+// When `out_sinks` is provided, stores SinkExpression if this lvalue path has one.
+bool is_valid_mutation_path(AnyExprV v, std::vector<SinkExpression>* out_sinks, bool inside_dot_obj) {
   if (auto as_ref = v->try_as<ast_reference>()) {
     if (out_sinks) {
       if (LocalVarPtr var_ref = as_ref->sym->try_as<LocalVarPtr>()) {
@@ -534,20 +534,8 @@ bool is_valid_lvalue_path(AnyExprV v, std::vector<SinkExpression>* out_sinks, bo
     }
     return true;
   }
-  if (v->try_as<ast_underscore>()) {
-    return true;
-  }
-  if (auto as_decl = v->try_as<ast_local_vars_declaration>()) {
-    return is_valid_lvalue_path(as_decl->get_expr(), out_sinks);
-  }
-  if (auto decl_var = v->try_as<ast_local_var_lhs>()) {
-    if (out_sinks) {
-      out_sinks->emplace_back(decl_var->var_ref);
-    }
-    return true;
-  }
   if (auto as_nn = v->try_as<ast_not_null_operator>()) {
-    return inside_dot_obj && is_valid_lvalue_path(as_nn->get_expr(), out_sinks, inside_dot_obj);
+    return inside_dot_obj && is_valid_mutation_path(as_nn->get_expr(), out_sinks, inside_dot_obj);
   }
   if (auto as_dot = v->try_as<ast_dot_access>();
            as_dot && (as_dot->is_target_indexed_access() || as_dot->is_target_struct_field())) {
@@ -559,7 +547,7 @@ bool is_valid_lvalue_path(AnyExprV v, std::vector<SinkExpression>* out_sinks, bo
       return false;
     }
     std::vector<SinkExpression> inner_sinks;
-    bool inner_valid = is_valid_lvalue_path(as_dot->get_obj(), &inner_sinks, true);
+    bool inner_valid = is_valid_mutation_path(as_dot->get_obj(), &inner_sinks, true);
     if (out_sinks) {
       for (SinkExpression s : inner_sinks) {
         out_sinks->push_back(s.get_child_s_expr(index_at));
@@ -567,21 +555,43 @@ bool is_valid_lvalue_path(AnyExprV v, std::vector<SinkExpression>* out_sinks, bo
     }
     return inner_valid;
   }
+  return false;
+}
+
+// is_valid_assignment_lhs checks destructuring assignments patterns.
+// When `out_sinks` is provided, stores SinkExpression for every lhs target.
+bool is_valid_assignment_lhs(AnyExprV v, std::vector<SinkExpression>* out_sinks) {
+  if (auto as_decl = v->try_as<ast_local_vars_declaration>()) {
+    return is_valid_assignment_lhs(as_decl->get_expr(), out_sinks);
+  }
+  if (auto decl_var = v->try_as<ast_local_var_lhs>()) {
+    if (out_sinks) {
+      out_sinks->emplace_back(decl_var->var_ref);
+    }
+    return true;
+  }
+  if (v->try_as<ast_underscore>()) {
+    return true;
+  }
+  // allow destructuring `(a, b) = someTensor`, store both `a` and `b`
   if (auto as_tensor = v->try_as<ast_tensor>()) {
     bool all_valid = true;
     for (int i = 0; i < as_tensor->size(); ++i) {
-      all_valid &= is_valid_lvalue_path(as_tensor->get_item(i), out_sinks);
+      all_valid &= is_valid_assignment_lhs(as_tensor->get_item(i), out_sinks);
     }
     return all_valid;
   }
+  // allow destructuring `[a, b] = someTuple` and nesting like `(a, [b,c]) = rhs`
   if (auto as_square = v->try_as<ast_square_brackets>()) {
     bool all_valid = true;
     for (int i = 0; i < as_square->size(); ++i) {
-      all_valid &= is_valid_lvalue_path(as_square->get_item(i), out_sinks);
+      all_valid &= is_valid_assignment_lhs(as_square->get_item(i), out_sinks);
     }
     return all_valid;
   }
-  return false;
+  // allow `lhs = rhs` if `f(mutate lhs)` is allowed:
+  // examples: `variable = rhs`, `(_, _, obj.field) = rhs` (we are in recursion inside a tensor)
+  return is_valid_mutation_path(v, out_sinks);
 }
 
 // given `lhs = rhs`, calculate "original" type of `lhs`

--- a/tolk/smart-casts-cfg.cpp
+++ b/tolk/smart-casts-cfg.cpp
@@ -199,14 +199,17 @@ static TypePtr calculate_type_lca(TypePtr a, TypePtr b, bool* became_union = nul
   if (tensor1 && tensor2 && tensor1->size() == tensor2->size()) {
     std::vector<TypePtr> types_lca;
     types_lca.reserve(tensor1->size());
+    bool ith_became_union = false;
     for (int i = 0; i < tensor1->size(); ++i) {
-      TypePtr next = calculate_type_lca(tensor1->items[i], tensor2->items[i], became_union);
+      TypePtr next = calculate_type_lca(tensor1->items[i], tensor2->items[i], &ith_became_union);
       if (next == nullptr) {
         return nullptr;
       }
       types_lca.push_back(next);
     }
-    return TypeDataTensor::create(std::move(types_lca));
+    if (!ith_became_union) {
+      return TypeDataTensor::create(std::move(types_lca));
+    }
   }
 
   TypePtr resulting_union = TypeDataUnion::create(std::vector{a, b});

--- a/tolk/smart-casts-cfg.h
+++ b/tolk/smart-casts-cfg.h
@@ -207,7 +207,8 @@ std::ostream& operator<<(std::ostream& os, const FactsAboutExpr& facts);
 std::ostream& operator<<(std::ostream& os, const FlowContext& flow);
 TypePtr calculate_type_subtract_rhs_type(TypePtr type, TypePtr subtract_type);
 SinkExpression extract_sink_expression_from_vertex(AnyExprV v);
-bool is_valid_lvalue_path(AnyExprV v, std::vector<SinkExpression>* out_sinks = nullptr, bool inside_dot_obj = false);
+bool is_valid_mutation_path(AnyExprV v, std::vector<SinkExpression>* out_sinks = nullptr, bool inside_dot_obj = false);
+bool is_valid_assignment_lhs(AnyExprV v, std::vector<SinkExpression>* out_sinks = nullptr);
 TypePtr calc_declared_type_before_smart_cast(AnyExprV v);
 TypePtr calc_smart_cast_type_on_assignment(TypePtr lhs_declared_type, TypePtr rhs_inferred_type);
 

--- a/tolk/symtable.h
+++ b/tolk/symtable.h
@@ -125,7 +125,7 @@ struct FunctionData final : Symbol {
     flagAcceptsSelf = 512,      // is a member function (has `self` first parameter)
     flagReturnsSelf = 1024,     // return type is `self` (returns the mutated 1st argument), calls can be chainable
     flagReallyUsed = 2048,      // calculated via dfs from used functions; declared but unused functions are not codegenerated
-    flagCompileTimeVal = 4096,  // calculated only at compile-time for constant arguments: `ton("0.05")`, `"str".crc32()`, and others
+    flagCompileTimeVal = 4096,  // calculated only at compile-time for constant arguments: `grams("0.05")`, `"str".crc32()`, and others
     flagAllowAnyWidthT = 16384, // for built-in generic functions that <T> is not restricted to be 1-slot type
     flagManualOnBounce = 32768, // for onInternalMessage, don't insert "if (isBounced) return"
   };

--- a/tolk/tolk-version.h
+++ b/tolk/tolk-version.h
@@ -18,6 +18,6 @@
 
 namespace tolk {
 
-constexpr const char* TOLK_VERSION = "1.4.1";
+constexpr const char* TOLK_VERSION = "1.4.2";
 
 } // namespace tolk

--- a/tolk/type-system.h
+++ b/tolk/type-system.h
@@ -592,7 +592,7 @@ public:
 
 /*
  * `coins` is just integer at TVM level, but encoded as varint when serializing structures.
- * Example: `var cost = ton("0.05")` has type `coins`.
+ * Example: `var cost = grams("0.05")` has type `coins`.
  */
 class TypeDataCoins final : public TypeData {
   TypeDataCoins() : TypeData(0) {}


### PR DESCRIPTION
This is a minor update, mostly required to reflect step 4 of MTONGA.

## Rename `ton("0.05")` to `grams("0.05")`

The currency name is being changed from "TON" to "GRAM". Hence, this renaming has been done throughout the compiler, stdlib, and doc comments.

For instance, a built-in function `ton` is becoming deprecated: use `grams`

```
// before
val amount = ton("0.05");     // 50000000 nanotons

// now
val amount = grams("0.05");   // 50000000 nanograms
```

**The old `ton` function is still available for backward compatibility**. So, rewriting your code immediately is not required, though recommended for consistency.

Similarly, `reserveToncoinsOnBalance` becomes deprecated in favor of `reserveGramsOnBalance`.

Note that many standard contracts have field naming like `forwardTonAmount`. Probably, you have similar in your contracts. They can be safely renamed to `forwardGrams` etc., because field names do not affect binary encoding.

## Minor changes in a language

Besides, there are small changes and bugfixes in corner cases.

1. **Tensors are not valid lvalues anymore**. Example: `f(mutate (a,b))` and `(a, b).0 = newA` are now forbidden. This is absolutely useless in practice, but could lead to unexpected side effects.
  Note that syntax `(a, b) = rhs` is allowed. It's now treated as a special destructuring syntax, as well as `[a, b] = rhs`. In the future, destructuring of structs will be supported the same way.

2. **Disallow `SomeAlias { ... }`, allow only `SomeStruct { ... }`**. This restriction was introduced to prevent ambiguilty when structs/aliases contradict in custom serializers. 

3. **Disallow `lazyVar = rhs`, allow only `lazyVar.field = rhs`**. Whole-lazy assignments are impractical, but may lead to corner cases bugs like `(v = v).toCell()`.

4. **Minor bug fixes of issues found by LLM fuzzing**. Traditionally, we continuously scan the compiler to find corner cases where it mismatches specification or crashes. All findings are absolutely impractical.
For example, recursive implicit generics that appear in constant initializers.
For example, assigning one `lazy` variable to another, which probably should be prohibited. 
For example, `assert (condition) throw funThatThrows()`.
And so on.


## Related pull requests

* https://github.com/ton-blockchain/tolk-js/pull/21
* https://github.com/ton-org/docs/pull/2222
* https://github.com/ton-blockchain/acton/pull/1128
* https://github.com/ton-blockchain/acton/pull/1139