### PR TITLE
Fix ADNL inbound peer limiter poisoning

### DIFF
--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -90,15 +90,18 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
   co_return {};
 }
 
-void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer) {
+void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer, td::Promise<td::Unit> promise) {
   auto &rate_limiter = inbound_rate_limiter_[remove_port(addr)];
-  if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT) {
+  if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT &&
+      !rate_limiter.recent_inbound_peers.contains(peer)) {
+    promise.set_error(td::Status::Error("too many unique peer ids from a single ip"));
     return;
   }
   rate_limiter.recent_inbound_peers.insert(peer);
   if (!cleanup_recent_inbound_peers_at_) {
     alarm_timestamp().relax(cleanup_recent_inbound_peers_at_ = td::Timestamp::in(UNIQUE_PEERS_PER_IP_WINDOW));
   }
+  promise.set_value(td::Unit());
 }
 
 void AdnlLocalId::deliver(AdnlNodeIdShort src, td::BufferSlice data) {

--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -83,16 +83,22 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
     if (!rate_limiter.recent_inbound_peers.contains(packet.from_short())) {
       co_return td::Status::Error("too many unique peer ids from a single ip");
     }
-  } else {
-    rate_limiter.recent_inbound_peers.insert(packet.from_short());
-    if (!cleanup_recent_inbound_peers_at_) {
-      alarm_timestamp().relax(cleanup_recent_inbound_peers_at_ = td::Timestamp::in(UNIQUE_PEERS_PER_IP_WINDOW));
-    }
   }
 
   td::actor::send_closure(peer_table_, &AdnlPeerTable::receive_decrypted_packet, short_id_, std::move(packet),
                           data_size);
   co_return {};
+}
+
+void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer) {
+  auto &rate_limiter = inbound_rate_limiter_[remove_port(addr)];
+  if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT) {
+    return;
+  }
+  rate_limiter.recent_inbound_peers.insert(peer);
+  if (!cleanup_recent_inbound_peers_at_) {
+    alarm_timestamp().relax(cleanup_recent_inbound_peers_at_ = td::Timestamp::in(UNIQUE_PEERS_PER_IP_WINDOW));
+  }
 }
 
 void AdnlLocalId::deliver(AdnlNodeIdShort src, td::BufferSlice data) {

--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -92,6 +92,9 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
 
 void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer, td::Promise<td::Unit> promise) {
   auto &rate_limiter = inbound_rate_limiter_[remove_port(addr)];
+  if (!cleanup_rate_limiter_at_) {
+    alarm_timestamp().relax(cleanup_rate_limiter_at_ = td::Timestamp::in(1.0));
+  }
   if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT &&
       !rate_limiter.recent_inbound_peers.contains(peer)) {
     promise.set_error(td::Status::Error("too many unique peer ids from a single ip"));

--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -92,15 +92,18 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
   co_return {};
 }
 
-void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer) {
+void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer, td::Promise<td::Unit> promise) {
   auto &rate_limiter = inbound_rate_limiter_[remove_port(addr)];
-  if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT) {
+  if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT &&
+      !rate_limiter.recent_inbound_peers.contains(peer)) {
+    promise.set_error(td::Status::Error("too many unique peer ids from a single ip"));
     return;
   }
   rate_limiter.recent_inbound_peers.insert(peer);
   if (!cleanup_recent_inbound_peers_at_) {
     alarm_timestamp().relax(cleanup_recent_inbound_peers_at_ = td::Timestamp::in(UNIQUE_PEERS_PER_IP_WINDOW));
   }
+  promise.set_value(td::Unit());
 }
 
 void AdnlLocalId::deliver(AdnlNodeIdShort src, td::BufferSlice data) {

--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -85,16 +85,22 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
     if (!rate_limiter.recent_inbound_peers.contains(packet.from_short())) {
       co_return td::Status::Error("too many unique peer ids from a single ip");
     }
-  } else {
-    rate_limiter.recent_inbound_peers.insert(packet.from_short());
-    if (!cleanup_recent_inbound_peers_at_) {
-      alarm_timestamp().relax(cleanup_recent_inbound_peers_at_ = td::Timestamp::in(UNIQUE_PEERS_PER_IP_WINDOW));
-    }
   }
 
   td::actor::send_closure(peer_table_, &AdnlPeerTable::receive_decrypted_packet, short_id_, std::move(packet),
                           data_size);
   co_return {};
