### PR TITLE
Fix C++20 coroutine compilation and strictness issues

### DIFF
--- a/adnl/adnl-local-id.cpp
+++ b/adnl/adnl-local-id.cpp
@@ -50,7 +50,7 @@ void AdnlLocalId::receive(td::IPAddress addr, td::BufferSlice data) {
     if (R.is_error()) {
       VLOG(adnl, INFO) << self << ": dropping IN message from " << addr << ": " << R.move_as_error();
     }
-    co_return {};
+    co_return td::Unit{};
   }(this, std::move(addr), std::move(data))
                                                                          .start()
                                                                          .detach();
@@ -92,7 +92,7 @@ td::actor::Task<> AdnlLocalId::receive_coro(td::IPAddress addr, td::BufferSlice 
 
   td::actor::send_closure(peer_table_, &AdnlPeerTable::receive_decrypted_packet, short_id_, std::move(packet),
                           data_size);
-  co_return {};
+  co_return td::Unit{};
 }
 
 void AdnlLocalId::deliver(AdnlNodeIdShort src, td::BufferSlice data) {

--- a/overlay/overlay.cpp
+++ b/overlay/overlay.cpp
@@ -378,6 +378,20 @@ void OverlayImpl::get_plumtree_stats_records(
   promise.set_value(broadcasts_plumtree_.collect_stats_records());
 }
 
+static td::actor::Task<> await_broadcast_task(td::actor::Task<> task, int id, adnl::AdnlNodeIdShort src) {
+  auto status = (co_await std::move(task).wrap()).move_as_status();
+  LOG_IF(WARNING, status.is_error() && status.code() != ErrorCode::notready)
+      << "Failed to process broadcast (type=" << id << ") from " << src << ": " << status;
+  co_return td::Unit{};
+}
+
+template <class T>
+void process_broadcast_helper(OverlayImpl *self, adnl::AdnlNodeIdShort src, tl_object_ptr<T> obj) {
+  auto id = obj->get_id();
+  auto task = self->process_broadcast(src, std::move(obj));
+  await_broadcast_task(std::move(task), id, src).start().detach();
+}
+
 void OverlayImpl::receive_message(adnl::AdnlNodeIdShort src, tl_object_ptr<ton_api::overlay_messageExtra> extra,
                                   td::BufferSlice data) {
   if (!check_src_peer(src, extra ? extra->certificate_.get() : nullptr)) {
@@ -393,15 +407,8 @@ void OverlayImpl::receive_message(adnl::AdnlNodeIdShort src, tl_object_ptr<ton_a
   }
   auto Q = X.move_as_ok();
   ton_api::downcast_call(*Q, [self = this, &Q, &src](auto &object) {
-    [](OverlayImpl *self, adnl::AdnlNodeIdShort src, auto obj) -> td::actor::Task<> {
-      auto id = obj->get_id();
-      auto status = (co_await self->process_broadcast(src, std::move(obj)).wrap()).move_as_status();
-      LOG_IF(WARNING, status.is_error() && status.code() != ErrorCode::notready)
-          << "Failed to process broadcast (type=" << id << ") from " << src << ": " << status;
-      co_return {};
-    }(self, src, move_tl_object_as<std::remove_reference_t<decltype(object)>>(Q))
-                                                                      .start()
-                                                                      .detach();
+    using ObjectType = std::remove_reference_t<decltype(object)>;
+    process_broadcast_helper(self, src, move_tl_object_as<ObjectType>(Q));
   });
 }
 

--- a/overlay/overlay.hpp
+++ b/overlay/overlay.hpp
@@ -206,6 +206,9 @@ struct AuthorizedKeyLimiter {
 
 class OverlayImpl : public Overlay {
  public:
+  template <class T>
+  friend void process_broadcast_helper(OverlayImpl *self, adnl::AdnlNodeIdShort src, tl_object_ptr<T> obj);
+
   OverlayImpl(td::actor::ActorId<keyring::Keyring> keyring, td::actor::ActorId<adnl::Adnl> adnl,
               td::actor::ActorId<OverlayManager> manager, td::actor::ActorId<dht::Dht> dht_node,
               adnl::AdnlNodeIdShort local_id, OverlayIdFull overlay_id, OverlayType overlay_type,

--- a/tdactor/td/actor/coro_task.h
+++ b/tdactor/td/actor/coro_task.h
@@ -142,7 +142,8 @@ struct promise_value : promise_common {
   }
 
   struct ExternalResult {
-    explicit ExternalResult() = default;
+    struct Tag {};
+    explicit ExternalResult(Tag) {}
   };
   void return_value(ExternalResult&&) noexcept {
   }
@@ -514,7 +515,7 @@ struct [[nodiscard]] StartedTask {
   };
 
   static std::pair<StartedTask, ExternalPromise> make_bridge() {
-    auto task = []() -> Task<T> { co_return typename promise_type::ExternalResult{}; }();
+    auto task = []() -> Task<T> { co_return typename promise_type::ExternalResult{typename promise_type::ExternalResult::Tag{}}; }();
     task.set_executor(Executor::on_scheduler());
     auto promise = ExternalPromise(&task.h.promise());
     auto started_task = std::move(task).start_external();

--- a/validator/validator.h
+++ b/validator/validator.h
@@ -428,7 +428,7 @@ class ValidatorManagerInterface : public td::actor::Actor {
   }
 
   virtual td::actor::Task<> collect(metrics::Context ctx) {
-    co_return {};
+    co_return td::Unit{};
   }
 };
 


### PR DESCRIPTION
- Add tag constructor to promise_value::ExternalResult to fix instantiation without aggregate construction.
- Replace empty co_return statements returning Task<Unit> with explicit co_return td::Unit{} to satisfy stricter compiler check constraints.
- Refactor inline coroutine lambda inside OverlayImpl::receive_message to a helper function process_broadcast_helper to simplify compilation context.