### PR TITLE
simplex: speculatively validate children before parent certification

### DIFF
--- a/test/validator/consensus/CMakeLists.txt
+++ b/test/validator/consensus/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(test-consensus PRIVATE
 add_executable(test-consensus-metrics
     test-candidate-resolver-metrics.cpp
     test-consensus-metrics.cpp
+    test-speculative-validation.cpp
+    test-speculative-validator.cpp
 )
 target_link_libraries(test-consensus-metrics PRIVATE
     adnl

--- a/test/validator/consensus/test-speculative-validation.cpp
+++ b/test/validator/consensus/test-speculative-validation.cpp
@@ -333,6 +333,26 @@ TEST(SpeculativeValidation, VotesRespectParentIntervalAndCandidateTimestamp) {
   }
 }
 
+TEST(SpeculativeValidation, OrdinaryValidationWaitsForCandidateTimestamp) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    h.parent_time += 0.5;
+    h.parent_can_validate_child = false;
+    h.bus.publish<CandidateReceived>(h.candidate(0));
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.normal_calls[0], 1u);
+    EXPECT_EQ(h.votes(0), 0u);
+
+    scheduler.advance_time(std::chrono::milliseconds{200});
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(0), 0u);
+    scheduler.advance_time(std::chrono::milliseconds{310});
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(0), 1u);
+    EXPECT_EQ(h.speculative_calls[0], 0u);
+    co_return {};
+  });
+}
+
 TEST(SpeculativeValidation, OneChildAheadAndDuplicateCandidatesDoNotMultiplyWork) {
   run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
     co_await start_parent_and_child(h, scheduler);

--- a/test/validator/consensus/test-speculative-validation.cpp
+++ b/test/validator/consensus/test-speculative-validation.cpp
@@ -1,0 +1,534 @@
+/*
+ * Copyright (c) 2026, TON CORE TECHNOLOGIES CO. L.L.C
+ *
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#include <algorithm>
+#include <map>
+#include <set>
+
+#include "consensus/simplex/bus.h"
+#include "td/actor/TestScheduler.h"
+#include "td/utils/tests.h"
+#include "vm/cells/CellBuilder.h"
+
+namespace ton::validator::consensus::simplex::test {
+namespace {
+
+const ShardIdFull kShard{0, shardIdAll};
+
+CandidateId candidate_id(td::uint32 slot, bool conflicting = false) {
+  return {slot, conflicting ? td::Bits256::ones() : td::Bits256::zero()};
+}
+
+BlockIdExt block_id(td::uint32 seqno, bool conflicting = false) {
+  return {BlockId{kShard, seqno}, conflicting ? td::Bits256::ones() : td::Bits256::zero(), td::Bits256::zero()};
+}
+
+class FixtureBlock final : public BlockData {
+ public:
+  explicit FixtureBlock(BlockIdExt id) : id_(id) {
+  }
+  td::BufferSlice data() const override {
+    return {};
+  }
+  FileHash file_hash() const override {
+    return id_.file_hash;
+  }
+  BlockIdExt block_id() const override {
+    return id_;
+  }
+  td::Ref<vm::Cell> root_cell() const override {
+    return vm::CellBuilder{}.finalize_novm();
+  }
+
+ private:
+  BlockIdExt id_;
+};
+
+class RemoteCollator final : public CollatorSchedule {
+ public:
+  PeerValidatorId expected_collator_for(td::uint32) const override {
+    return PeerValidatorId{1};
+  }
+};
+
+struct Harness {
+  td::actor::Runtime runtime;
+  BusHandle bus;
+  std::map<td::uint32, CandidateRef> candidates;
+  std::set<td::uint32> allowed_parents{0};
+  std::set<td::uint32> held_stores;
+  std::map<td::uint32, std::vector<td::Promise<WaitForParent::ReturnType>>> parent_waiters;
+  std::map<td::uint32, std::vector<td::Promise<td::Unit>>> store_waiters;
+  std::map<td::uint32, td::Promise<ValidateCandidateResult>> speculative_waiters;
+  std::map<td::uint32, size_t> normal_calls;
+  std::map<td::uint32, size_t> speculative_calls;
+  std::map<td::uint32, size_t> store_calls;
+  std::vector<CandidateId> notar_votes;
+  std::vector<CandidateId> final_votes;
+  std::set<td::uint32> skip_votes;
+  std::vector<std::shared_ptr<SpeculativeValidationRequest>> speculative_requests;
+  BlockIdExt min_mc{BlockId{masterchainId, shardIdAll, 10}, td::Bits256::zero(), td::Bits256::zero()};
+  double parent_time = 0;
+  bool parent_can_validate_child = true;
+  bool conflicting_state = false;
+  bool reject_parent = false;
+  bool parent_conflict = false;
+
+  CandidateRef candidate(td::uint32 slot, bool conflicting = false, bool empty = false) {
+    ParentId parent;
+    if (slot != 0) {
+      parent = candidate_id(slot - 1);
+    }
+    std::variant<BlockIdExt, BlockCandidate> block;
+    if (empty) {
+      block = block_id(100 + slot);
+    } else {
+      BlockCandidate full;
+      full.id = block_id(101 + slot, conflicting);
+      block = std::move(full);
+    }
+    auto result = td::make_ref<Candidate>(candidate_id(slot, conflicting), parent, PeerValidatorId{1}, std::move(block),
+                                          td::BufferSlice{});
+    if (!conflicting) {
+      candidates[slot] = result;
+    }
+    return result;
+  }
+
+  ChainStateRef state(ParentId parent) {
+    auto id = parent ? candidates.at(parent->slot)->block_id() : block_id(100);
+    if (conflicting_state && parent) {
+      id.root_hash = td::Bits256::ones();
+    }
+    return td::make_ref<ChainState>(
+        ChainState::NormalTip{td::make_ref<FixtureBlock>(id), vm::CellBuilder{}.finalize_novm()}, min_mc);
+  }
+
+  size_t votes(td::uint32 slot) const {
+    return std::count_if(notar_votes.begin(), notar_votes.end(), [slot](const auto& id) { return id.slot == slot; });
+  }
+
+  void allow_parent(td::uint32 child) {
+    allowed_parents.insert(child);
+    for (auto& waiter : parent_waiters[child]) {
+      waiter.set_value(std::nullopt);
+    }
+    parent_waiters.erase(child);
+  }
+
+  void store(td::uint32 slot) {
+    held_stores.erase(slot);
+    for (auto& waiter : store_waiters[slot]) {
+      waiter.set_value(td::Unit{});
+    }
+    store_waiters.erase(slot);
+  }
+
+  void accept_speculation(td::uint32 slot, double ok_from = 0) {
+    speculative_waiters.at(slot).set_value(CandidateAccept{.ok_from_utime = ok_from, .can_validate_child = true});
+    speculative_waiters.erase(slot);
+  }
+
+  void certify(td::uint32 slot) {
+    auto id = candidate_id(slot);
+    bus.publish<NotarizationObserved>(
+        id, td::make_ref<NotarCert>(NotarizeVote{id}, std::vector<NotarCert::VoteSignature>{}));
+    allow_parent(slot + 1);
+  }
+
+  void stop() {
+    bus.publish<StopRequested>();
+  }
+};
+
+Harness* active = nullptr;
+
+// Only the external dependencies are mocked: each scenario runs the production Consensus actor.
+class ControlledDependencies final : public td::actor::SpawnsWith<Bus>, public td::actor::ConnectsTo<Bus> {
+ public:
+  TON_RUNTIME_DEFINE_EVENT_HANDLER();
+
+  template <>
+  td::actor::Task<WaitForParent::ReturnType> process(BusHandle, std::shared_ptr<WaitForParent> request) {
+    auto slot = request->candidate->id.slot;
+    if (active->allowed_parents.contains(slot)) {
+      if (slot != 0 && active->parent_conflict) {
+        co_return td::make_ref<Misbehavior>();
+      }
+      co_return std::nullopt;
+    }
+    auto [task, promise] = td::actor::StartedTask<WaitForParent::ReturnType>::make_bridge();
+    active->parent_waiters[slot].push_back(std::move(promise));
+    co_return co_await std::move(task);
+  }
+
+  template <>
+  td::actor::Task<ResolveState::ReturnType> process(BusHandle, std::shared_ptr<ResolveState> request) {
+    co_return ResolveState::Result{active->state(request->id),
+                                   request->id ? std::optional{active->parent_time} : std::nullopt};
+  }
+
+  template <>
+  td::actor::Task<> process(BusHandle, std::shared_ptr<StoreCandidate> request) {
+    auto slot = request->candidate->id.slot;
+    ++active->store_calls[slot];
+    if (active->held_stores.contains(slot)) {
+      auto [task, promise] = td::actor::StartedTask<>::make_bridge();
+      active->store_waiters[slot].push_back(std::move(promise));
+      co_await std::move(task);
+    }
+    co_return {};
+  }
+
+  template <>
+  td::actor::Task<ValidateCandidateResult> process(BusHandle, std::shared_ptr<ValidationRequest> request) {
+    ++active->normal_calls[request->candidate->id.slot];
+    if (active->reject_parent && request->candidate->id.slot == 0) {
+      co_return CandidateReject{.reason = "invalid parent", .proof = {}};
+    }
+    co_return CandidateAccept{.ok_from_utime = active->parent_time,
+                              .can_validate_child = active->parent_can_validate_child};
+  }
+
+  template <>
+  td::actor::Task<ValidateCandidateResult> process(BusHandle, std::shared_ptr<SpeculativeValidationRequest> request) {
+    auto slot = request->candidate->id.slot;
+    ++active->speculative_calls[slot];
+    active->speculative_requests.push_back(request);
+    auto [task, promise] = td::actor::StartedTask<ValidateCandidateResult>::make_bridge();
+    EXPECT(!active->speculative_waiters.contains(slot));
+    active->speculative_waiters.emplace(slot, std::move(promise));
+    co_return co_await std::move(task);
+  }
+
+  template <>
+  td::actor::Task<> process(BusHandle, std::shared_ptr<BroadcastVote> request) {
+    if (auto vote = std::get_if<NotarizeVote>(&request->vote.vote)) {
+      active->notar_votes.push_back(vote->id);
+    } else if (auto vote = std::get_if<FinalizeVote>(&request->vote.vote)) {
+      active->final_votes.push_back(vote->id);
+    } else {
+      active->skip_votes.insert(std::get<SkipVote>(request->vote.vote).slot);
+    }
+    co_return {};
+  }
+
+  template <>
+  void handle(BusHandle, std::shared_ptr<const StopRequested>) {
+    stop();
+  }
+};
+
+template <typename Scenario>
+void run_scenario(Scenario scenario, std::chrono::milliseconds min_interval = std::chrono::milliseconds{0}) {
+  td::actor::TestScheduler scheduler;
+  Harness h;
+  active = &h;
+  Consensus::register_in(h.runtime);
+  h.runtime.register_actor<ControlledDependencies>("ControlledDependencies");
+  scheduler.run([&]() -> td::actor::Task<> {
+    auto bus = std::make_shared<Bus>();
+    PeerValidator local{};
+    local.idx = PeerValidatorId{0};
+    auto remote = local;
+    remote.idx = PeerValidatorId{1};
+    bus->local_id = local;
+    bus->validator_set = {local, remote};
+    bus->local_adnl_id = remote.adnl_id;
+    bus->shard = kShard;
+    bus->config.slots_per_leader_window = 16;
+    bus->config.noncritical_params.min_block_interval = min_interval;
+    bus->config.noncritical_params.first_block_timeout = std::chrono::seconds{30};
+    bus->collator_schedule = td::make_ref<RemoteCollator>();
+    h.parent_time = td::Clocks::system();
+    h.bus = h.runtime.start(std::move(bus), "speculative-validation");
+    co_await scheduler.wait_sync_work();
+    co_await h.bus.publish<LeaderWindowObserved>(0, ParentId{});
+    co_await scenario(h, scheduler);
+    h.stop();
+    co_await scheduler.wait_sync_work();
+    h.parent_waiters.clear();
+    h.store_waiters.clear();
+    h.speculative_waiters.clear();
+    h.bus = {};
+    co_await scheduler.wait_sync_work();
+    co_return {};
+  });
+  active = nullptr;
+}
+
+td::actor::Task<> start_parent_and_child(Harness& h, td::actor::TestScheduler& scheduler) {
+  // Child-first arrival also exercises wakeup when the parent's local validation later completes.
+  h.bus.publish<CandidateReceived>(h.candidate(1));
+  co_await scheduler.wait_sync_work();
+  EXPECT_EQ(h.speculative_calls[1], 0u);
+  h.bus.publish<CandidateReceived>(h.candidate(0));
+  co_await scheduler.wait_sync_work();
+  EXPECT_EQ(h.votes(0), 1u);
+  EXPECT_EQ(h.speculative_calls[1], 1u);
+  EXPECT_EQ(h.votes(1), 0u);
+  const auto& request = *h.speculative_requests.back();
+  EXPECT(request.parent_id == candidate_id(0));
+  EXPECT(request.parent_block_id == h.candidates.at(0)->block_id());
+  EXPECT(request.min_masterchain_block_id == h.min_mc);
+  co_return {};
+}
+
+TEST(SpeculativeValidation, ResultBeforeCertificateStillWaitsForCertificateAndStorage) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    h.held_stores.insert(1);
+    co_await start_parent_and_child(h, scheduler);
+    h.accept_speculation(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    h.certify(0);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    h.store(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 1u);
+    EXPECT_EQ(h.normal_calls[1], 0u);
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, CertificateBeforeResultReusesInFlightValidation) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    co_await start_parent_and_child(h, scheduler);
+    h.certify(0);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    EXPECT_EQ(h.normal_calls[1], 0u);
+    h.accept_speculation(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 1u);
+    EXPECT_EQ(h.normal_calls[1], 0u);
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, VotesRespectParentIntervalAndCandidateTimestamp) {
+  for (bool child_timestamp_later : {false, true}) {
+    run_scenario(
+        [child_timestamp_later](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+          co_await start_parent_and_child(h, scheduler);
+          h.accept_speculation(1, h.parent_time + (child_timestamp_later ? 0.5 : 0.1));
+          h.certify(0);
+          co_await scheduler.wait_sync_work();
+          scheduler.advance_time(std::chrono::milliseconds{200});
+          co_await scheduler.wait_sync_work();
+          EXPECT_EQ(h.votes(1), 0u);
+          scheduler.advance_time(std::chrono::milliseconds{110});
+          co_await scheduler.wait_sync_work();
+          EXPECT_EQ(h.votes(1), child_timestamp_later ? 0u : 1u);
+          scheduler.advance_time(std::chrono::milliseconds{200});
+          co_await scheduler.wait_sync_work();
+          EXPECT_EQ(h.votes(1), 1u);
+          co_return {};
+        },
+        std::chrono::milliseconds{300});
+  }
+}
+
+TEST(SpeculativeValidation, OneChildAheadAndDuplicateCandidatesDoNotMultiplyWork) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    co_await start_parent_and_child(h, scheduler);
+    h.bus.publish<CandidateReceived>(h.candidate(1, true));
+    h.bus.publish<CandidateReceived>(h.candidates.at(1));
+    h.bus.publish<CandidateReceived>(h.candidate(2));
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.speculative_calls[1], 1u);
+    EXPECT_EQ(h.store_calls[1], 1u);
+    EXPECT_EQ(h.speculative_calls[2], 0u);
+    h.accept_speculation(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.speculative_calls[2], 0u);
+    h.certify(0);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 1u);
+    EXPECT_EQ(h.speculative_calls[2], 1u);
+    h.accept_speculation(2);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(2), 0u);
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, ErrorsAndRejectionsRetryOnlyAfterParentCertificate) {
+  for (bool reject : {false, true}) {
+    run_scenario([reject](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+      co_await start_parent_and_child(h, scheduler);
+      auto& promise = h.speculative_waiters.at(1);
+      if (reject) {
+        promise.set_value(CandidateReject{.reason = "early rejection", .proof = {}});
+      } else {
+        promise.set_error(td::Status::Error("parent data not available yet"));
+      }
+      h.speculative_waiters.erase(1);
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.normal_calls[1], 0u);
+      EXPECT_EQ(h.votes(1), 0u);
+      h.certify(0);
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.normal_calls[1], 1u);
+      EXPECT_EQ(h.votes(1), 1u);
+      co_return {};
+    });
+  }
+}
+
+TEST(SpeculativeValidation, ChangedParentOrMasterchainContextRequiresOrdinaryValidation) {
+  for (bool change_parent : {false, true}) {
+    run_scenario([change_parent](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+      co_await start_parent_and_child(h, scheduler);
+      h.accept_speculation(1);
+      if (change_parent) {
+        h.conflicting_state = true;
+      } else {
+        h.min_mc.id.seqno += 1;
+      }
+      h.certify(0);
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.normal_calls[1], 1u);
+      EXPECT_EQ(h.votes(1), 1u);
+      co_return {};
+    });
+  }
+}
+
+TEST(SpeculativeValidation, ParentConflictDuringStoragePreventsVote) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    h.held_stores.insert(1);
+    co_await start_parent_and_child(h, scheduler);
+    h.accept_speculation(1);
+    h.certify(0);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    h.parent_conflict = true;
+    h.store(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, ConflictingCandidateCertificateDuringStoragePreventsVote) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    h.held_stores.insert(1);
+    co_await start_parent_and_child(h, scheduler);
+    h.accept_speculation(1);
+    h.certify(0);
+    co_await scheduler.wait_sync_work();
+    auto id = candidate_id(1, true);
+    h.bus.publish<NotarizationObserved>(
+        id, td::make_ref<NotarCert>(NotarizeVote{id}, std::vector<NotarCert::VoteSignature>{}));
+    co_await scheduler.wait_sync_work();
+    h.store(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, ObsoleteRunningValidationKeepsSingleSpeculationReservation) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    co_await start_parent_and_child(h, scheduler);
+    auto id = candidate_id(1);
+    h.bus.publish<FinalizationObserved>(
+        id, td::make_ref<FinalCert>(FinalizeVote{id}, std::vector<FinalCert::VoteSignature>{}));
+    h.allow_parent(2);
+    h.bus.publish<CandidateReceived>(h.candidate(2));
+    h.bus.publish<CandidateReceived>(h.candidate(3));
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(2), 1u);
+    EXPECT_EQ(h.speculative_calls[3], 0u);
+    h.accept_speculation(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    h.certify(2);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(3), 1u);
+    h.bus.publish<CandidateReceived>(h.candidate(4));
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.speculative_calls[4], 1u);
+    h.accept_speculation(4);
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, SkipAllowsLateNotarizationButPreventsFinalVote) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    co_await start_parent_and_child(h, scheduler);
+    scheduler.advance_time(std::chrono::seconds{35});
+    co_await scheduler.wait_sync_work();
+    EXPECT(h.skip_votes.contains(1));
+    h.accept_speculation(1);
+    h.certify(0);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 1u);
+    h.certify(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT(std::none_of(h.final_votes.begin(), h.final_votes.end(), [](auto id) { return id.slot == 1; }));
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidation, FinalizationAndSessionStopPreventLateVotes) {
+  for (bool stop : {false, true}) {
+    run_scenario([stop](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+      co_await start_parent_and_child(h, scheduler);
+      if (stop) {
+        h.stop();
+      } else {
+        auto id = candidate_id(1, true);
+        h.bus.publish<FinalizationObserved>(
+            id, td::make_ref<FinalCert>(FinalizeVote{id}, std::vector<FinalCert::VoteSignature>{}));
+      }
+      co_await scheduler.wait_sync_work();
+      h.accept_speculation(1);
+      h.certify(0);
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.votes(1), 0u);
+      co_return {};
+    });
+  }
+}
+
+TEST(SpeculativeValidation, RejectedOrIneligibleParentCannotStartChildEarly) {
+  for (bool reject : {false, true}) {
+    run_scenario([reject](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+      h.reject_parent = reject;
+      h.parent_can_validate_child = false;
+      h.bus.publish<CandidateReceived>(h.candidate(0));
+      h.bus.publish<CandidateReceived>(h.candidate(1));
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.speculative_calls[1], 0u);
+      EXPECT_EQ(h.votes(1), 0u);
+      co_return {};
+    });
+  }
+}
+
+TEST(SpeculativeValidation, UnusedCompletedSpeculationReleasesCandidateAfterStop) {
+  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+    co_await start_parent_and_child(h, scheduler);
+    auto child = h.candidates.at(1);
+    h.accept_speculation(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(h.votes(1), 0u);
+    h.stop();
+    co_await scheduler.wait_sync_work();
+    h.parent_waiters.clear();
+    h.speculative_requests.clear();
+    h.candidates.erase(1);
+    co_await scheduler.wait_sync_work();
+    EXPECT_EQ(child->get_refcnt(), 1);
+    co_return {};
+  });
+}
+
+}  // namespace
+}  // namespace ton::validator::consensus::simplex::test

--- a/test/validator/consensus/test-speculative-validation.cpp
+++ b/test/validator/consensus/test-speculative-validation.cpp
@@ -152,6 +152,11 @@ class ControlledDependencies final : public td::actor::SpawnsWith<Bus>, public t
   TON_RUNTIME_DEFINE_EVENT_HANDLER();
 
   template <>
+  td::actor::Task<> process(BusHandle, std::shared_ptr<LeaderWindowObserved>) {
+    co_return {};
+  }
+
+  template <>
   td::actor::Task<WaitForParent::ReturnType> process(BusHandle, std::shared_ptr<WaitForParent> request) {
     auto slot = request->candidate->id.slot;
     if (active->allowed_parents.contains(slot)) {
@@ -229,6 +234,7 @@ void run_scenario(Scenario scenario, std::chrono::milliseconds min_interval = st
   active = &h;
   Consensus::register_in(h.runtime);
   h.runtime.register_actor<ControlledDependencies>("ControlledDependencies");
+  bool completed = false;
   scheduler.run([&]() -> td::actor::Task<> {
     auto bus = std::make_shared<Bus>();
     PeerValidator local{};
@@ -243,7 +249,7 @@ void run_scenario(Scenario scenario, std::chrono::milliseconds min_interval = st
     bus->config.noncritical_params.min_block_interval = min_interval;
     bus->config.noncritical_params.first_block_timeout = std::chrono::seconds{30};
     bus->collator_schedule = td::make_ref<RemoteCollator>();
-    h.parent_time = td::Clocks::system();
+    h.parent_time = td::Clocks::system() - 0.001;  // Avoid clock conversion rounding into the future.
     h.bus = h.runtime.start(std::move(bus), "speculative-validation");
     co_await scheduler.wait_sync_work();
     co_await h.bus.publish<LeaderWindowObserved>(0, ParentId{});
@@ -255,8 +261,10 @@ void run_scenario(Scenario scenario, std::chrono::milliseconds min_interval = st
     h.speculative_waiters.clear();
     h.bus = {};
     co_await scheduler.wait_sync_work();
+    completed = true;
     co_return {};
   });
+  EXPECT(completed);
   active = nullptr;
 }
 
@@ -453,30 +461,50 @@ TEST(SpeculativeValidation, ConflictingCandidateCertificateDuringStoragePrevents
   });
 }
 
-TEST(SpeculativeValidation, ObsoleteRunningValidationKeepsSingleSpeculationReservation) {
-  run_scenario([](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
-    co_await start_parent_and_child(h, scheduler);
-    auto id = candidate_id(1);
-    h.bus.publish<FinalizationObserved>(
-        id, td::make_ref<FinalCert>(FinalizeVote{id}, std::vector<FinalCert::VoteSignature>{}));
-    h.allow_parent(2);
-    h.bus.publish<CandidateReceived>(h.candidate(2));
-    h.bus.publish<CandidateReceived>(h.candidate(3));
-    co_await scheduler.wait_sync_work();
-    EXPECT_EQ(h.votes(2), 1u);
-    EXPECT_EQ(h.speculative_calls[3], 0u);
-    h.accept_speculation(1);
-    co_await scheduler.wait_sync_work();
-    EXPECT_EQ(h.votes(1), 0u);
-    h.certify(2);
-    co_await scheduler.wait_sync_work();
-    EXPECT_EQ(h.votes(3), 1u);
-    h.bus.publish<CandidateReceived>(h.candidate(4));
-    co_await scheduler.wait_sync_work();
-    EXPECT_EQ(h.speculative_calls[4], 1u);
-    h.accept_speculation(4);
-    co_return {};
-  });
+TEST(SpeculativeValidation, ObsoleteValidationRestartsPendingChild) {
+  for (bool completed : {false, true}) {
+    run_scenario([completed](Harness& h, td::actor::TestScheduler& scheduler) -> td::actor::Task<> {
+      co_await start_parent_and_child(h, scheduler);
+      if (completed) {
+        h.accept_speculation(1);
+        co_await scheduler.wait_sync_work();
+      }
+
+      h.allow_parent(2);
+      h.bus.publish<CandidateReceived>(h.candidate(2));
+      h.bus.publish<CandidateReceived>(h.candidate(3));
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.votes(2), 1u);
+      EXPECT_EQ(h.speculative_calls[3], 0u);
+
+      auto id = candidate_id(1);
+      h.bus.publish<FinalizationObserved>(
+          id, td::make_ref<FinalCert>(FinalizeVote{id}, std::vector<FinalCert::VoteSignature>{}));
+      co_await scheduler.wait_sync_work();
+      if (!completed) {
+        EXPECT_EQ(h.speculative_calls[3], 0u);
+        h.accept_speculation(1);
+        co_await scheduler.wait_sync_work();
+      }
+      EXPECT_EQ(h.votes(1), 0u);
+      EXPECT_EQ(h.speculative_calls[3], 1u);
+      EXPECT_EQ(h.normal_calls[3], 0u);
+
+      h.accept_speculation(3);
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.votes(3), 0u);
+      h.certify(2);
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.votes(3), 1u);
+      EXPECT_EQ(h.normal_calls[3], 0u);
+
+      h.bus.publish<CandidateReceived>(h.candidate(4));
+      co_await scheduler.wait_sync_work();
+      EXPECT_EQ(h.speculative_calls[4], 1u);
+      h.accept_speculation(4);
+      co_return {};
+    });
+  }
 }
 
 TEST(SpeculativeValidation, SkipAllowsLateNotarizationButPreventsFinalVote) {

--- a/test/validator/consensus/test-speculative-validator.cpp
+++ b/test/validator/consensus/test-speculative-validator.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, TON CORE TECHNOLOGIES CO. L.L.C
+ *
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#include "consensus/bus.h"
+#include "td/actor/TestScheduler.h"
+#include "td/utils/tests.h"
+
+namespace ton::validator::consensus::test {
+namespace {
+
+BlockIdExt block_id(WorkchainId workchain, ShardId shard, BlockSeqno seqno) {
+  return {workchain, shard, seqno, td::Bits256::zero(), td::Bits256::zero()};
+}
+
+CandidateRef candidate(CandidateId id, ParentId parent, BlockIdExt block, bool empty = false) {
+  if (empty) {
+    return td::make_ref<Candidate>(id, parent, PeerValidatorId{0}, block, td::BufferSlice{});
+  }
+  BlockCandidate payload;
+  payload.id = block;
+  payload.pubkey = Ed25519_PublicKey{td::Bits256::zero()};
+  payload.collated_file_hash = td::Bits256::zero();
+  payload.data = td::BufferSlice("block bytes");
+  payload.collated_data = td::BufferSlice("collated bytes");
+  return td::make_ref<Candidate>(id, parent, PeerValidatorId{0}, std::move(payload), td::BufferSlice{});
+}
+
+struct ValidationCalls {
+  size_t count = 0;
+  std::optional<BlockCandidate> block;
+  std::optional<ValidateParams> params;
+  double ok_from = 0;
+  bool fail = false;
+};
+
+class RecordingManager final : public ManagerFacade {
+ public:
+  explicit RecordingManager(ValidationCalls& calls) : calls_(calls) {
+  }
+
+  td::actor::Task<ValidateCandidateResult> validate_block_candidate(BlockCandidate block, ValidateParams params,
+                                                                    td::Timestamp) override {
+    ++calls_.count;
+    calls_.block = std::move(block);
+    calls_.params = std::move(params);
+    if (calls_.fail) {
+      co_return td::Status::Error(ErrorCode::notready, "Missing proof dependency");
+    }
+    co_return CandidateAccept{.ok_from_utime = calls_.ok_from, .can_validate_child = true};
+  }
+
+  td::actor::Task<BlockCandidate> collate_block(CollateParams, td::CancellationToken) override {
+    UNREACHABLE();
+    co_return td::Status::Error("Unexpected collation");
+  }
+
+  td::actor::Task<> accept_block(BlockIdExt, td::Ref<BlockData>, size_t, td::Ref<block::BlockSignatureSet>, int, int,
+                                 bool, bool) override {
+    UNREACHABLE();
+    co_return {};
+  }
+
+  td::actor::Task<td::Ref<vm::Cell>> wait_block_state_root(BlockIdExt, td::Timestamp) override {
+    UNREACHABLE();
+    co_return td::Status::Error("Unexpected state lookup");
+  }
+
+  td::actor::Task<td::Ref<BlockData>> wait_block_data(BlockIdExt, td::Timestamp) override {
+    UNREACHABLE();
+    co_return td::Status::Error("Unexpected block lookup");
+  }
+
+  td::actor::Task<double> get_sync_delay() override {
+    UNREACHABLE();
+    co_return 0.0;
+  }
+
+ private:
+  ValidationCalls& calls_;
+};
+
+enum class RequestCase { Eligible, Empty, Masterchain, ParentHash, SlotGap, ChildShard, ParentShard, SeqnoGap };
+
+void check_dispatch(RequestCase request_case, bool manager_fails = false) {
+  td::actor::TestScheduler scheduler;
+  td::actor::Runtime runtime;
+  BlockValidator::register_in(runtime);
+  ValidationCalls calls;
+  calls.fail = manager_fails;
+
+  scheduler.run([&]() -> td::actor::Task<> {
+    auto manager = td::actor::create_actor<RecordingManager>("recording-manager", calls);
+    auto bus = std::make_shared<Bus>();
+    bus->shard = {basechainId, shardIdAll};
+    PeerValidator local{};
+    local.idx = PeerValidatorId{0};
+    local.short_id = PublicKeyHash{td::Bits256::zero()};
+    bus->local_id = local;
+    bus->manager = manager.get();
+    const CandidateId parent{6, td::Bits256::zero()};
+    CandidateId child{7, td::Bits256::zero()};
+    ParentId claimed_parent = parent;
+    auto parent_block = block_id(basechainId, shardIdAll, 100);
+    auto child_block = block_id(basechainId, shardIdAll, 101);
+    const auto min_mc = block_id(masterchainId, shardIdAll, 200);
+
+    switch (request_case) {
+      case RequestCase::Masterchain:
+        bus->shard = {masterchainId, shardIdAll};
+        parent_block = block_id(masterchainId, shardIdAll, 100);
+        child_block = block_id(masterchainId, shardIdAll, 101);
+        break;
+      case RequestCase::ParentHash:
+        claimed_parent->hash.as_slice()[0] = 1;
+        break;
+      case RequestCase::SlotGap:
+        ++child.slot;
+        break;
+      case RequestCase::ChildShard:
+        child_block = block_id(basechainId, shardIdAll >> 1, 101);
+        break;
+      case RequestCase::ParentShard:
+        parent_block = block_id(basechainId, shardIdAll >> 1, 100);
+        break;
+      case RequestCase::SeqnoGap:
+        child_block = block_id(basechainId, shardIdAll, 102);
+        break;
+      default:
+        break;
+    }
+    auto block = candidate(child, claimed_parent, child_block, request_case == RequestCase::Empty);
+    auto handle = runtime.start(std::move(bus), "speculative-validator");
+    co_await scheduler.wait_sync_work();
+    calls.ok_from = td::Timestamp::in(60).at_unix();
+
+    auto validation = handle.publish<SpeculativeValidationRequest>(block, parent, parent_block, min_mc).start();
+    co_await scheduler.wait_sync_work();
+    // The caller must receive the result while its timestamp is still in the future.
+    EXPECT(validation.await_ready());
+    auto result = co_await std::move(validation).wrap();
+    if (request_case != RequestCase::Eligible) {
+      EXPECT(result.is_error());
+      EXPECT_EQ(result.error().code(), ErrorCode::notready);
+      EXPECT_EQ(calls.count, 0u);
+    } else {
+      EXPECT_EQ(calls.count, 1u);
+      EXPECT_EQ(calls.block->id, child_block);
+      EXPECT_EQ(calls.block->data.as_slice(), "block bytes");
+      EXPECT_EQ(calls.block->collated_data.as_slice(), "collated bytes");
+      EXPECT_EQ(calls.params->shard, (ShardIdFull{basechainId, shardIdAll}));
+      EXPECT_EQ(calls.params->prev.size(), 1u);
+      EXPECT_EQ(calls.params->prev[0], parent_block);
+      EXPECT_EQ(calls.params->min_masterchain_block_id, min_mc);
+      EXPECT_EQ(calls.params->local_validator_id, local.short_id);
+      EXPECT(calls.params->require_full_collated_data);
+      EXPECT(calls.params->prev_block_state_roots.empty());
+      EXPECT(!calls.params->is_fake);
+      if (manager_fails) {
+        EXPECT(result.is_error());
+        EXPECT_EQ(result.error().code(), ErrorCode::notready);
+      } else {
+        EXPECT(result.is_ok());
+        EXPECT(result.ok().has<CandidateAccept>());
+        EXPECT_EQ(result.ok().get<CandidateAccept>().ok_from_utime, calls.ok_from);
+        EXPECT(result.ok().get<CandidateAccept>().can_validate_child);
+        EXPECT(!td::Timestamp::at_unix(calls.ok_from).is_in_past());
+      }
+    }
+
+    handle.publish<StopRequested>();
+    handle = {};
+    manager.reset();
+    co_await scheduler.wait_sync_work();
+    co_return {};
+  });
+}
+
+TEST(SpeculativeValidator, IneligibleRequestsNeverReachManager) {
+  for (auto request_case : {RequestCase::Empty, RequestCase::Masterchain, RequestCase::ParentHash, RequestCase::SlotGap,
+                            RequestCase::ChildShard, RequestCase::ParentShard, RequestCase::SeqnoGap}) {
+    check_dispatch(request_case);
+  }
+}
+
+TEST(SpeculativeValidator, ExactContextAndRawFutureTimestamp) {
+  check_dispatch(RequestCase::Eligible);
+}
+
+TEST(SpeculativeValidator, MissingDependencyRemainsRetryable) {
+  check_dispatch(RequestCase::Eligible, true);
+}
+
+}  // namespace
+}  // namespace ton::validator::consensus::test

--- a/test/validator/consensus/test-speculative-validator.cpp
+++ b/test/validator/consensus/test-speculative-validator.cpp
@@ -7,6 +7,7 @@
 #include "consensus/bus.h"
 #include "td/actor/TestScheduler.h"
 #include "td/utils/tests.h"
+#include "vm/cells/CellBuilder.h"
 
 namespace ton::validator::consensus::test {
 namespace {
@@ -82,7 +83,7 @@ class RecordingManager final : public ManagerFacade {
   ValidationCalls& calls_;
 };
 
-enum class RequestCase { Eligible, Empty, Masterchain, ParentHash, SlotGap, ChildShard, ParentShard, SeqnoGap };
+enum class RequestCase { Eligible, Ordinary, Empty, Masterchain, ParentHash, SlotGap, ChildShard, ParentShard, SeqnoGap };
 
 void check_dispatch(RequestCase request_case, bool manager_fails = false) {
   td::actor::TestScheduler scheduler;
@@ -108,6 +109,10 @@ void check_dispatch(RequestCase request_case, bool manager_fails = false) {
     const auto min_mc = block_id(masterchainId, shardIdAll, 200);
 
     switch (request_case) {
+      case RequestCase::Ordinary:
+        parent_block = block_id(basechainId, shardIdAll, 0);
+        child_block = block_id(basechainId, shardIdAll, 1);
+        break;
       case RequestCase::Masterchain:
         bus->shard = {masterchainId, shardIdAll};
         parent_block = block_id(masterchainId, shardIdAll, 100);
@@ -136,12 +141,19 @@ void check_dispatch(RequestCase request_case, bool manager_fails = false) {
     co_await scheduler.wait_sync_work();
     calls.ok_from = td::Timestamp::in(60).at_unix();
 
-    auto validation = handle.publish<SpeculativeValidationRequest>(block, parent, parent_block, min_mc).start();
+    td::actor::StartedTask<ValidateCandidateResult> validation;
+    if (request_case == RequestCase::Ordinary) {
+      auto state = td::make_ref<ChainState>(
+          ChainState::ZerostateTip{parent_block, vm::CellBuilder{}.finalize_novm()}, min_mc);
+      validation = handle.publish<ValidationRequest>(std::move(state), block).start();
+    } else {
+      validation = handle.publish<SpeculativeValidationRequest>(block, parent, parent_block, min_mc).start();
+    }
     co_await scheduler.wait_sync_work();
     // The caller must receive the result while its timestamp is still in the future.
     EXPECT(validation.await_ready());
     auto result = co_await std::move(validation).wrap();
-    if (request_case != RequestCase::Eligible) {
+    if (request_case != RequestCase::Eligible && request_case != RequestCase::Ordinary) {
       EXPECT(result.is_error());
       EXPECT_EQ(result.error().code(), ErrorCode::notready);
       EXPECT_EQ(calls.count, 0u);
@@ -155,8 +167,8 @@ void check_dispatch(RequestCase request_case, bool manager_fails = false) {
       EXPECT_EQ(calls.params->prev[0], parent_block);
       EXPECT_EQ(calls.params->min_masterchain_block_id, min_mc);
       EXPECT_EQ(calls.params->local_validator_id, local.short_id);
-      EXPECT(calls.params->require_full_collated_data);
-      EXPECT(calls.params->prev_block_state_roots.empty());
+      EXPECT_EQ(calls.params->require_full_collated_data, request_case != RequestCase::Ordinary);
+      EXPECT_EQ(calls.params->prev_block_state_roots.size(), request_case == RequestCase::Ordinary ? 1u : 0u);
       EXPECT(!calls.params->is_fake);
       if (manager_fails) {
         EXPECT(result.is_error());
@@ -187,6 +199,10 @@ TEST(SpeculativeValidator, IneligibleRequestsNeverReachManager) {
 
 TEST(SpeculativeValidator, ExactContextAndRawFutureTimestamp) {
   check_dispatch(RequestCase::Eligible);
+}
+
+TEST(SpeculativeValidator, OrdinaryValidationReturnsRawFutureTimestamp) {
+  check_dispatch(RequestCase::Ordinary);
 }
 
 TEST(SpeculativeValidator, MissingDependencyRemainsRetryable) {

--- a/validator/consensus/block-validator.cpp
+++ b/validator/consensus/block-validator.cpp
@@ -108,19 +108,9 @@ class BlockValidatorImpl : public td::actor::SpawnsWith<Bus>, public td::actor::
 
     owning_bus().publish<TraceEvent>(stats::ValidationFinished::create(event->candidate->id));
 
-    if (validation_result.has<CandidateReject>()) {
-      if (event->candidate->leader == bus.local_id->idx) {
-        LOG(ERROR) << "BUG! Candidate " << event->candidate->id
-                   << " is self-rejected: " << validation_result.get<CandidateReject>().reason;
-      }
-      co_return validation_result;
-    }
-
-    td::Timestamp ok_from = td::Timestamp::at_unix(validation_result.get<CandidateAccept>().ok_from_utime);
-    if (!ok_from.is_in_past()) {
-      LOG(INFO) << "Candidate " << event->candidate->id << " has timestamp in the future, wait for " << ok_from.in()
-                << " s";
-      co_await td::actor::coro_sleep(ok_from);
+    if (validation_result.has<CandidateReject>() && event->candidate->leader == bus.local_id->idx) {
+      LOG(ERROR) << "BUG! Candidate " << event->candidate->id
+                 << " is self-rejected: " << validation_result.get<CandidateReject>().reason;
     }
     co_return validation_result;
   }

--- a/validator/consensus/block-validator.cpp
+++ b/validator/consensus/block-validator.cpp
@@ -125,6 +125,37 @@ class BlockValidatorImpl : public td::actor::SpawnsWith<Bus>, public td::actor::
     co_return validation_result;
   }
 
+  template <>
+  td::actor::Task<ValidateCandidateResult> process(BusHandle, std::shared_ptr<SpeculativeValidationRequest> event) {
+    auto& bus = *owning_bus();
+    auto& candidate = *event->candidate;
+    if (bus.shard.workchain != basechainId || candidate.is_empty() || candidate.parent_id != event->parent_id ||
+        candidate.id.slot == 0 || candidate.id.slot - 1 != event->parent_id.slot) {
+      co_return td::Status::Error(ErrorCode::notready, "Candidate is not eligible for speculative validation");
+    }
+    const auto& block = std::get<BlockCandidate>(candidate.block);
+    if (block.id.shard_full() != bus.shard || event->parent_block_id.shard_full() != bus.shard ||
+        block.id.seqno() == 0 || block.id.seqno() - 1 != event->parent_block_id.seqno()) {
+      co_return td::Status::Error(ErrorCode::notready, "Candidate is not the next block in the parent's shard");
+    }
+
+    ValidateParams validate_params{
+        .shard = bus.shard,
+        .min_masterchain_block_id = event->min_masterchain_block_id,
+        .prev = {event->parent_block_id},
+        .local_validator_id = bus.local_id->short_id,
+        .require_full_collated_data = true,
+    };
+    LOG(DEBUG) << "Speculative validation started for " << candidate.id << " after " << event->parent_id;
+    auto result = co_await td::actor::ask(bus.manager, &ManagerFacade::validate_block_candidate, block.clone(),
+                                          std::move(validate_params), td::Timestamp::in(60.0))
+                      .wrap();
+    LOG(DEBUG) << "Speculative validation finished for " << candidate.id << ": "
+               << (result.is_ok() ? ValidationRequest::response_to_string(result.ok()) : result.error().to_string());
+    // Certification and both time gates remain the responsibility of the consensus actor.
+    co_return std::move(result);
+  }
+
  private:
   void on_new_accepted_block(std::optional<BlockIdExt> block) {
     if (last_accepted_block_ < block) {

--- a/validator/consensus/bus.cpp
+++ b/validator/consensus/bus.cpp
@@ -115,6 +115,15 @@ std::string ValidationRequest::response_to_string(const ReturnType& result) {
   return str;
 }
 
+std::string SpeculativeValidationRequest::contents_to_string() const {
+  return PSTRING() << "{candidate=" << candidate_to_string(candidate) << ", parent=" << parent_id
+                   << ", parent_block=" << parent_block_id << ", min_mc_block=" << min_masterchain_block_id << "}";
+}
+
+std::string SpeculativeValidationRequest::response_to_string(const ReturnType& result) {
+  return ValidationRequest::response_to_string(result);
+}
+
 std::string IncomingProtocolMessage::contents_to_string() const {
   return PSTRING() << "{source_validator=" << source << ", source=" << source
                    << ", message=" << message_to_string(message) << "}";

--- a/validator/consensus/bus.h
+++ b/validator/consensus/bus.h
@@ -79,6 +79,18 @@ struct ValidationRequest {
   static std::string response_to_string(const ReturnType&);
 };
 
+struct SpeculativeValidationRequest {
+  using ReturnType = ValidateCandidateResult;
+
+  CandidateRef candidate;
+  CandidateId parent_id;
+  BlockIdExt parent_block_id;
+  BlockIdExt min_masterchain_block_id;
+
+  std::string contents_to_string() const;
+  static std::string response_to_string(const ReturnType&);
+};
+
 struct IncomingProtocolMessage {
   using LogToDebug = std::true_type;
 
@@ -199,11 +211,12 @@ class Db {
 
 class Bus : public td::actor::Bus {
  public:
-  using Events = td::TypeList<Start, StopRequested, FinalizeBlock, OurLeaderWindowStarted, OurLeaderWindowUpcoming,
-                              CandidateGenerated, CandidateReceived, ValidationRequest, IncomingProtocolMessage,
-                              OutgoingProtocolMessage, IncomingCandidateRequest, IncomingCollatorRequest,
-                              OutgoingOverlayRequest, BlockFinalizedInMasterchain, MisbehaviorReport, TraceEvent,
-                              NoncriticalParamsUpdated, ValidatorOptionsUpdated, PrecheckCandidateBroadcast>;
+  using Events =
+      td::TypeList<Start, StopRequested, FinalizeBlock, OurLeaderWindowStarted, OurLeaderWindowUpcoming,
+                   CandidateGenerated, CandidateReceived, ValidationRequest, SpeculativeValidationRequest,
+                   IncomingProtocolMessage, OutgoingProtocolMessage, IncomingCandidateRequest, IncomingCollatorRequest,
+                   OutgoingOverlayRequest, BlockFinalizedInMasterchain, MisbehaviorReport, TraceEvent,
+                   NoncriticalParamsUpdated, ValidatorOptionsUpdated, PrecheckCandidateBroadcast>;
 
   Bus() = default;
   ~Bus() override {

--- a/validator/consensus/simplex/consensus.cpp
+++ b/validator/consensus/simplex/consensus.cpp
@@ -276,6 +276,7 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
       // Dropping the result does not cancel ValidateQuery. Reserve the single slot until it finishes.
       if (speculative_->completed) {
         speculative_.reset();
+        retry_speculation();
       }
     }
   }
@@ -291,9 +292,18 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
     job->completed = true;
     if (job->obsolete && speculative_ == job) {
       speculative_.reset();
+      retry_speculation();
     }
     promise.set_result(std::move(result));
     co_return {};
+  }
+
+  void retry_speculation() {
+    // A pending child's first attempt may have been blocked by the previous reservation.
+    auto [begin, end] = state_->tracked_slots_interval();
+    for (auto i = begin; i < end && !stopping_ && !speculative_; ++i) {
+      try_speculate(*state_->slot_at(i));
+    }
   }
 
   void try_speculate(State::SlotRef slot) {

--- a/validator/consensus/simplex/consensus.cpp
+++ b/validator/consensus/simplex/consensus.cpp
@@ -380,7 +380,7 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
     std::optional<ValidateCandidateResult> accepted_early;
     auto job = speculative_;
     if (job && !job->obsolete && job->id == candidate->id && candidate->parent_id == job->parent_id &&
-        parent.state->block_ids() == std::vector<BlockIdExt>{job->parent_block_id} &&
+        parent.state->as_normal() == job->parent_block_id &&
         parent.state->min_mc_block_id() == job->min_mc_block_id) {
       auto early = co_await std::move(job->result).wrap();
       if (!active_candidate(candidate)) {
@@ -409,6 +409,8 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
     auto accepted = validation_result.get<CandidateAccept>();
     auto ok_from = td::Timestamp::at_unix(accepted.ok_from_utime);
     if (!ok_from.is_in_past()) {
+      LOG(INFO) << "Candidate " << candidate->id << " has timestamp in the future, wait for " << ok_from.in()
+                << " s";
       co_await td::actor::coro_sleep(ok_from);
     }
     if (!active_candidate(candidate)) {

--- a/validator/consensus/simplex/consensus.cpp
+++ b/validator/consensus/simplex/consensus.cpp
@@ -24,10 +24,24 @@ struct SlotState {
   std::optional<CandidateId> notar_cert;
   bool voted_skip = false;
   bool voted_final = false;
+  bool validation_started = false;
+  std::optional<BlockIdExt> validated_min_mc_block_id;
 };
 
 class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::ConnectsTo<Bus> {
   using State = ConsensusState<SlotState, td::Unit>;
+
+  struct SpeculativeValidation {
+    CandidateId id;
+    CandidateId parent_id;
+    BlockIdExt parent_block_id;
+    BlockIdExt min_mc_block_id;
+    td::actor::StartedTask<ValidateCandidateResult> result;
+    std::unique_ptr<stats::ValidationStarted> started;
+    std::unique_ptr<stats::ValidationFinished> finished;
+    bool completed = false;
+    bool obsolete = false;
+  };
 
  public:
   TON_RUNTIME_DEFINE_EVENT_HANDLER();
@@ -109,6 +123,10 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
 
   template <>
   void handle(BusHandle, std::shared_ptr<const StopRequested>) {
+    stopping_ = true;
+    if (speculative_) {
+      discard_speculation(speculative_->id);
+    }
     stop();
   }
 
@@ -120,6 +138,9 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
   template <>
   void handle(BusHandle, std::shared_ptr<const FinalizationObserved> event) {
     state_->notify_finalized(event->id.slot);
+    if (speculative_ && speculative_->id.slot <= event->id.slot) {
+      discard_speculation(speculative_->id);
+    }
   }
 
   template <>
@@ -215,6 +236,7 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
     if (candidate->collated_by(*owning_bus()) != owning_bus()->local_adnl_id) {
       owning_bus().publish<TraceEvent>(stats::CandidateReceived::create(candidate, false));
     }
+    try_speculate(*slot);
     try_notarize(*slot).start().detach();
   }
 
@@ -236,8 +258,96 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
     co_return {};
   }
 
-  td::actor::Task<> try_notarize(State::SlotRef slot) {
+  std::optional<State::SlotRef> active_candidate(const CandidateRef& candidate) {
+    if (stopping_) {
+      return std::nullopt;
+    }
+    auto slot = state_->slot_at(candidate->id.slot);
+    if (!slot || !slot->state->pending_block || (*slot->state->pending_block)->id != candidate->id ||
+        slot->state->voted_notar || (slot->state->notar_cert && slot->state->notar_cert != candidate->id)) {
+      return std::nullopt;
+    }
+    return slot;
+  }
+
+  void discard_speculation(CandidateId id) {
+    if (speculative_ && speculative_->id == id) {
+      speculative_->obsolete = true;
+      // Dropping the result does not cancel ValidateQuery. Reserve the single slot until it finishes.
+      if (speculative_->completed) {
+        speculative_.reset();
+      }
+    }
+  }
+
+  td::actor::Task<> validate_speculatively(std::shared_ptr<SpeculativeValidation> job, CandidateRef candidate,
+                                         td::Promise<ValidateCandidateResult> promise) {
+    job->started = stats::ValidationStarted::create(job->id);
+    auto result = co_await owning_bus()
+                      .publish<SpeculativeValidationRequest>(candidate, job->parent_id, job->parent_block_id,
+                                                              job->min_mc_block_id)
+                      .wrap();
+    job->finished = stats::ValidationFinished::create(job->id);
+    job->completed = true;
+    if (job->obsolete && speculative_ == job) {
+      speculative_.reset();
+    }
+    promise.set_result(std::move(result));
+    co_return {};
+  }
+
+  void try_speculate(State::SlotRef slot) {
+    if (stopping_ || speculative_ || slot.state->validation_started || slot.state->voted_notar ||
+        !slot.state->pending_block || owning_bus()->shard.workchain != basechainId) {
+      return;
+    }
     const auto& candidate = *slot.state->pending_block;
+    if (candidate->is_empty() || !candidate->parent_id || candidate->id.slot == 0 ||
+        candidate->parent_id->slot != candidate->id.slot - 1 || !active_candidate(candidate)) {
+      return;
+    }
+    auto parent = state_->slot_at(candidate->parent_id->slot);
+    if (!parent || !parent->state->validated_min_mc_block_id || !parent->state->pending_block ||
+        parent->state->voted_notar != candidate->parent_id || parent->state->notar_cert) {
+      return;
+    }
+    const auto& parent_candidate = *parent->state->pending_block;
+    auto parent_block = parent_candidate->block_id();
+    auto block = candidate->block_id();
+    if (parent_candidate->id != candidate->parent_id || parent_candidate->is_empty() ||
+        block.shard_full() != owning_bus()->shard || parent_block.shard_full() != block.shard_full() ||
+        block.seqno() == 0 || parent_block.seqno() != block.seqno() - 1) {
+      return;
+    }
+
+    auto job = std::make_shared<SpeculativeValidation>();
+    job->id = candidate->id;
+    job->parent_id = *candidate->parent_id;
+    job->parent_block_id = parent_block;
+    job->min_mc_block_id = *parent->state->validated_min_mc_block_id;
+    auto [result, promise] = td::actor::StartedTask<ValidateCandidateResult>::make_bridge();
+    job->result = std::move(result);
+    speculative_ = job;
+    validate_speculatively(job, candidate, std::move(promise)).start().detach();
+  }
+
+  td::actor::Task<> try_notarize(State::SlotRef slot) {
+    auto candidate = *slot.state->pending_block;
+    auto result = co_await notarize_candidate(candidate).wrap();
+    discard_speculation(candidate->id);
+
+    // Only an authoritative local vote unlocks the next child, never a speculative success alone.
+    if (!stopping_ && slot.state->voted_notar == candidate->id &&
+        candidate->id.slot + 1 < state_->tracked_slots_interval().end) {
+      auto child = state_->slot_at(candidate->id.slot + 1);
+      if (child) {
+        try_speculate(*child);
+      }
+    }
+    co_return std::move(result);
+  }
+
+  td::actor::Task<> notarize_candidate(CandidateRef candidate) {
     auto store_candidate = owning_bus().publish<StoreCandidate>(candidate).start();
 
     auto maybe_misbehavior = co_await owning_bus().publish<WaitForParent>(candidate);
@@ -245,8 +355,14 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
       owning_bus().publish<MisbehaviorReport>(candidate->leader, *maybe_misbehavior);
       co_return {};
     }
+    if (!active_candidate(candidate)) {
+      co_return {};
+    }
 
     auto parent = co_await owning_bus().publish<ResolveState>(candidate->parent_id);
+    if (!active_candidate(candidate)) {
+      co_return {};
+    }
 
     if (!candidate->is_empty() && parent.gen_utime_exact.has_value()) {
       auto earliest = td::Timestamp::at_unix(*parent.gen_utime_exact) + params_.min_block_interval;
@@ -255,7 +371,33 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
       }
     }
 
-    auto validation_result = co_await owning_bus().publish<ValidationRequest>(parent.state, candidate);
+    auto slot = active_candidate(candidate);
+    if (!slot) {
+      co_return {};
+    }
+    slot->state->validation_started = true;
+
+    std::optional<ValidateCandidateResult> accepted_early;
+    auto job = speculative_;
+    if (job && !job->obsolete && job->id == candidate->id && candidate->parent_id == job->parent_id &&
+        parent.state->block_ids() == std::vector<BlockIdExt>{job->parent_block_id} &&
+        parent.state->min_mc_block_id() == job->min_mc_block_id) {
+      auto early = co_await std::move(job->result).wrap();
+      if (!active_candidate(candidate)) {
+        co_return {};
+      }
+      if (early.is_ok() && early.ok().has<CandidateAccept>()) {
+        accepted_early.emplace(early.move_as_ok());
+        // Keep actual work timestamps; failed attempts leave the ordinary retry's metrics intact.
+        owning_bus().publish<TraceEvent>(std::move(job->started));
+        owning_bus().publish<TraceEvent>(std::move(job->finished));
+      }
+    }
+    auto validation_result = accepted_early ? std::move(*accepted_early)
+                                           : co_await owning_bus().publish<ValidationRequest>(parent.state, candidate);
+    if (!active_candidate(candidate)) {
+      co_return {};
+    }
 
     if (validation_result.has<CandidateReject>()) {
       LOG(WARNING) << "Candidate " << candidate->id
@@ -263,12 +405,34 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
       // FIXME: Report misbehavior
       co_return {};
     }
+
+    auto accepted = validation_result.get<CandidateAccept>();
+    auto ok_from = td::Timestamp::at_unix(accepted.ok_from_utime);
+    if (!ok_from.is_in_past()) {
+      co_await td::actor::coro_sleep(ok_from);
+    }
+    if (!active_candidate(candidate)) {
+      co_return {};
+    }
     co_await std::move(store_candidate);
 
-    slot.state->voted_notar = candidate->id;
+    // Certificates/ancestry can change while validation or persistence is suspended.
+    maybe_misbehavior = co_await owning_bus().publish<WaitForParent>(candidate);
+    if (maybe_misbehavior) {
+      owning_bus().publish<MisbehaviorReport>(candidate->leader, *maybe_misbehavior);
+      co_return {};
+    }
+    slot = active_candidate(candidate);
+    if (!slot) {
+      co_return {};
+    }
+    slot->state->voted_notar = candidate->id;
+    if (accepted.can_validate_child) {
+      slot->state->validated_min_mc_block_id = parent.state->min_mc_block_id();
+    }
 
     owning_bus().publish<BroadcastVote>(NotarizeVote{candidate->id}).start().detach();
-    try_vote_final(slot);  // If we've observed NotarCert already, it might be possible to vote final.
+    try_vote_final(*slot);  // If we've observed NotarCert already, it might be possible to vote final.
     co_return {};
   }
 
@@ -319,6 +483,8 @@ class ConsensusImpl : public td::actor::SpawnsWith<Bus>, public td::actor::Conne
   bool previous_window_had_skip_ = false;
   std::optional<State> state_;
   td::uint32 current_window_ = 0;
+  std::shared_ptr<SpeculativeValidation> speculative_;
+  bool stopping_ = false;
 
   static constexpr double UPCOMING_FIRST_WINDOW_BEFORE = 5.0;
 };

--- a/validator/fabric.h
+++ b/validator/fabric.h
@@ -62,6 +62,9 @@ struct ValidateParams {
 
   bool parallel_validation = false;
 
+  // Speculative validation must use proofs, without loading the uncertified parent's state.
+  bool require_full_collated_data = false;
+
   // Optional - if empty, states are taken from manager
   // If not empty, should be the same size as prev
   std::vector<Ref<vm::Cell>> prev_block_state_roots = {};

--- a/validator/impl/validate-query.cpp
+++ b/validator/impl/validate-query.cpp
@@ -96,6 +96,7 @@ ValidateQuery::ValidateQuery(BlockCandidate candidate, ValidateParams params,
     , timeout(timeout)
     , main_promise(std::move(promise))
     , is_fake_(params.is_fake)
+    , require_full_collated_data_(params.require_full_collated_data)
     , parallel_accounts_validation_(params.parallel_validation)
     , shard_pfx_(shard_.shard)
     , shard_pfx_len_(ton::shard_prefix_length(shard_))
@@ -263,7 +264,11 @@ void ValidateQuery::finish_query() {
     stats_.comment = (PSTRING() << "OK ts=" << now_);
     LOG(WARNING) << "validate query done";
     double ok_from_utime = now_ms_ ? (double)now_ms_.value() / 1000.0 : (double)now_;
-    main_promise.set_result(CandidateAccept{.ok_from_utime = ok_from_utime});
+    main_promise.set_result(CandidateAccept{
+        .ok_from_utime = ok_from_utime,
+        .can_validate_child = workchain() == ton::basechainId && full_collated_data_ && !after_split_ &&
+                              !after_merge_ && !before_split_,
+    });
   }
   stop();
 }
@@ -392,6 +397,12 @@ void ValidateQuery::start_up() {
       reject_query("error unpacking block candidate");
       return;
     }
+  }
+  if (require_full_collated_data_ &&
+      (workchain() != ton::basechainId || !full_collated_data_ || after_split_ || after_merge_ || before_split_)) {
+    main_promise.set_error(td::Status::Error(ErrorCode::notready, "Candidate requires certified parent state"));
+    stop();
+    return;
   }
   // 4. load state(s) corresponding to previous block(s) (not full-collated-data or masterchain)
   prev_states.resize(prev_blocks.size());

--- a/validator/impl/validate-query.hpp
+++ b/validator/impl/validate-query.hpp
@@ -149,6 +149,7 @@ class ValidateQuery : public td::actor::Actor {
   bool update_shard_cc_{false};
   bool is_fake_{false};
   bool full_collated_data_{false};
+  bool require_full_collated_data_{false};
   bool prev_key_block_exists_{false};
   bool debug_checks_{false};
   bool parallel_accounts_validation_{false};

--- a/validator/interfaces/validator-manager.h
+++ b/validator/interfaces/validator-manager.h
@@ -45,6 +45,7 @@ namespace validator {
 
 struct CandidateAccept {
   double ok_from_utime = 0.0;
+  bool can_validate_child = false;
 };
 
 struct CandidateReject {


### PR DESCRIPTION
Start validating the next block while waiting for its parent’s certificate to reduce waiting between blocks. Votes are still sent only after all required certificates and checks are complete. Consensus rules remain unchanged.

This overlaps useful work with certificate collection and can shorten the delay between notarized blocks. It will lead to per-shard TPS increase because more blocks can be notarized per window, especially with candidates collated by gton.

This optimization targets the common case of consecutive basechain blocks within the same shard, using full collated data. Split and merge transitions use the existing validation flow to keep the implementation simple.