+}
+
+void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer) {
+  auto &rate_limiter = inbound_rate_limiter_[remove_port(addr)];
+  if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT) {
+    return;
+  }
+  rate_limiter.recent_inbound_peers.insert(peer);
+  if (!cleanup_recent_inbound_peers_at_) {
+    alarm_timestamp().relax(cleanup_recent_inbound_peers_at_ = td::Timestamp::in(UNIQUE_PEERS_PER_IP_WINDOW));
+  }
 }
 
 void AdnlLocalId::deliver(AdnlNodeIdShort src, td::BufferSlice data) {

--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -94,6 +94,9 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
 
 void AdnlLocalId::add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer, td::Promise<td::Unit> promise) {
   auto &rate_limiter = inbound_rate_limiter_[remove_port(addr)];
+  if (!cleanup_rate_limiter_at_) {
+    alarm_timestamp().relax(cleanup_rate_limiter_at_ = td::Timestamp::in(1.0));
+  }
   if (rate_limiter.recent_inbound_peers.size() >= UNIQUE_PEERS_PER_IP_LIMIT &&
       !rate_limiter.recent_inbound_peers.contains(peer)) {
     promise.set_error(td::Status::Error("too many unique peer ids from a single ip"));

--- a/adnl/adnl-local-id.h
+++ b/adnl/adnl-local-id.h
@@ -52,6 +52,7 @@ class AdnlLocalId : public td::actor::Actor {
   void deliver_query(AdnlNodeIdShort src, td::BufferSlice data, td::Promise<td::BufferSlice> promise);
   void receive(td::IPAddress addr, td::BufferSlice data);
   td::actor::Task<> receive_coro(td::IPAddress addr, td::BufferSlice data);
+  void add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer);
 
   void subscribe(std::string prefix, std::unique_ptr<AdnlPeerTable::Callback> callback);
   void unsubscribe(std::string prefix);

--- a/adnl/adnl-local-id.h
+++ b/adnl/adnl-local-id.h
@@ -52,7 +52,7 @@ class AdnlLocalId : public td::actor::Actor {
   void deliver_query(AdnlNodeIdShort src, td::BufferSlice data, td::Promise<td::BufferSlice> promise);
   void receive(td::IPAddress addr, td::BufferSlice data);
   td::actor::Task<> receive_coro(td::IPAddress addr, td::BufferSlice data);
-  void add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer);
+  void add_inbound_peer(td::IPAddress addr, AdnlNodeIdShort peer, td::Promise<td::Unit> promise);
 
   void subscribe(std::string prefix, std::unique_ptr<AdnlPeerTable::Callback> callback);
   void unsubscribe(std::string prefix);

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -129,35 +129,6 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
   }
   AdnlNodeIdShort src = packet.from_short();
 
-  auto it = peers_.find(src);
-  if (it == peers_.end()) {
-    if (!packet.inited_from()) {
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: unknown peer and no full src in packet";
-      return;
-    }
-    if (network_manager_.empty()) {
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: unknown peer and network manager uninitialized";
-      return;
-    }
-
-    auto R = packet.from().pubkey().create_encryptor();
-    if (R.is_error()) {
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: failed to create encryptor: " << R.move_as_error();
-      return;
-    }
-    auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
-    if (S.is_error()) {
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: bad signature: " << S;
-      return;
-    }
-
-    it = peers_.try_emplace(src).first;
-  }
-
   auto it2 = local_ids_.find(dst);
   if (it2 == local_ids_.end()) {
     VLOG(adnl, ERROR) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
@@ -165,6 +136,65 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
     return;
   }
 
+  auto it = peers_.find(src);
+  if (it != peers_.end() && it->second.peers.count(dst) != 0) {
+    dispatch_decrypted_packet(dst, std::move(packet), serialized_size);
+    return;
+  }
+
+  if (it == peers_.end()) {
+    if (network_manager_.empty()) {
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: unknown peer and network manager uninitialized";
+      return;
+    }
+  }
+
+  AdnlNodeIdFull peer_id;
+  if (packet.inited_from()) {
+    peer_id = packet.from();
+  } else if (it != peers_.end() && !it->second.peer_id.empty()) {
+    peer_id = it->second.peer_id;
+  } else {
+    VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                     << "]: unknown peer and no full src in packet";
+    return;
+  }
+
+  auto R = peer_id.pubkey().create_encryptor();
+  if (R.is_error()) {
+    VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                     << "]: failed to create encryptor: " << R.move_as_error();
+    return;
+  }
+  auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
+  if (S.is_error()) {
+    VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                     << "]: bad signature: " << S;
+    return;
+  }
+
+  auto addr = packet.remote_addr();
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), dst, packet = std::move(packet),
+                                       serialized_size](td::Result<td::Unit> R) mutable {
+    if (R.is_error()) {
+      return;
+    }
+    td::actor::send_closure(SelfId, &AdnlPeerTableImpl::dispatch_decrypted_packet, dst, std::move(packet),
+                            serialized_size);
+  });
+  td::actor::send_closure(it2->second.local_id, &AdnlLocalId::add_inbound_peer, addr, src, std::move(P));
+}
+
+void AdnlPeerTableImpl::dispatch_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket packet,
+                                                  td::uint64 serialized_size) {
+  auto it2 = local_ids_.find(dst);
+  if (it2 == local_ids_.end()) {
+    return;
+  }
+
+  AdnlNodeIdShort src = packet.from_short();
+  auto it = peers_.try_emplace(src).first;
   if (packet.inited_from()) {
     update_id(it->second, packet.from());
   }

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -142,6 +142,19 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
       return;
     }
 
