### PR TITLE
feat(liteserver): add getBlockSignatures method

### DIFF
--- a/tl/generate/scheme/lite_api.tl
+++ b/tl/generate/scheme/lite_api.tl
@@ -108,6 +108,7 @@ liteServer.getValidatorStats#091a58bc mode:# id:tonNode.blockIdExt limit:int sta
 liteServer.getLibraries library_list:(vector int256) = liteServer.LibraryResult;
 liteServer.getLibrariesWithProof id:tonNode.blockIdExt mode:# library_list:(vector int256) = liteServer.LibraryResultWithProof;
 liteServer.getShardBlockProof id:tonNode.blockIdExt = liteServer.ShardBlockProof;
+liteServer.getBlockSignatures id:tonNode.blockIdExt = liteServer.SignatureSet;
 liteServer.getOutMsgQueueSizes mode:# wc:mode.0?int shard:mode.0?long = liteServer.OutMsgQueueSizes;
 liteServer.getBlockOutMsgQueueSize mode:# id:tonNode.blockIdExt want_proof:mode.0?true = liteServer.BlockOutMsgQueueSize;
 liteServer.getDispatchQueueInfo mode:# id:tonNode.blockIdExt after_addr:mode.1?int256 max_accounts:int want_proof:mode.0?true = liteServer.DispatchQueueInfo;

--- a/validator/impl/liteserver.cpp
+++ b/validator/impl/liteserver.cpp
@@ -271,6 +271,7 @@ void LiteQuery::perform() {
             this->perform_getLibrariesWithProof(ton::create_block_id(q.id_), q.mode_, q.library_list_);
           },
           [&](lite_api::liteServer_getShardBlockProof& q) { this->perform_getShardBlockProof(create_block_id(q.id_)); },
+          [&](lite_api::liteServer_getBlockSignatures& q) { this->perform_getBlockSignatures(create_block_id(q.id_)); },
           [&](lite_api::liteServer_nonfinal_getPendingShardBlocks& q) {
             this->perform_nonfinal_getPendingShardBlocks(q.mode_, ShardIdFull{q.wc_, (ShardId)q.shard_});
           },
@@ -3345,6 +3346,41 @@ void LiteQuery::continue_getShardBlockProof(Ref<BlockData> cur_block,
                                         std::move(result));
         }
       });
+}
+
+void LiteQuery::perform_getBlockSignatures(BlockIdExt blkid) {
+  LOG(INFO) << "started a getBlockSignatures(" << blkid.to_str() << ") liteserver query";
+  if (!blkid.is_valid_ext()) {
+    fatal_error("invalid block id");
+    return;
+  }
+  if (!blkid.is_masterchain()) {
+    fatal_error("only masterchain block signatures are available");
+    return;
+  }
+  td::actor::send_closure_later(
+      manager_, &ValidatorManager::wait_block_signatures_short, blkid, td::Timestamp::in(5.0),
+      [Self = actor_id(this)](td::Result<td::Ref<block::BlockSignatureSet>> R) {
+        if (R.is_error()) {
+          td::actor::send_closure(Self, &LiteQuery::abort_query,
+                                  R.move_as_error_prefix("cannot get block signatures: "));
+        } else {
+          td::actor::send_closure_later(Self, &LiteQuery::continue_getBlockSignatures, R.move_as_ok());
+        }
+      });
+}
+
+void LiteQuery::continue_getBlockSignatures(td::Ref<block::BlockSignatureSet> sig_set) {
+  if (sig_set.is_null()) {
+    fatal_error("no signatures stored for this block");
+    return;
+  }
+  if (!sig_set->is_final()) {
+    fatal_error("stored block signatures are not final");
+    return;
+  }
+  LOG(INFO) << "getBlockSignatures() query completed";
+  finish_query(serialize_tl_object(sig_set->tl_lite(), true));
 }
 
 void LiteQuery::perform_getOutMsgQueueSizes(td::optional<ShardIdFull> shard) {

--- a/validator/impl/liteserver.hpp
+++ b/validator/impl/liteserver.hpp
@@ -177,6 +177,8 @@ class LiteQuery : public td::actor::Actor {
   void perform_getShardBlockProof(BlockIdExt blkid);
   void continue_getShardBlockProof(Ref<BlockData> cur_block,
                                    std::vector<std::pair<BlockIdExt, td::BufferSlice>> result);
+  void perform_getBlockSignatures(BlockIdExt blkid);
+  void continue_getBlockSignatures(td::Ref<block::BlockSignatureSet> sig_set);
   void perform_getOutMsgQueueSizes(td::optional<ShardIdFull> shard);
   void continue_getOutMsgQueueSizes(td::optional<ShardIdFull> shard, Ref<MasterchainState> state);
   void perform_getBlockOutMsgQueueSize(int mode, BlockIdExt blkid);


### PR DESCRIPTION
Expose the stored per-block simplex signature set for any masterchain block via wait_block_signatures_short -> tl_lite(), so clients can fetch a block's own signatures directly (incl. past-epoch blocks), not only via getBlockProof.

```
liteServer.getBlockSignatures id:tonNode.blockIdExt = liteServer.SignatureSet
```