### PR TITLE
Do not spawn simplex::Pool on observers with protocol_version=1

### DIFF
--- a/validator/consensus/simplex/pool.cpp
+++ b/validator/consensus/simplex/pool.cpp
@@ -314,6 +314,10 @@ class PoolImpl : public td::actor::SpawnsWith<Bus>, public td::actor::ConnectsTo
  public:
   TON_RUNTIME_DEFINE_EVENT_HANDLER();
 
+  static bool should_be_spawned(const Bus &bus) {
+    return bus.is_validator() || !bus.config.enable_block_sync();
+  }
+
   void start_up() override {
     auto &bus = *owning_bus();
 


### PR DESCRIPTION
Otherwise it will register PrecheckCandidateBroadcast which would conflict with BlockSyncObserver's handler.