+    auto R = packet.from().pubkey().create_encryptor();
+    if (R.is_error()) {
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: failed to create encryptor: " << R.move_as_error();
+      return;
+    }
+    auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
+    if (S.is_error()) {
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: bad signature: " << S;
+      return;
+    }
+
     it = peers_.try_emplace(src).first;
   }
 

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -174,12 +174,14 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
 
   auto R = peer_id.pubkey().create_encryptor();
   if (R.is_error()) {
+    record_transport_dropped(metrics::Direction::in, metrics::Reason::invalid);
     VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
                      << "]: failed to create encryptor: " << R.move_as_error();
     return;
   }
   auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
   if (S.is_error()) {
+    record_transport_dropped(metrics::Direction::in, metrics::Reason::invalid);
     VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
                      << "]: bad signature: " << S;
     return;

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -137,37 +137,6 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
   }
   AdnlNodeIdShort src = packet.from_short();
 
-  auto it = peers_.find(src);
-  if (it == peers_.end()) {
-    if (!packet.inited_from()) {
-      record_transport_dropped(metrics::Direction::in, metrics::Reason::invalid);
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: unknown peer and no full src in packet";
-      return;
-    }
-    if (network_manager_.empty()) {
-      record_transport_dropped(metrics::Direction::in, metrics::Reason::internal);
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: unknown peer and network manager uninitialized";
-      return;
-    }
-
-    auto R = packet.from().pubkey().create_encryptor();
-    if (R.is_error()) {
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: failed to create encryptor: " << R.move_as_error();
-      return;
-    }
-    auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
-    if (S.is_error()) {
-      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
-                       << "]: bad signature: " << S;
-      return;
-    }
-
-    it = peers_.try_emplace(src).first;
-  }
-
   auto it2 = local_ids_.find(dst);
   if (it2 == local_ids_.end()) {
     record_transport_dropped(metrics::Direction::in, metrics::Reason::internal);
@@ -176,6 +145,67 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
     return;
   }
 
+  auto it = peers_.find(src);
+  if (it != peers_.end() && it->second.peers.count(dst) != 0) {
+    dispatch_decrypted_packet(dst, std::move(packet), serialized_size);
+    return;
+  }
+
+  if (it == peers_.end()) {
+    if (network_manager_.empty()) {
+      record_transport_dropped(metrics::Direction::in, metrics::Reason::internal);
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: unknown peer and network manager uninitialized";
+      return;
+    }
+  }
+
+  AdnlNodeIdFull peer_id;
+  if (packet.inited_from()) {
+    peer_id = packet.from();
+  } else if (it != peers_.end() && !it->second.peer_id.empty()) {
+    peer_id = it->second.peer_id;
+  } else {
+    record_transport_dropped(metrics::Direction::in, metrics::Reason::invalid);
+    VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                     << "]: unknown peer and no full src in packet";
+    return;
+  }
+
+  auto R = peer_id.pubkey().create_encryptor();
+  if (R.is_error()) {
+    VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                     << "]: failed to create encryptor: " << R.move_as_error();
+    return;
+  }
+  auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
+  if (S.is_error()) {
+    VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                     << "]: bad signature: " << S;
+    return;
+  }
+
+  auto addr = packet.remote_addr();
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), dst, packet = std::move(packet),
+                                       serialized_size](td::Result<td::Unit> R) mutable {
+    if (R.is_error()) {
+      return;
+    }
+    td::actor::send_closure(SelfId, &AdnlPeerTableImpl::dispatch_decrypted_packet, dst, std::move(packet),
+                            serialized_size);
+  });
+  td::actor::send_closure(it2->second.local_id, &AdnlLocalId::add_inbound_peer, addr, src, std::move(P));
+}
+
+void AdnlPeerTableImpl::dispatch_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket packet,
+                                                  td::uint64 serialized_size) {
+  auto it2 = local_ids_.find(dst);
+  if (it2 == local_ids_.end()) {
+    return;
+  }
+
+  AdnlNodeIdShort src = packet.from_short();
+  auto it = peers_.try_emplace(src).first;
   if (packet.inited_from()) {
     update_id(it->second, packet.from());
   }

--- a/adnl/adnl-peer-table.cpp
+++ b/adnl/adnl-peer-table.cpp
@@ -152,6 +152,19 @@ void AdnlPeerTableImpl::receive_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket
       return;
     }
 
