### PR TITLE
More readable printing of tlb dicts

### DIFF
--- a/crypto/tl/tlbc-gen-cpp.cpp
+++ b/crypto/tl/tlbc-gen-cpp.cpp
@@ -2341,6 +2341,29 @@ void CppTypeCode::generate_print_cons_method(std::ostream& os, std::string nl, i
 
 void CppTypeCode::generate_print_method(std::ostream& os, int options) {
   bool ret_ext = options & 2;
+  if (!ret_ext) {
+    std::string name = type.get_name();
+    if (name == "HashmapE") {
+      os << "\nbool " << cpp_type_class_name << "::print_skip(PrettyPrinter& pp, vm::CellSlice& cs) const {\n"
+         << "  return tlb::print_hashmap(pp, cs, m_, *this, X_, false);\n}\n";
+      return;
+    }
+    if (name == "Hashmap") {
+      os << "\nbool " << cpp_type_class_name << "::print_skip(PrettyPrinter& pp, vm::CellSlice& cs) const {\n"
+         << "  return tlb::print_hashmap(pp, cs, m_, *this, X_, true);\n}\n";
+      return;
+    }
+    if (name == "HashmapAugE") {
+      os << "\nbool " << cpp_type_class_name << "::print_skip(PrettyPrinter& pp, vm::CellSlice& cs) const {\n"
+         << "  return tlb::print_hashmap_aug(pp, cs, m_, *this, X_, Y_, false);\n}\n";
+      return;
+    }
+    if (name == "HashmapAug") {
+      os << "\nbool " << cpp_type_class_name << "::print_skip(PrettyPrinter& pp, vm::CellSlice& cs) const {\n"
+         << "  return tlb::print_hashmap_aug(pp, cs, m_, *this, X_, Y_, true);\n}\n";
+      return;
+    }
+  }
   os << "\nbool " << cpp_type_class_name << "::print_skip(PrettyPrinter& pp, vm::CellSlice& cs";
   if (ret_ext) {
     os << skip_extra_args;

--- a/crypto/tl/tlblib.cpp
+++ b/crypto/tl/tlblib.cpp
@@ -280,7 +280,7 @@ bool print_hashmap(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const TLB& 
       }
       pp.mode_nl();
       pp.os << "x" << key.to_hex(key_len) << ":";
-      return value_type.print_skip(pp, value.write()) || pp.fail("invalid hashmap value");
+      return (value_type.print_skip(pp, value.write()) && value->empty_ext()) || pp.fail("invalid hashmap value");
     }) && pp.close();
   } catch (vm::VmError&) {
     return pp.fail("invalid Hashmap");
@@ -312,7 +312,7 @@ bool print_hashmap_aug(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const T
       }
       pp.mode_nl();
       pp.os << "x" << key.to_hex(key_len) << ":";
-      return value_type.print_skip(pp, value.write()) || pp.fail("invalid hashmapAug value");
+      return (value_type.print_skip(pp, value.write()) && value->empty_ext()) || pp.fail("invalid hashmapAug value");
     }) && pp.close();
   } catch (vm::VmError&) {
     return pp.fail("invalid HashmapAug");

--- a/crypto/tl/tlblib.cpp
+++ b/crypto/tl/tlblib.cpp
@@ -275,6 +275,9 @@ bool print_hashmap(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const TLB& 
     }
     pp.open(non_empty ? "Hashmap" : "HashmapE");
     return dict.check_for_each([&](Ref<vm::CellSlice> value, td::ConstBitPtr key, int key_len) {
+      if (!pp.register_recursive_call()) {
+        return pp.fail("too many recursive calls while printing a TL-B value");
+      }
       pp.mode_nl();
       pp.os << "x" << key.to_hex(key_len) << ":";
       return value_type.print_skip(pp, value.write()) || pp.fail("invalid hashmap value");
@@ -304,6 +307,9 @@ bool print_hashmap_aug(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const T
     pp.open(non_empty ? "HashmapAug" : "HashmapAugE");
     return dict->check_for_each_extra([&](Ref<vm::CellSlice> value, Ref<vm::CellSlice>, td::ConstBitPtr key,
                                           int key_len) {
+      if (!pp.register_recursive_call()) {
+        return pp.fail("too many recursive calls while printing a TL-B value");
+      }
       pp.mode_nl();
       pp.os << "x" << key.to_hex(key_len) << ":";
       return value_type.print_skip(pp, value.write()) || pp.fail("invalid hashmapAug value");

--- a/crypto/tl/tlblib.cpp
+++ b/crypto/tl/tlblib.cpp
@@ -19,6 +19,8 @@
 #include <set>
 #include <tl/tlblib.hpp>
 
+#include "vm/dict.h"
+
 namespace tlb {
 
 const False t_False;
@@ -224,6 +226,91 @@ std::string TLB::as_string_ref(Ref<vm::Cell> cell_ref, int indent) const {
   std::ostringstream os;
   print_ref(os, std::move(cell_ref), indent);
   return os.str();
+}
+
+namespace {
+
+struct PrintAug : vm::dict::AugmentationData {
+  const TLB& aug_type;
+  explicit PrintAug(const TLB& aug_type) : aug_type(aug_type) {
+  }
+  bool skip_extra(vm::CellSlice& cs) const override {
+    return aug_type.skip(cs);
+  }
+  bool eval_leaf(vm::CellBuilder&, vm::CellSlice&) const override {
+    return false;
+  }
+  bool eval_fork(vm::CellBuilder&, vm::CellSlice&, vm::CellSlice&) const override {
+    return false;
+  }
+  bool eval_empty(vm::CellBuilder&) const override {
+    return false;
+  }
+  bool check_empty(vm::CellSlice& cs) const override {
+    return true;
+  }
+  bool check_fork(vm::CellSlice& cs, vm::CellSlice& left_cs, vm::CellSlice& right_cs) const override {
+    return true;
+  }
+  bool check_leaf(vm::CellSlice& cs, vm::CellSlice& val_cs) const override {
+    return true;
+  }
+};
+
+}  // namespace
+
+bool print_hashmap(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const TLB& dict_type, const TLB& value_type,
+                   bool non_empty) {
+  try {
+    vm::CellSlice dict_cs{cs};
+    if (!dict_type.skip(cs)) {
+      return pp.fail("invalid Hashmap");
+    }
+    dict_cs.cut_tail(cs);
+    vm::Dictionary dict{(int)n};
+    if (non_empty) {
+      dict = vm::Dictionary{vm::DictNonEmpty{}, dict_cs, (int)n, false};
+    } else {
+      dict = vm::Dictionary{dict_cs, (int)n, false};
+    }
+    pp.open(non_empty ? "Hashmap" : "HashmapE");
+    return dict.check_for_each([&](Ref<vm::CellSlice> value, td::ConstBitPtr key, int key_len) {
+      pp.mode_nl();
+      pp.os << "x" << key.to_hex(key_len) << ":";
+      return value_type.print_skip(pp, value.write()) || pp.fail("invalid hashmap value");
+    }) && pp.close();
+  } catch (vm::VmError&) {
+    return pp.fail("invalid Hashmap");
+  }
+}
+
+bool print_hashmap_aug(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const TLB& dict_type, const TLB& value_type,
+                       const TLB& aug_type, bool non_empty) {
+  try {
+    vm::CellSlice dict_cs{cs};
+    if (!dict_type.skip(cs)) {
+      return pp.fail("invalid HashmapAug");
+    }
+    dict_cs.cut_tail(cs);
+    PrintAug aug{aug_type};
+    std::unique_ptr<vm::AugmentedDictionary> dict;
+    if (non_empty) {
+      dict = std::make_unique<vm::AugmentedDictionary>(vm::DictNonEmpty{}, Ref<vm::CellSlice>{true, std::move(dict_cs)},
+                                                       (int)n, aug, false);
+    } else {
+      dict =
+          std::make_unique<vm::AugmentedDictionary>(Ref<vm::CellSlice>{true, std::move(dict_cs)}, (int)n, aug, false);
+    }
+    pp.open(non_empty ? "HashmapAug" : "HashmapAugE");
+    return dict->check_for_each_extra([&](Ref<vm::CellSlice> value, Ref<vm::CellSlice>, td::ConstBitPtr key,
+                                          int key_len) {
+      pp.mode_nl();
+      pp.os << "x" << key.to_hex(key_len) << ":";
+      return value_type.print_skip(pp, value.write()) || pp.fail("invalid hashmapAug value");
+    }) && pp.close();
+  } catch (vm::VmError&) {
+    return pp.fail("invalid HashmapAug");
+  }
 }
 
 PrettyPrinter::~PrettyPrinter() {

--- a/crypto/tl/tlblib.hpp
+++ b/crypto/tl/tlblib.hpp
@@ -616,6 +616,11 @@ struct PrettyPrinter {
   }
 };
 
+bool print_hashmap(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const TLB& dict_type, const TLB& value_type,
+                   bool non_empty);
+bool print_hashmap_aug(PrettyPrinter& pp, vm::CellSlice& cs, unsigned n, const TLB& dict_type, const TLB& value_type,
+                       const TLB& aug_type, bool non_empty);
+
 }  // namespace tlb
 
 namespace tlb {


### PR DESCRIPTION
Better printing TLB Hashmap and HashmapAug. This affects lite-client, blockchain-explorer and logs.

Before:
```
ConfigParam(31) = (
  fundamental_smc_addr:(hme_root
    root:(hm_edge
      label:(hml_short
        len:unary_zero s:x)
      node:(hmn_fork
        left:(hm_edge
          label:(hml_short
            len:unary_zero s:x)
          node:(hmn_fork
            left:(hm_edge
              label:(hml_short
                len:unary_zero s:x)
              node:(hmn_fork
                left:(hm_edge
                  label:(hml_same v:0 n:253)
                  node:(hmn_leaf
                    value:true))
                right:(hm_edge
                  label:(hml_long n:253 s:x999999999999999999999999999999999999999999999999999999999999999C_)
                  node:(hmn_leaf
                    value:true))))
...
```

After:
```
ConfigParam(31) = (
  fundamental_smc_addr:(HashmapE
    x0000000000000000000000000000000000000000000000000000000000000000:true
    x3333333333333333333333333333333333333333333333333333333333333333:true
    x4D5C0210B35DADDAA219FAC459DBA0FDEFB1FAE4E97A0D0797739FE050D694CA:true
    x9234809B5B02186E833D082B8A3DBB8225B230BA74A9C06EF24CF334C7A01A34:true
    xA8CE6C36AA8BA536B2A5A833098A6C18F9AE3523DCB443F0AC38717DADD8C411:true
    xB74DD9593F9BD8EAA2C514211258A0EA38C71252EBF876362514BC7742C8DFAD:true
    xC50F890366C81F5C4690C683D894C2940A767FFF47DA9ABB0A4A3C125D4996BF:true
    xDD24C4A1F2B88F8B7053513B5CC6C5A31BC44B2A72DCB4D8C0338AF0F0D37EC5:true
    xEAD7DA389BDE317C5FB285807CE507BAAD31C35FE5534B3C418785E901F64C68:true))
```