### PR TITLE
Split reason in session stats

### DIFF
--- a/tl/generate/scheme/ton_api.tl
+++ b/tl/generate/scheme/ton_api.tl
@@ -882,7 +882,8 @@ validatorStats.blockLimitsStatus
     load_fraction_queue_cleanup:double load_fraction_dispatch:double
     load_fraction_internals:double load_fraction_externals:double
     load_fraction_new_msgs:double
-    limits_log:string = validatorStats.BlockLimitsStatus;
+    limits_log:string
+    overload_reason:int want_split:Bool peak_block_limit_class:int = validatorStats.BlockLimitsStatus;
 validatorStats.blockStats.extMsgsStats
     ext_msgs_total:int ext_msgs_filtered:int ext_msgs_accepted:int ext_msgs_rejected:int = validatorStats.ExtMsgsStats;
 validatorStats.blockStats.neighborStats shard:tonNode.shardId is_trivial:Bool is_local:Bool msg_limit:int

--- a/validator/impl/collator.cpp
+++ b/validator/impl/collator.cpp
@@ -5451,6 +5451,14 @@ bool Collator::check_block_overload() {
                 << out_msg_queue_size_ << " > " << SPLIT_MAX_QUEUE_SIZE << ")";
     } else {
       overload_history_ |= 1;
+      // Record which cause set the overload bit, mirroring the message priority above.
+      if (block_limit_class_ >= block::ParamLimits::cl_soft) {
+        stats_.overload_reason = 1;  // load: a block-limit axis hit soft
+      } else if (long_collation_overload) {
+        stats_.overload_reason = 3;  // collation took too long
+      } else {
+        stats_.overload_reason = 4;  // long dispatch queue processing
+      }
       LOG(INFO) << message;
     }
   } else if (block_limit_class_ <= block::ParamLimits::cl_underload) {
@@ -5470,6 +5478,7 @@ bool Collator::check_block_overload() {
   if (!(overload_history_ & 1) && out_msg_queue_size_ >= FORCE_SPLIT_QUEUE_SIZE &&
       out_msg_queue_size_ <= SPLIT_MAX_QUEUE_SIZE) {
     overload_history_ |= 1;
+    stats_.overload_reason = 2;  // out_msg_queue reached the force-split limit
     LOG(INFO) << "setting overload history because out_msg_queue reached force split limit (" << out_msg_queue_size_
               << " >= " << FORCE_SPLIT_QUEUE_SIZE << ")";
   }
@@ -5483,6 +5492,9 @@ bool Collator::check_block_overload() {
     LOG(INFO) << "want_merge set because of underload history " << buffer;
     want_merge_ = true;
   }
+  // Record the final want_split decision and the peak block-limit class for session-stats attribution.
+  stats_.want_split = want_split_;
+  stats_.peak_block_limit_class = block_limit_class_;
   return true;
 }
 

--- a/validator/interfaces/validator-manager.h
+++ b/validator/interfaces/validator-manager.h
@@ -94,6 +94,12 @@ struct CollationStats {
   td::uint32 estimated_bytes = 0, gas = 0, lt_delta = 0, estimated_collated_data_bytes = 0;
   int cat_bytes = 0, cat_gas = 0, cat_lt_delta = 0, cat_collated_data_bytes = 0;
   std::string limits_log;
+  // Machine-readable attribution of why this block set its overload bit (feeds shard-split analysis):
+  // 0 = none/normal, 1 = load (a block-limit axis hit soft), 2 = out_msg_queue force-split,
+  // 3 = long_collation, 4 = dispatch_queue.
+  int overload_reason = 0;
+  bool want_split = false;             // the collator's final want_split decision for this block
+  int peak_block_limit_class = 0;      // running-max block_limit_class_ (cat_* only approximates this)
   double total_time = 0.0;
   std::string time_stats;
 
@@ -189,7 +195,8 @@ struct CollationStats {
         create_tl_object<ton_api::validatorStats_blockLimitsStatus>(
             estimated_bytes, gas, lt_delta, estimated_collated_data_bytes, cat_bytes, cat_gas, cat_lt_delta,
             cat_collated_data_bytes, load_fraction_queue_cleanup, load_fraction_dispatch, load_fraction_internals,
-            load_fraction_externals, load_fraction_new_msgs, limits_log),
+            load_fraction_externals, load_fraction_new_msgs, limits_log, overload_reason, want_split,
+            peak_block_limit_class),
         std::move(block_stats), storage_stat_cache.tl());
   }
 };