+    auto R = packet.from().pubkey().create_encryptor();
+    if (R.is_error()) {
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: failed to create encryptor: " << R.move_as_error();
+      return;
+    }
+    auto S = R.move_as_ok()->check_signature(packet.to_sign().as_slice(), packet.signature().as_slice());
+    if (S.is_error()) {
+      VLOG(adnl, INFO) << this << ": dropping IN message [" << packet.from_short() << "->" << dst
+                       << "]: bad signature: " << S;
+      return;
+    }
+
     it = peers_.try_emplace(src).first;
   }
 

--- a/adnl/adnl-peer-table.hpp
+++ b/adnl/adnl-peer-table.hpp
@@ -160,6 +160,7 @@ class AdnlPeerTableImpl : public AdnlPeerTable {
   void gc_peer_pairs(AdnlNodeIdShort local_id, LocalIdInfo &local_id_info);
 
   static void update_id(PeerInfo &peer_info, AdnlNodeIdFull &&peer_id);
+  void dispatch_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket packet, td::uint64 serialized_size);
   td::actor::ActorOwn<AdnlPeerPair> &get_peer_pair(AdnlNodeIdShort peer_id, PeerInfo &peer_info,
                                                    AdnlNodeIdShort local_id, LocalIdInfo &local_id_info);
   PeerPair *get_peer_pair_if_exists(AdnlNodeIdShort peer_id, AdnlNodeIdShort local_id);

--- a/adnl/adnl-peer-table.hpp
+++ b/adnl/adnl-peer-table.hpp
@@ -213,6 +213,7 @@ class AdnlPeerTableImpl : public AdnlPeerTable {
   void gc_peer_pairs(AdnlNodeIdShort local_id, LocalIdInfo &local_id_info);
 
   static void update_id(PeerInfo &peer_info, AdnlNodeIdFull &&peer_id);
+  void dispatch_decrypted_packet(AdnlNodeIdShort dst, AdnlPacket packet, td::uint64 serialized_size);
   td::actor::ActorOwn<AdnlPeerPair> &get_peer_pair(AdnlNodeIdShort peer_id, PeerInfo &peer_info,
                                                    AdnlNodeIdShort local_id, LocalIdInfo &local_id_info);
   PeerPair *get_peer_pair_if_exists(AdnlNodeIdShort peer_id, AdnlNodeIdShort local_id);

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -249,7 +249,7 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
       td::actor::send_closure(actor_id(this), &AdnlPeerPairImpl::send_messages_from_queue);
     }
   }
-  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), peer_id_short_);
   receive_packet_checked(std::move(packet));
 }
 

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -249,6 +249,7 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
       td::actor::send_closure(actor_id(this), &AdnlPeerPairImpl::send_messages_from_queue);
     }
   }
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
   receive_packet_checked(std::move(packet));
 }
 
@@ -268,6 +269,7 @@ void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_s
     return;
   }
 
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
   receive_packet_checked(std::move(packet));
 }
 

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -249,8 +249,14 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
       td::actor::send_closure(actor_id(this), &AdnlPeerPairImpl::send_messages_from_queue);
     }
   }
-  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), peer_id_short_);
-  receive_packet_checked(std::move(packet));
+  auto addr = packet.remote_addr();
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), packet = std::move(packet)](td::Result<td::Unit> R) mutable {
+    if (R.is_error()) {
+      return;
+    }
+    td::actor::send_closure(SelfId, &AdnlPeerPairImpl::receive_packet_checked, std::move(packet));
+  });
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, addr, peer_id_short_, std::move(P));
 }
 
 void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_size) {
@@ -269,8 +275,15 @@ void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_s
     return;
   }
 
