### PR TITLE
fix(pool): enforce amount validation in recover_stake_ok and state guard in recover_stake

### DIFF
--- a/crypto/func/auto-tests/legacy_tests/nominator-pool/pool.fc
+++ b/crypto/func/auto-tests/legacy_tests/nominator-pool/pool.fc
@@ -470,29 +470,31 @@ cell distribute_share(int reward, cell nominators) inline_ref {
             accept_message();
 
             if (op == op::recover_stake_ok()) {
-                state = 0;
+                if (msg_value >= stake_amount_sent) {
+                    state = 0;
 
-                int reward = msg_value - stake_amount_sent;
-                int nominators_reward = 0;
+                    int reward = msg_value - stake_amount_sent;
+                    int nominators_reward = 0;
 
-                if (reward <= 0) {
-                    validator_amount += reward;
-                    if (validator_amount < 0) {
-                        ;; even this should never happen
-                        nominators_reward = validator_amount;
-                        validator_amount = 0;
+                    if (reward <= 0) {
+                        validator_amount += reward;
+                        if (validator_amount < 0) {
+                            ;; even this should never happen
+                            nominators_reward = validator_amount;
+                            validator_amount = 0;
+                        }
+                    } else {
+                        int validator_reward = (reward * validator_reward_share) / 10000;
+                        if (validator_reward > reward) { ;; Theoretical invalid case if validator_reward_share > 10000
+                            validator_reward = reward;
+                        }
+                        validator_amount += validator_reward;
+                        nominators_reward = reward - validator_reward;
                     }
-                } else {
-                    int validator_reward = (reward * validator_reward_share) / 10000;
-                    if (validator_reward > reward) { ;; Theoretical invalid case if validator_reward_share > 10000
-                        validator_reward = reward;
-                    }
-                    validator_amount += validator_reward;
-                    nominators_reward = reward - validator_reward;
+
+                    nominators = distribute_share(nominators_reward, nominators); ;; call even if there was no reward to process deposit requests
+                    stake_amount_sent = 0;
                 }
-
-                nominators = distribute_share(nominators_reward, nominators); ;; call even if there was no reward to process deposit requests
-                stake_amount_sent = 0;
             }
 
             if (state == 1) {
@@ -564,6 +566,7 @@ cell distribute_share(int reward, cell nominators) inline_ref {
             }
 
             if (op == op::recover_stake()) { ;; send recover_stake to elector (anyone can send)
+                throw_unless(77, state == 0);
 
                 ;; We need to take all credits from the elector at once,
                 ;; because if we do not take all at once, then it will be processed as a fine by pool.


### PR DESCRIPTION
## Overview

This PR fixes a state tracking issue in `pool.fc` where the contract's internal accounting can desynchronize from the Elector's state during stake recovery.

> **Note for Core Maintainers / Triage Team:** A full technical vulnerability analysis, state-transition proofs, and detailed execution trace have been submitted via the official TON Bug Bounty Bot (`@ton_bugs_bot`). Please reference that submission for the complete report.

## Problem Statement

In `pool.fc`, `op::recover_stake_ok()` unconditionally resets contract state (`state = 0`, `stake_amount_sent = 0`) upon receiving any `op::recover_stake_ok` message from the Elector. 

However, the Elector maintains `credits` (which include surplus stake returns and complaint rewards) separately from `past_elections` (frozen stake). If `recover_stake` is processed when the Elector holds a pre-unfreeze credit balance while principal remains frozen in `past_elections`, the pool receives a `recover_stake_ok` message carrying only the partial credit. 

Because `pool.fc` currently lacks an amount check on `msg_value`, processing this partial response prematurely zeros `stake_amount_sent` and resets `state = 0`. The subsequent legitimate return of the main stake is then misclassified as validation yield rather than principal return, corrupting reward distribution logic.

## Summary of Changes

1. **`op::recover_stake_ok` Amount Verification:**
   - Updated the handler to check `if (msg_value >= stake_amount_sent)` before clearing `stake_amount_sent` and resetting `state = 0`.
   - If `msg_value < stake_amount_sent`, the incoming coins (partial credit) are accepted into pool balance, but `state` and `stake_amount_sent` remain active until the full stake is recovered.

2. **`op::recover_stake` State Guard:**
   - Added `throw_unless(77, state == 0)` to `op::recover_stake` to ensure recovery requests can only be forwarded to the Elector when the pool is in an idle state.

## Impact & Severity

- **State Integrity:** Ensures `stake_amount_sent` accurately tracks outstanding frozen principal at all times.
- **Accounting Accuracy:** Prevents misclassifying returned principal as yield under non-standard recovery sequences.