--- a/validator/interfaces/validator-manager.h
+++ b/validator/interfaces/validator-manager.h
@@ -98,8 +98,8 @@ struct CollationStats {
   // 0 = none/normal, 1 = load (a block-limit axis hit soft), 2 = out_msg_queue force-split,
   // 3 = long_collation, 4 = dispatch_queue.
   int overload_reason = 0;
-  bool want_split = false;             // the collator's final want_split decision for this block
-  int peak_block_limit_class = 0;      // running-max block_limit_class_ (cat_* only approximates this)
+  bool want_split = false;         // the collator's final want_split decision for this block
+  int peak_block_limit_class = 0;  // running-max block_limit_class_ (cat_* only approximates this)
   double total_time = 0.0;
   std::string time_stats;
 


### PR DESCRIPTION
## What

Adds a machine-readable **cause of overload / split** to the per-block session-stats JSON, so an operator can attribute shard splits directly from their session-stats archive with **no recompute**.

Today the block-limits record stores `cat_gas`/`cat_bytes`/`cat_lt_delta`/`cat_collated_data_bytes`, `new_out_msg_queue_size`, and the collation-timing fields, so the cause is *reconstructable* but not stored explicitly. This makes it explicit.

## New fields on `validatorStats.blockLimitsStatus`

- `overload_reason:int` — why this block set its overload bit:
  - `0` = none / normal
  - `1` = **load** (a block-limit axis — gas/bytes/lt/collated — hit `cl_soft`; ConfigParam 23 limits for basechain)
  - `2` = **out_msg_queue force-split** (`out_msg_queue_size >= FORCE_SPLIT_QUEUE_SIZE` = 4096)
  - `3` = **long_collation** (collation took too long — the `long_collation_overload` predicate)
  - `4` = **dispatch_queue** (`dispatch_queue_total_limit_reached`)
- `want_split:Bool` — the collator's final `want_split` decision for the block (the weighted-history outcome; unambiguous and cheap).
- `peak_block_limit_class:int` — the running-max `block_limit_class_` (the `cat_*` fields only approximate this at finalize).

## Where

- `tl/generate/scheme/ton_api.tl` — three fields appended to the `validatorStats.blockLimitsStatus` constructor (natural home next to `cat_*`). The auto-generated TL sources (`tl/generate/auto/tl/ton_api.*`, `ton_api_json.*`) are **not** checked into this tree — they're produced at build time by `tl-parser` + `generate_common`, so no hand-edited generated files are included; CI regenerates them.
- `validator/interfaces/validator-manager.h` — `overload_reason` / `want_split` / `peak_block_limit_class` members on `CollationStats` (defaulted) and emitted into the `blockLimitsStatus` `create_tl_object(...)` call.
- `validator/impl/collator.cpp` — `Collator::check_block_overload()` sets `stats_.overload_reason` inside the exact branches that set the overload-history bit, in the same priority order as the existing log-message construction (load > long_collation > dispatch; force-split handled separately). `stats_.want_split` and `stats_.peak_block_limit_class` are recorded at the end of the method.

## Safety

Session-stats is **local JSON logging** — not consensus/ADNL-critical. This change is purely observational and additive: no consensus-affecting serialization, block content, or the `want_split` decision logic itself is changed.

## Build / TL-regen status

- The TL scheme was verified to parse cleanly with `tl-parser` (regenerating `ton_api.tlo` with exit 0), confirming the new constructor is well-formed. The auto-generated C++/JSON TL sources regenerate from the scheme at build time (they are gitignored in this tree), so no generated files needed hand-editing.
- Field/argument parity checked by hand: the constructor now has 17 fields and the `create_tl_object<validatorStats_blockLimitsStatus>(...)` call passes 17 matching arguments (types `int` / `bool` / `int` for the three new ones).
- A full `cmake` build was not run in the authoring environment (this tree force-builds a custom OpenSSL from a submodule at configure time, which is impractical here). CI should exercise the full compile + TL regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)