-  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
-  receive_packet_checked(std::move(packet));
+  auto addr = packet.remote_addr();
+  auto peer = packet.from_short();
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), packet = std::move(packet)](td::Result<td::Unit> R) mutable {
+    if (R.is_error()) {
+      return;
+    }
+    td::actor::send_closure(SelfId, &AdnlPeerPairImpl::receive_packet_checked, std::move(packet));
+  });
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, addr, peer, std::move(P));
 }
 
 void AdnlPeerPairImpl::deliver_message(AdnlMessage message) {

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -263,8 +263,14 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
       td::actor::send_closure(actor_id(this), &AdnlPeerPairImpl::send_messages_from_queue);
     }
   }
-  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), peer_id_short_);
-  receive_packet_checked(std::move(packet));
+  auto addr = packet.remote_addr();
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), packet = std::move(packet)](td::Result<td::Unit> R) mutable {
+    if (R.is_error()) {
+      return;
+    }
+    td::actor::send_closure(SelfId, &AdnlPeerPairImpl::receive_packet_checked, std::move(packet));
+  });
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, addr, peer_id_short_, std::move(P));
 }
 
 void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_size) {
@@ -285,8 +291,15 @@ void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_s
     return;
   }
 
-  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
-  receive_packet_checked(std::move(packet));
+  auto addr = packet.remote_addr();
+  auto peer = packet.from_short();
+  auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), packet = std::move(packet)](td::Result<td::Unit> R) mutable {
+    if (R.is_error()) {
+      return;
+    }
+    td::actor::send_closure(SelfId, &AdnlPeerPairImpl::receive_packet_checked, std::move(packet));
+  });
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, addr, peer, std::move(P));
 }
 
 void AdnlPeerPairImpl::deliver_message(AdnlMessage message) {

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -263,7 +263,7 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
       td::actor::send_closure(actor_id(this), &AdnlPeerPairImpl::send_messages_from_queue);
     }
   }
-  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), peer_id_short_);
   receive_packet_checked(std::move(packet));
 }
 

--- a/adnl/adnl-peer.cpp
+++ b/adnl/adnl-peer.cpp
@@ -263,6 +263,7 @@ void AdnlPeerPairImpl::receive_packet_from_channel(AdnlChannelIdShort id, AdnlPa
       td::actor::send_closure(actor_id(this), &AdnlPeerPairImpl::send_messages_from_queue);
     }
   }
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
   receive_packet_checked(std::move(packet));
 }
 
@@ -284,6 +285,7 @@ void AdnlPeerPairImpl::receive_packet(AdnlPacket packet, td::uint64 serialized_s
     return;
   }
 
+  td::actor::send_closure(local_actor_, &AdnlLocalId::add_inbound_peer, packet.remote_addr(), packet.from_short());
   receive_packet_checked(std::move(packet));
 }
 

--- a/adnl/adnl-test-loopback-implementation.h
+++ b/adnl/adnl-test-loopback-implementation.h
@@ -68,6 +68,14 @@ class TestLoopbackNetworkManager : public ton::adnl::AdnlNetworkManager {
     CHECK(p >= 0 && p <= 1);
     loss_probability_ = p;
   }
+
+  void inject_packet(td::IPAddress addr, td::BufferSlice data) {
+    CHECK(callback_);
+    AdnlCategoryMask category_mask;
+    category_mask[0] = true;
+    callback_->receive_packet(std::move(addr), std::move(category_mask), std::move(data));
+  }
+
   void set_local_id_category(AdnlNodeIdShort id, td::uint8 cat) override {
   }
 

--- a/test/test-adnl.cpp
+++ b/test/test-adnl.cpp
@@ -31,6 +31,7 @@
 #include <thread>
 
 #include "adnl/adnl-network-manager.h"
+#include "adnl/adnl-packet.h"
 #include "adnl/adnl-test-loopback-implementation.h"
 #include "adnl/adnl.h"
 #include "keys/encryptor.h"
