### PR TITLE
feat(tonlib): implement `blocks.getBlock` request

### DIFF
--- a/tl/generate/scheme/tonlib_api.tl
+++ b/tl/generate/scheme/tonlib_api.tl
@@ -226,6 +226,7 @@ blocks.shortTxId mode:# account:mode.0?bytes lt:mode.1?int64 hash:mode.2?bytes =
 blocks.transactions id:ton.blockIdExt req_count:int32 incomplete:Bool transactions:vector<blocks.shortTxId> = blocks.Transactions;
 blocks.transactionsExt id:ton.blockIdExt req_count:int32 incomplete:Bool transactions:vector<raw.transaction> = blocks.TransactionsExt;
 blocks.header id:ton.blockIdExt global_id:int32 version:int32 flags:# after_merge:Bool after_split:Bool before_split:Bool want_merge:Bool want_split:Bool validator_list_hash_short:int32 catchain_seqno:int32 min_ref_mc_seqno:int32 is_key_block:Bool prev_key_block_seqno:int32 start_lt:int64 end_lt:int64 gen_utime:int53 vert_seqno:# prev_blocks:vector<ton.blockIdExt> = blocks.Header;
+blocks.blockData id:ton.blockIdExt data:bytes = blocks.BlockData;
 //blocks.shortData header:blocks.Header transactions:blocks.Header = blocks.BlockData;
 
 blocks.signature node_id_short:int256 signature:bytes = blocks.Signature;
@@ -340,6 +341,7 @@ blocks.lookupBlock mode:int32 id:ton.blockId lt:int64 utime:int32 = ton.BlockIdE
 blocks.getTransactions id:ton.blockIdExt mode:# count:# after:blocks.accountTransactionId = blocks.Transactions;
 blocks.getTransactionsExt id:ton.blockIdExt mode:# count:# after:blocks.accountTransactionId = blocks.TransactionsExt;
 blocks.getBlockHeader id:ton.blockIdExt = blocks.Header;
+blocks.getBlock id:ton.blockIdExt = blocks.BlockData;
 blocks.getMasterchainBlockSignatures seqno:int32 = blocks.BlockSignatures;
 blocks.getShardBlockProof id:ton.blockIdExt mode:# from:mode.0?ton.blockIdExt = blocks.ShardBlockProof;
 blocks.getOutMsgQueueSizes mode:# wc:mode.0?int32 shard:mode.0?int64 = blocks.OutMsgQueueSizes;

--- a/tonlib/tonlib/TonlibClient.cpp
+++ b/tonlib/tonlib/TonlibClient.cpp
@@ -6737,6 +6737,33 @@ td::Status TonlibClient::do_request(const tonlib_api::blocks_getBlockHeader& req
   return td::Status::OK();
 }
 
+td::Status TonlibClient::do_request(const tonlib_api::blocks_getBlock& request,
+                                    td::Promise<object_ptr<tonlib_api::blocks_blockData>>&& promise) {
+  if (!request.id_) {
+    return TonlibError::EmptyField("id");
+  }
+
+  TRY_RESULT(lite_block, to_lite_api(*request.id_));
+  TRY_RESULT(req_block_id, to_block_id(*request.id_));
+
+  client_.send_query(ton::lite_api::liteServer_getBlock(std::move(lite_block)),
+                     promise.wrap([req_block_id](lite_api_ptr<ton::lite_api::liteServer_blockData>&& block_data)
+                                      -> td::Result<tonlib_api::object_ptr<tonlib_api::blocks_blockData>> {
+                       const auto block_id = ton::create_block_id(block_data->id_);
+                       if (req_block_id != block_id) {
+                         return td::Status::Error("Liteserver responded with wrong block");
+                       }
+
+                       tonlib_api::blocks_blockData r;
+                       r.id_ = to_tonlib_api(*block_data->id_);
+                       r.data_ = block_data->data_.as_slice().str();
+
+                       return tonlib_api::make_object<tonlib_api::blocks_blockData>(std::move(r));
+                     }));
+
+  return td::Status::OK();
+}
+
 td::Status TonlibClient::do_request(const tonlib_api::blocks_getMasterchainBlockSignatures& request,
                                     td::Promise<object_ptr<tonlib_api::blocks_BlockSignatures>>&& promise) {
   auto actor_id = actor_id_++;

--- a/tonlib/tonlib/TonlibClient.h
+++ b/tonlib/tonlib/TonlibClient.h
@@ -403,6 +403,8 @@ class TonlibClient : public td::actor::Actor {
                         td::Promise<object_ptr<tonlib_api::blocks_transactionsExt>>&& promise);
   td::Status do_request(const tonlib_api::blocks_getBlockHeader& request,
                         td::Promise<object_ptr<tonlib_api::blocks_header>>&& promise);
+  td::Status do_request(const tonlib_api::blocks_getBlock& request,
+                        td::Promise<object_ptr<tonlib_api::blocks_blockData>>&& promise);
   td::Status do_request(const tonlib_api::blocks_getMasterchainBlockSignatures& request,
                         td::Promise<object_ptr<tonlib_api::blocks_BlockSignatures>>&& promise);
   td::Status do_request(const tonlib_api::blocks_getShardBlockProof& request,


### PR DESCRIPTION
Added a new method so that it can be used in `ton-http-api-cpp` (a.k.a. `API V2`). 

PR in `ton-http-api-cpp`, where it will be used https://github.com/toncenter/ton-http-api-cpp/pull/20