### PR TITLE
fix(consensus): validate slots_per_leader_window >= 1 in consensus config to prevent SIGFPE crash

### DIFF
--- a/crypto/block/block.cpp
+++ b/crypto/block/block.cpp
@@ -1871,9 +1871,37 @@ bool check_one_config_param(Ref<vm::CellSlice> cs_ref, td::ConstBitPtr key, td::
     return true;
   }
   unsigned cfg_idx = static_cast<unsigned>(idx);
-  bool ok = block::gen::ConfigParam{cfg_idx}.validate_ref(1024, std::move(cell));
+  bool ok = block::gen::ConfigParam{cfg_idx}.validate_ref(1024, cell);
   if (!ok) {
     LOG(ERROR) << "configuration parameter #" << idx << " is invalid";
+    return false;
+  }
+  if (idx == 30) {
+    block::gen::NewConsensusConfigAll::Record rec;
+    if (block::gen::NewConsensusConfigAll{}.cell_unpack(std::move(cell), rec)) {
+      auto check_consensus_config = [](Ref<vm::CellSlice> config_cs) -> bool {
+        if (config_cs.is_null()) {
+          return true;
+        }
+        auto cs = config_cs->prefetch_ref();
+        if (cs.is_null()) {
+          return true;
+        }
+        block::gen::NewConsensusConfig::Record_simplex_config v1;
+        if (block::gen::NewConsensusConfig{}.cell_unpack(cs, v1)) {
+          return v1.slots_per_leader_window >= 1;
+        }
+        block::gen::NewConsensusConfig::Record_simplex_config_v2 v2;
+        if (block::gen::NewConsensusConfig{}.cell_unpack(cs, v2)) {
+          return v2.slots_per_leader_window >= 1;
+        }
+        return false;
+      };
+      if (!check_consensus_config(rec.mc) || !check_consensus_config(rec.shard)) {
+        LOG(ERROR) << "configuration parameter #30 has invalid slots_per_leader_window (< 1)";
+        return false;
+      }
+    }
   }
   return ok;
 }

--- a/crypto/block/mc-config.cpp
+++ b/crypto/block/mc-config.cpp
@@ -374,6 +374,10 @@ ton::NewConsensusConfig Config::get_new_consensus_config(ton::WorkchainId wc) co
   }
 
   if (gen::NewConsensusConfig::Record_simplex_config_v2 v2; gen::unpack_cell(c2, v2)) {
+    if (v2.slots_per_leader_window == 0) {
+      LOG(ERROR) << "Invalid slots_per_leader_window = 0 in config param 30";
+      return config;
+    }
     config.protocol_version = v2.protocol_version;
     config.slots_per_leader_window = v2.slots_per_leader_window;
 

--- a/test/validator/consensus/test-consensus.cpp
+++ b/test/validator/consensus/test-consensus.cpp
@@ -955,6 +955,9 @@ int main(int argc, char *argv[]) {
   });
   p.add_checked_option('\0', "slots-per-leader-window", "slots per leader window (default: 4)", [&](td::Slice arg) {
     TRY_RESULT_ASSIGN(SLOTS_PER_LEADER_WINDOW, td::to_integer_safe<td::uint32>(arg));
+    if (SLOTS_PER_LEADER_WINDOW == 0) {
+      return td::Status::Error("slots-per-leader-window must be at least 1");
+    }
     return td::Status::OK();
   });
   p.add_checked_option('\0', "net-ping", "network ping (range, default: 0.05:0.1)", [&](td::Slice arg) {


### PR DESCRIPTION
## Overview

This PR validates that `slots_per_leader_window >= 1` in consensus configuration parameter #30 to prevent division-by-zero crashes (`SIGFPE`) in the Simplex consensus engine.

> **Note for Core Maintainers / Triage Team:** A full technical vulnerability analysis, state-transition proofs, crash logs, and execution traces have been submitted via the official TON Bug Bounty Bot (`@ton_bugs_bot`). Please reference that submission for full details.

## Problem Statement

In `block.tlb`:
```tlb
simplex_config#01 slots_per_leader_window:(## 32) { slots_per_leader_window >= 1 }
```

However, node-side block checks rely on generated structural validation (`validate_ref`) that ignores semantic constraints in curly braces `{ ... }`. In addition, configuration parameter #30 accepts cell updates without validating inner deserialized values.

If an on-chain configuration parameter #30 sets `slots_per_leader_window = 0`:
1. Node checking accepts the proposal.
2. The config is applied and saved to disk.
3. `PoolImpl::advance_present` in `validator/consensus/simplex/pool.cpp` executes `position % slots_per_leader_window_` (0), resulting in a `SIGFPE` (Integer division-by-zero) crash.
4. Because the invalid config is persisted in the state root cell on disk, node restarts reload the state and crash again, creating a restart crash loop.

## Summary of Changes

1. **`crypto/block/block.cpp`:** Updated `check_one_config_param` to unpack parameter #30 and verify `slots_per_leader_window >= 1` for both Simplex v1 and v2 records during block checking.
2. **`crypto/block/mc-config.cpp`:** Added guard in `Config::get_new_consensus_config` to log an error and return default config if `slots_per_leader_window == 0`.
3. **`test/validator/consensus/test-consensus.cpp`:** Added command line option validation requiring `slots-per-leader-window >= 1`.

## Impact

Prevents consensus node `SIGFPE` crash and persistent restart loops triggered by invalid consensus parameter #30 configuration values.