### PR TITLE
fix(elector): prevent division-by-zero deadlock in unfreeze_with_bonuses when tot_stakes is zero

### DIFF
--- a/crypto/smartcont/elector-code.fc
+++ b/crypto/smartcont/elector-code.fc
@@ -307,7 +307,7 @@ _ ~credit_to(credits, addr, amount) inline_ref {
       if (banned) {
         recovered += stake;
       } else {
-        var bonus = muldiv(tot_bonuses, stake, tot_stakes);
+        var bonus = tot_stakes ? muldiv(tot_bonuses, stake, tot_stakes) : 0;
         returned_bonuses += bonus;
         credits~credit_to(addr, stake + bonus);
       }


### PR DESCRIPTION
## Overview

This PR fixes a division-by-zero deadlock vulnerability in the Elector smart contract (`crypto/smartcont/elector-code.fc`).

> **Note for Core Maintainers / Triage Team:** A full technical vulnerability analysis, state-transition proofs, and execution trace have been submitted via the official TON Bug Bounty Bot (`@ton_bugs_bot`). Please reference that submission for full details.

## Problem Statement

In `unfreeze_with_bonuses`:
```func
var bonus = muldiv(tot_bonuses, stake, tot_stakes);
```
If all validators in a past election cycle are slashed (e.g., due to double-signing, key compromise, or past epoch issues), `tot_stakes` for that cycle becomes `0`.

When `unfreeze_all` attempts to process this past election, the `muldiv` instruction executes `tot_bonuses / 0`, triggering TVM Exception Code 4 (Integer division-by-zero) and reverting the transaction.

Because the transaction reverts, the past election record is never cleared from the `past_elections` queue. This permanently deadlocks the unfreezing lifecycle for all subsequent elections, trapping all future validator stakes and rewards.

## Summary of Changes

Updated the calculation to verify `tot_stakes > 0` before executing `muldiv`:
```func
var bonus = tot_stakes ? muldiv(tot_bonuses, stake, tot_stakes) : 0;
```

## Impact

Prevents permanent queue deadlock and fund locking during validator set rotation when a past epoch has zero remaining total stake.