@@ -62,6 +63,7 @@ int main() {
 
   ton::adnl::AdnlNodeIdShort src;
   ton::adnl::AdnlNodeIdShort dst;
+  ton::PublicKey dst_public;
 
   td::actor::Scheduler scheduler({7});
 
@@ -78,6 +80,7 @@ int main() {
 
     auto pk2 = ton::PrivateKey{ton::privkeys::Ed25519::random()};
     auto pub2 = pk2.compute_public_key();
+    dst_public = pub2;
     dst = ton::adnl::AdnlNodeIdShort{pub2.compute_short_id()};
     td::actor::send_closure(keyring, &ton::keyring::Keyring::add_key, std::move(pk2), true, [](td::Result<>) {});
 
@@ -195,6 +198,69 @@ int main() {
     };
     td::actor::send_closure(adnl, &ton::adnl::Adnl::subscribe, dst, "1", std::make_unique<Callback>(remaining));
   });
+
+  auto test_setup_timeout = td::Timestamp::in(1.0);
+  while (scheduler.run(1) && !test_setup_timeout.is_in_past()) {
+  }
+
+  LOG(ERROR) << "testing forged inbound peers do not poison the per-IP limiter";
+  auto destination_encryptor = dst_public.create_encryptor().move_as_ok();
+  auto encode_inbound_packet = [&](ton::adnl::AdnlPacket packet) {
+    auto serialized = serialize_tl_object(packet.tl(), true);
+    auto encrypted = destination_encryptor->encrypt(serialized.as_slice()).move_as_ok();
+
+    td::BufferSlice datagram{encrypted.size() + 32};
+    auto output = datagram.as_slice();
+    output.copy_from(dst.as_slice());
+    output.remove_prefix(32);
+    output.copy_from(encrypted.as_slice());
+    return datagram;
+  };
+
+  td::IPAddress shared_source_addr;
+  shared_source_addr.init_host_port("127.0.0.1", 12345).ensure();
+
+  // Fill the old limiter's per-IP capacity with unauthenticated source IDs.
+  std::set<ton::adnl::AdnlNodeIdShort> forged_ids;
+  while (forged_ids.size() < 60) {
+    auto forged_key = ton::PrivateKey{ton::privkeys::Ed25519::random()};
+    forged_ids.emplace(forged_key.compute_public_key().compute_short_id());
+  }
+  scheduler.run_in_context([&] {
+    for (const auto &forged_id : forged_ids) {
+      ton::adnl::AdnlPacket packet;
+      packet.set_source(forged_id);
+      packet.init_random();
+      td::actor::send_closure(network_manager, &ton::adnl::TestLoopbackNetworkManager::inject_packet,
+                              shared_source_addr, encode_inbound_packet(std::move(packet)));
+    }
+  });
+
+  auto forged_packets_processed_at = td::Timestamp::in(2.0);
+  while (scheduler.run(1) && !forged_packets_processed_at.is_in_past()) {
+  }
+
+  auto legitimate_key = ton::PrivateKey{ton::privkeys::Ed25519::random()};
+  auto legitimate_public = legitimate_key.compute_public_key();
+  ton::adnl::AdnlPacket legitimate_packet;
+  legitimate_packet.set_source(ton::adnl::AdnlNodeIdFull{legitimate_public});
+  legitimate_packet.add_message(
+      ton::adnl::AdnlMessage{ton::adnl::adnlmessage::AdnlMessageCustom{send_packet(1)}});
+  legitimate_packet.init_random();
+  auto signer = legitimate_key.create_decryptor().move_as_ok();
+  legitimate_packet.set_signature(signer->sign(legitimate_packet.to_sign().as_slice()).move_as_ok());
+
+  remaining++;
+  scheduler.run_in_context([&] {
+    td::actor::send_closure(network_manager, &ton::adnl::TestLoopbackNetworkManager::inject_packet,
+                            shared_source_addr, encode_inbound_packet(std::move(legitimate_packet)));
+  });
+
+  auto legitimate_packet_timeout = td::Timestamp::in(5.0);
+  while (scheduler.run(1) && remaining != 0 && !legitimate_packet_timeout.is_in_past()) {
+  }
+  CHECK(remaining == 0);
+  LOG(ERROR) << "successfully ignored forged inbound peer IDs without blocking an authenticated peer";
 
   LOG(ERROR) << "Ed25519 version is " << td::Ed25519::version();
   LOG(ERROR) << "testing delivering of all packets";


### PR DESCRIPTION
## Summary

- Defer adding inbound peer IDs until packet authentication succeeds.
- Preserve the per-IP admission limit for already-known peer IDs.
- Apply the same protection to authenticated channel packets.

The inbound limiter previously recorded `packet.from_short()` before signature verification. An attacker could therefore fill the 60-peer set for an IP with forged IDs and block legitimate peers. This change moves the set update after authentication while retaining the existing admission check.

Fixes #2373